### PR TITLE
Resolve retrieved file correctly if its a processed file

### DIFF
--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -227,8 +227,12 @@ class RteImagesDbHook extends RteHtmlParser
                                 if ($fileOrFolderObject instanceof FileInterface) {
                                     $fileIdentifier = $fileOrFolderObject->getIdentifier();
                                     $fileObject = $fileOrFolderObject->getStorage()->getFile($fileIdentifier);
-                                    // @todo if the retrieved file is a processed file, get the original file...
-                                    $attribArray['data-htmlarea-file-uid'] = $fileObject->getUid();
+                                    $fileUid = $fileObject->getUid();
+                                    // if the retrieved file is a processed file, get the original file...
+                                    if($fileObject->hasProperty('original')){
+                                        $fileUid = $fileObject->getProperty('original');
+                                    }
+                                    $attribArray['data-htmlarea-file-uid'] = $fileUid;
                                 }
                             } catch (ResourceDoesNotExistException $resourceDoesNotExistException) {
                                 // Nothing to be done if file/folder not found


### PR DESCRIPTION
If a file that is resolved by its path is a processed file the uid must be resolved correctly.
This implements following todo from the source sode:
"@todo if the retrieved file is a processed file, get the original file..."