### PR TITLE
[BUGFIX] `Image properties` not working inside table cell

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -53,6 +53,7 @@
                 exec: function () {
                     var current = editor.getSelection().getSelectedElement();
                     if (current && current.is('img') && current.getAttribute('data-htmlarea-file-uid')) {
+                        // If the button is clicked with a selected image
                         edit(
                             current.getAttribute('data-htmlarea-file-table') || 'sys_file',
                             current.getAttribute('data-htmlarea-file-uid'),
@@ -64,6 +65,36 @@
                 },
                 allowedContent: 'img[' + allowedAttributes.join(',') + ']',
                 requiredContent: 'img[src]'
+            });
+
+            // Use a separate command for editing from the context menu
+            editor.addCommand('imageProperties', {
+                exec: function() {
+                    var current = editor.getSelection().getSelectedElement();
+                    var img;
+                    if (current) {
+                        if (!current.is('img')) {
+                            img = new CKEDITOR.dom.element(current.$.querySelector('img'));
+                        } else {
+                            img = current;
+                        }
+                    }
+                    if (img && img.getAttribute('data-htmlarea-file-uid')) {
+                        edit(
+                            img.getAttribute('data-htmlarea-file-table') || 'sys_file',
+                            img.getAttribute('data-htmlarea-file-uid'),
+                            img.getAttributes()
+                        );
+                    }
+                }
+            });
+            // Override the existing `image` content menu item to use the separate editing command
+            editor.addMenuItems({
+                image: {
+                    label: editor.lang.image.menu,
+                    command: 'imageProperties',
+                    group: 'image'
+                }
             });
 
             // Open our and not the CKEditor image dialog on double click:

--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -70,8 +70,8 @@
             // Use a separate command for editing from the context menu
             editor.addCommand('imageProperties', {
                 exec: function() {
-                    var current = editor.getSelection().getSelectedElement();
-                    var img;
+                    var current = editor.getSelection().getSelectedElement(),
+                        img;
                     if (current) {
                         if (!current.is('img')) {
                             img = new CKEDITOR.dom.element(current.$.querySelector('img'));
@@ -88,7 +88,7 @@
                     }
                 }
             });
-            // Override the existing `image` content menu item to use the separate editing command
+            // Override the existing `image` context menu item to use the separate editing command
             editor.addMenuItems({
                 image: {
                     label: editor.lang.image.menu,

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.0.x-dev"
+			"dev-master": "8.x-dev"
 		},
 		"typo3/cms": {
 			"cms-package-dir": "{$vendor-dir}/typo3/cms",


### PR DESCRIPTION
Introduce a separate command for the context menu, that tries to find
the image in the current selection, to make the properties dialog appear,
even if the editor selects the table cell, because the image is the only
element in the cell.

Set branch alias correctly to 8.x-dev.