### PR TITLE
WIP: [BUGFIX] #112: Remove wrapping p-tag from images via TS

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,4 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('rte_ckeditor_image', 'Configuration/TypoScript/ImageRendering', 'CKEditor Image Support');

--- a/Configuration/TypoScript/ImageRendering/setup.txt
+++ b/Configuration/TypoScript/ImageRendering/setup.txt
@@ -25,3 +25,5 @@ lib.parseFunc {
         data-alt-override.unset = 1
     }
 }
+
+lib.parseFunc_RTE.nonTypoTagStdWrap.encapsLines.encapsTagList := addToList(img)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Add issues or explore the project on [github](https://github.com/netresearch/t3x
     RTE.default.preset = default
     ```
 
+5. Include extension Static Template file
+
+    1. go to Template » Info/Modify » Edit whole template record » Includes
+    2. choose `CKEditor Image Support` for `Include static (from extensions)`
 
 ## Configuration
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,9 +7,3 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_parsehtml_proc.php'
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('RTE.default.proc.overruleMode := addToList(default)');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('RTE.default.proc.overruleMode := addToList(rtehtmlarea_images_db)');
-
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScript(
-    'rte_ckeditor_image',
-    'setup',
-    '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:rte_ckeditor_image/Configuration/TypoScript/ImageRendering/setup.txt">'
-);


### PR DESCRIPTION
RTE Images within links shouldn't be wrapped by an p tag, that's not valid HTML.
One solution is to disable it via TypoScript Setup.
Therefore the order of including the static TS file must be customizable.

Fixes #112