### PR TITLE
[BUGFIX] Use original files width and height for ratio and max

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -358,12 +358,12 @@
                         }
                     })
                 } else if (config.type === 'number') {
-                    var ratio = img.processed.width / img.processed.height;
+                    var ratio = img.width / img.height;
                     if (key === 'height') {
                         ratio = 1 / ratio;
                     }
                     var opposite = 1;
-                    var max = img.processed[key];
+                    var max = img[key];
                     var min = Math.ceil(opposite * ratio);
                     $el.attr('max', max);
                     $el.attr('min', min);


### PR DESCRIPTION
When calculating ratio, max width and height the original images data
must be used to allow scaling images to their originals maximum size.