### PR TITLE
[BUGFIX] Fix data attributes removed on save

### DIFF
--- a/Configuration/RTE/Plugin.yaml
+++ b/Configuration/RTE/Plugin.yaml
@@ -2,3 +2,7 @@
 editor:
   externalPlugins:
     typo3image: { resource: "EXT:rte_ckeditor_image/Resources/Public/JavaScript/Plugins/typo3image.js", route: "rteckeditorimage_wizard_select_image" }
+  config:
+    extraAllowedContent:
+      img:
+        attributes: 'data-htmlarea-file-uid, data-htmlarea-file-table'


### PR DESCRIPTION
The attributes `data-htmlarea-file-uid` and `data-htmlarea-file-table` are stripped away from images by default. Using the local file system driver everything still works, as TYPO3 detects the image as a local image. We have a setup where images are stored in an S3 bucket and thus have an external image url. In that case images get lost after saving a content element for the second time.