### PR TITLE
Depend on typo3/cms-core instead of typo3/cms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"homepage": "https://www.netresearch.de",
 	"license": ["GPL-2.0+"],
 	"require": {
-		"typo3/cms": "^8.7.0"
+		"typo3/cms-core": "^8.7.0"
 	},
 	"require-dev": {
 		"namelesscoder/typo3-repository-client": "^1.2"


### PR DESCRIPTION
In order to allow single packages for a project