### PR TITLE
[BUGFIX] Avoid loosing existing attributes when editing image

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -368,7 +368,6 @@
         );
 
         d.get = function () {
-            var attributes = {};
             $.each(fields, function () {
                 $.each(this, function(key) {
                     var value = elements[key].val();


### PR DESCRIPTION
* use existing `attributes` variable when returning the attributes from
  the editing dialog