### PR TITLE
[TASK] guard clause if jQuery is not present

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -25,6 +25,8 @@
     CKEDITOR.plugins.add('typo3image', {
         elementBrowser: null,
         init: function (editor) {
+            if(typeof $ == 'undefined')
+                return;
             var allowedAttributes = ['!src', 'alt', 'title', 'class', 'rel', 'width', 'height'],
                 additionalAttributes = getAdditionalAttributes(editor),
                 $shadowEditor = $(editor.element.$.innerText),


### PR DESCRIPTION
Rarely, ckeditor is not loaded if jQuery is not present at typo3image plugin init time.