### PR TITLE
Revert "[BUGFIX] use parseFunc_RTE for processing"

### DIFF
--- a/Configuration/TypoScript/ImageRendering/setup.txt
+++ b/Configuration/TypoScript/ImageRendering/setup.txt
@@ -4,7 +4,7 @@
 # Including library for processing of magic images and file abstraction attributes on img tag
 #******************************************************
 
-lib.parseFunc_RTE {
+lib.parseFunc {
     tags.img = TEXT
     tags.img {
         current = 1


### PR DESCRIPTION
Reverts netresearch/t3x-rte_ckeditor_image#116

Images won't be rendered any more by 
Netresearch\RteCKEditorImage\Controller\ImageRenderingController->renderImageAttributes