### PR TITLE
[BUGFIX] Fix override detection for title/alt attributes; allow empty…

### DIFF
--- a/Classes/Controller/ImageLinkRenderingController.php
+++ b/Classes/Controller/ImageLinkRenderingController.php
@@ -82,26 +82,32 @@ class ImageLinkRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPl
             // Get image attributes
             preg_match_all($attrSearchPattern, $passedImage, $passedAttributes);
             $passedAttributes = array_combine($passedAttributes[1], $passedAttributes[2]);
-            // Remove empty values
-            $passedAttributes = array_filter($passedAttributes);
 
             if (!empty($passedAttributes['data-htmlarea-file-uid'])) {
                 try {
                     $systemImage = Resource\ResourceFactory::getInstance()->getFileObject($passedAttributes['data-htmlarea-file-uid']);
+
                     $imageConfiguration = [
                         'width' => ($passedAttributes['width']) ? $passedAttributes['width'] : $systemImage->getProperty('width'),
                         'height' => ($passedAttributes['height']) ? $passedAttributes['height'] : $systemImage->getProperty('height')
                     ];
+
                     $processedFile = $this->getMagicImageService()->createMagicImage($systemImage, $imageConfiguration);
                     $imageAttributes = [
                         'src' => $processedFile->getPublicUrl(),
-                        'title' => ($passedAttributes['title']) ? $passedAttributes['title'] : $systemImage->getProperty('title'),
-                        'alt' => ($passedAttributes['alt']) ? $passedAttributes['alt'] : $systemImage->getProperty('alternative'),
+                        'title' => self::getAttributeValue('title', $passedAttributes, $systemImage),
+                        'alt' => self::getAttributeValue('alt', $passedAttributes, $systemImage),
                         'width' => ($passedAttributes['width']) ? $passedAttributes['width'] : $systemImage->getProperty('width'),
                         'height' => ($passedAttributes['height']) ? $passedAttributes['height'] : $systemImage->getProperty('height')
                     ];
+
+                    // Remove internal attributes
+                    unset($passedAttributes['data-title-override']);
+                    unset($passedAttributes['data-alt-override']);
+
                     // Add original attributes, if not already parsed
-                    $imageAttributes = $imageAttributes + $passedAttributes;
+                    $imageAttributes = array_merge($imageAttributes, $passedAttributes);
+
                     // Cleanup attributes; disable zoom images within links
                     $unsetParams = [
                         'data-htmlarea-file-uid',
@@ -110,7 +116,7 @@ class ImageLinkRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPl
                         'data-htmlarea-clickenlarge' // Legacy zoom property
                     ];
                     $imageAttributes = array_diff_key($imageAttributes, array_flip($unsetParams));
-                    // Image template; empty attributes are removed by 3nd param 'false'
+                    // Image template; empty attributes are removed by 3rd param 'false'
                     $parsedImages[] = '<img ' . GeneralUtility::implodeAttributes($imageAttributes, true, false) . ' />';
                 } catch (Resource\Exception\FileDoesNotExistException $fileDoesNotExistException) {
                     $parsedImages[] = $passedImage;
@@ -156,5 +162,26 @@ class ImageLinkRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPl
         /** @var $logManager \TYPO3\CMS\Core\Log\LogManager */
         $logManager = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Log\LogManager::class);
         return $logManager->getLogger(get_class($this));
+    }
+
+    /**
+     * Returns attributes value or even empty string when override mode is enabled
+     *
+     * @param string $attributeName
+     * @param array $attributes
+     * @param \TYPO3\CMS\Core\Resource\File $image
+     * @return string
+     */
+    protected static function getAttributeValue($attributeName, $attributes, $image)
+    {
+        if ($attributes['data-' . $attributeName . '-override']) {
+            $attributeValue = isset($attributes[$attributeName]) ? $attributes[$attributeName] : '';
+        } elseif (!empty($attributes[$attributeName])) {
+            $attributeValue = $attributes[$attributeName];
+        } else {
+            $attributeValue = $image->getProperty($attributeName);
+        }
+
+        return (string) $attributeValue;
     }
 }

--- a/Configuration/TypoScript/ImageRendering/setup.txt
+++ b/Configuration/TypoScript/ImageRendering/setup.txt
@@ -21,5 +21,7 @@ lib.parseFunc {
         data-htmlarea-file-table.unset = 1
         data-htmlarea-zoom.unset = 1
         data-htmlarea-clickenlarge.unset = 1
+        data-title-override.unset = 1
+        data-alt-override.unset = 1
     }
 }


### PR DESCRIPTION
Fix override detection for title/alt attributes; allow empty values for alt/title

When title/alt override checkbox was disabled, the default image values have been saved to the attributes array.
After saving the checkbox was enabled again and the value was handled as an overridden attribute instead of reading the default again.
So changes in default image attributes (title/alt) haven't been taken into account.

It's also possible now to enable overriding title/alt and leave the field empty.
So the image default won't be used and the fields will be left empty (attributes are removed).