### PR TITLE
[bugfix/145]Fix disabled button. Fixes netresearch/t3x-rte_ckeditor_image #145

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -30,6 +30,16 @@
                     $shadowEditor = $('<div>').append(editor.element.$.innerText),
                     existingImages = $shadowEditor.find('img');
 
+                editor.toolbar.forEach(function(toolbar){
+                    if(toolbar.items){
+                        toolbar.items.forEach(function(item){
+                            if(item.command == 'image'){
+                                item.setState(CKEDITOR.TRISTATE_OFF)
+                            }
+                        });
+                    }
+                });
+
                 if (additionalAttributes.length) {
                     allowedAttributes.push.apply(allowedAttributes, additionalAttributes);
                 }


### PR DESCRIPTION
Solution is parsing of every toolbars, then checking if the command is
'image'. If yes, put the button state at 'off' since button.getState
returns undefined

Fixes  netresearch/t3x-rte_ckeditor_image #145 