### PR TITLE
Fix deprecation log about locallang_core.xlf

### DIFF
--- a/Classes/Controller/SelectImageController.php
+++ b/Classes/Controller/SelectImageController.php
@@ -85,7 +85,7 @@ class SelectImageController extends ElementBrowserController
         $processedFile = $this->processImage($file, $params);
 
         $lang = $this->getLanguageService();
-        $this->getLanguageService()->includeLLFile('EXT:lang/Resources/Private/Language/locallang_core.xlf');
+        $this->getLanguageService()->includeLLFile('EXT:core/Resources/Private/Language/locallang_core.xlf');
         $this->getLanguageService()->includeLLFile('EXT:frontend/Resources/Private/Language/locallang_ttc.xlf');
 
         return new JsonResponse([


### PR DESCRIPTION
 TYPO3 Deprecation Notice: There is a reference to "EXT:lang/Resources/Private/Language/locallang_core.xlf", which has been moved to "EXT:core/Resources/Private/Language/locallang_core.xlf". This fallback will be removed with TYPO3 v10.0.