### PR TITLE
[BUGFIX] Fix extension name on install without TER

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		}
 	},
 	"replace": {
-		"rte-ckeditor-image": "self.version",
+		"rte_ckeditor_image": "self.version",
 		"typo3-ter/rte_ckeditor_image": "self.version"
 	},
 	"config": {


### PR DESCRIPTION
If the package is installed via "netresearch/rte-ckeditor-image", the TYPO3 Composer Installers use the first "replace" entry to determine the extension key and extension directory name in typo3conf/ext, thus this must use underscores.