### PR TITLE
[BUGFIX] #126 Wrong link in image, #142 Wrong backwards compatibility

### DIFF
--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -174,7 +174,19 @@ class RteImagesDbHook extends RteHtmlParser
                             $magicImage = $magicImageService->createMagicImage($originalImageFile, $imageConfiguration);
                             $attribArray['width'] = $magicImage->getProperty('width');
                             $attribArray['height'] = $magicImage->getProperty('height');
-                            $attribArray['src'] = $magicImage->getPublicUrl();
+
+                            $imgSrc = $magicImage->getPublicUrl();
+
+                            // publicUrl like 'https://www.domain.xy/typo3/image/process?token=...'?
+                            // -> generate img source from storage basepath and identifier instead
+                            if (strpos($imgSrc, 'process?token=') !== false) {
+                                $storageBasePath = $magicImage->getStorage()->getConfiguration()['basePath'];
+                                $imgUrlPre = (substr($storageBasePath, -1, 1) === '/') ? substr($storageBasePath, 0, -1) : $storageBasePath;
+
+                                $imgSrc = '/' . $imgUrlPre . $magicImage->getIdentifier();
+                            }
+
+                            $attribArray['src'] = $imgSrc;
                         }
                     } elseif (!GeneralUtility::isFirstPartOfStr($absoluteUrl, $siteUrl) && !$this->procOptions['dontFetchExtPictures'] && TYPO3_MODE === 'BE') {
                         // External image from another URL: in that case, fetch image, unless the feature is disabled or we are not in backend mode

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"homepage": "https://www.netresearch.de",
 	"license": ["GPL-2.0-or-later"],
 	"require": {
-		"typo3/cms-core": "^10.2 || ^11.5"
+		"typo3/cms-core": "^11.5"
 	},
 	"require-dev": {
 		"namelesscoder/typo3-repository-client": "^1.2"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,11 +7,11 @@ $EM_CONF[$_EXTKEY] = [
     'clearCacheOnLoad' => 0,
     'author' => 'Christian Opitz, Mathias Uhlmann',
     'author_email' => 'christian.opitz@netresearch.de',
-    'version' => '10.1.0',
+    'version' => '11.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.2.0-11.5.99',
-            'rte_ckeditor' => '10.2.0-11.5.99',
+            'typo3' => '11.0.0-11.5.99',
+            'rte_ckeditor' => '11.0.0-11.5.99',
         ],
         'conflicts' => [],
         'suggests' => [


### PR DESCRIPTION
Fixed img src generation on first save of RTE, changed TYPO3 version constraints (fixes #126 and #142)