### PR TITLE
[BUGFIX] Implement hotfix from #103

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -27,7 +27,7 @@
         init: function (editor) {
             var allowedAttributes = ['!src', 'alt', 'title', 'class', 'rel', 'width', 'height'],
                 additionalAttributes = getAdditionalAttributes(editor),
-                $shadowEditor = $(editor.element.$.innerText),
+                $shadowEditor = $({html:editor.element.$.innerText}),
                 existingImages = $shadowEditor.find('img');
 
             if (additionalAttributes.length) {


### PR DESCRIPTION
Related to https://github.com/netresearch/t3x-rte_ckeditor_image/issues/103

I stumbled over rte missing on translated records if they had the prefix "[Translate to <lang>:]" earlier using EXT:tt_news. However as I couldn't find anything and no relation to this ext and just removed that prefix from the database and creation of new records.

However now I stumbled upon a missing RTE field for a news entry without anything like that, but still having an old `<a target="_blank" class="external-link-new-window"` in the bodytext, but even after removing that the RTE wasn't rendered with `Uncaught Error: Syntax error, unrecognized expression`. I couldn't find the reason, the text in that case just had some umlauts and `<strong>` tags (one empty) but nothing suspicious.

The mentioned change in #103 immediately resolved the problem, so I propose to add that to the TYPO3_9.x codebase.

I don't know if they are implications for TYPO3_10.x as well, will try to copy the problematic rows to a 10LTS and add an additional issue/PR if applicable.