### PR TITLE
[TASK] Wrapping innerText to avoid js error

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -27,7 +27,7 @@
         init: function (editor) {
             var allowedAttributes = ['!src', 'alt', 'title', 'class', 'rel', 'width', 'height'],
                 additionalAttributes = getAdditionalAttributes(editor),
-                $shadowEditor = $("<div>").append(editor.element.$.innerText),
+                $shadowEditor = $('<div>').append(editor.element.$.innerText),
                 existingImages = $shadowEditor.find('img');
 
             if (additionalAttributes.length) {

--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -27,7 +27,7 @@
         init: function (editor) {
             var allowedAttributes = ['!src', 'alt', 'title', 'class', 'rel', 'width', 'height'],
                 additionalAttributes = getAdditionalAttributes(editor),
-                $shadowEditor = $(editor.element.$.innerText),
+                $shadowEditor = $("<div>").append(editor.element.$.innerText),
                 existingImages = $shadowEditor.find('img');
 
             if (additionalAttributes.length) {


### PR DESCRIPTION
When html loaded from a field is not wrapped on a single dom node js fails on line 30:

`$shadowEditor = $(editor.element.$.innerText),`

Forcing a wrap of the innerText value solves it:

`$shadowEditor = $("<div>").append(editor.element.$.innerText),`