### PR TITLE
Make extension PHPStan level 8 error-free

### DIFF
--- a/Classes/Controller/ImageLinkRenderingController.php
+++ b/Classes/Controller/ImageLinkRenderingController.php
@@ -45,13 +45,6 @@ class ImageLinkRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPl
     public $extKey = 'rte_ckeditor_image';
 
     /**
-     * Configuration
-     *
-     * @var array
-     */
-    public $conf = [];
-
-    /**
      * cObj object
      *
      * @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
@@ -61,10 +54,10 @@ class ImageLinkRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPl
     /**
      * Returns a processed image to be displayed on the Frontend.
      *
-     * @param array $conf TypoScript configuration
+     * @param array<mixed> $conf TypoScript configuration
      * @return string HTML output
      */
-    public function renderImages($conf)
+    public function renderImages($conf = [])
     {
         // Get link inner HTML
         $linkContent = $this->cObj->getCurrentVal();
@@ -178,7 +171,7 @@ class ImageLinkRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPl
      * Returns attributes value or even empty string when override mode is enabled
      *
      * @param string $attributeName
-     * @param array $attributes
+     * @param array<string, string> $attributes
      * @param \TYPO3\CMS\Core\Resource\File $image
      * @return string
      */

--- a/Classes/Controller/ImageLinkRenderingController.php
+++ b/Classes/Controller/ImageLinkRenderingController.php
@@ -169,7 +169,7 @@ class ImageLinkRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPl
      */
     protected function getLogger()
     {
-        /** @var $logManager \TYPO3\CMS\Core\Log\LogManager */
+        /** @var \TYPO3\CMS\Core\Log\LogManager $logManager */
         $logManager = GeneralUtility::makeInstance(LogManager::class);
         return $logManager->getLogger(get_class($this));
     }

--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -148,7 +148,7 @@ class ImageRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
         $img = '<img ' . GeneralUtility::implodeAttributes($imageAttributes, true, false) . ' />';
 
         // Popup rendering (support new `zoom` and legacy `clickenlarge` attributes)
-        if (($imageAttributes['data-htmlarea-zoom'] || $imageAttributes['data-htmlarea-clickenlarge']) && isset($systemImage) && $systemImage) {
+        if (($imageAttributes['data-htmlarea-zoom'] || $imageAttributes['data-htmlarea-clickenlarge']) && isset($systemImage)) {
             $config = $GLOBALS['TSFE']->tmpl->setup['lib.']['contentElement.']['settings.']['media.']['popup.'];
             $config['enable'] = 1;
             $systemImage->updateProperties(array('title'=>($imageAttributes['title']) ? $imageAttributes['title'] : $systemImage->getProperty('title')));

--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -83,7 +83,7 @@ class ImageRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
      * @param array $conf TypoScript configuration
      * @return string HTML output
      */
-    public function renderImageAttributes($content, $conf)
+    public function renderImageAttributes($content = '', $conf = [])
     {
         $imageAttributes = $this->getImageAttributes();
 

--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -210,7 +210,7 @@ class ImageRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
      */
     protected function getLogger()
     {
-        /** @var $logManager LogManager */
+        /** @var LogManager $logManager */
         $logManager = GeneralUtility::makeInstance(LogManager::class);
         return $logManager->getLogger(get_class($this));
     }

--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -63,13 +63,6 @@ class ImageRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
     public $extKey = 'rte_ckeditor_image';
 
     /**
-     * Configuration
-     *
-     * @var array
-     */
-    public $conf = [];
-
-    /**
      * cObj object
      *
      * @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer
@@ -80,7 +73,7 @@ class ImageRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
      * Returns a processed image to be displayed on the Frontend.
      *
      * @param string $content Content input (not used).
-     * @param array $conf TypoScript configuration
+     * @param array<mixed> $conf TypoScript configuration
      * @return string HTML output
      */
     public function renderImageAttributes($content = '', $conf = [])
@@ -167,7 +160,7 @@ class ImageRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
     /**
      * Returns a sanitizes array of attributes out of $this->cObj
      *
-     * @return array
+     * @return array<mixed>
      */
     protected function getImageAttributes()
     {
@@ -219,7 +212,7 @@ class ImageRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
      * Returns attributes value or even empty string when override mode is enabled
      *
      * @param string $attributeName
-     * @param array $attributes
+     * @param array<string, string> $attributes
      * @param File $image
      * @return string
      */

--- a/Classes/Controller/SelectImageController.php
+++ b/Classes/Controller/SelectImageController.php
@@ -80,7 +80,7 @@ class SelectImageController extends ElementBrowserController
         if (!$id || !is_numeric($id)) {
             HttpUtility::setResponseCodeAndExit(HttpUtility::HTTP_STATUS_412);
         }
-        $file = $this->getImage($id);
+        $file = $this->getImage((int)$id);
         $processedFile = $this->processImage($file, $params);
 
         $lang = $this->getLanguageService();

--- a/Classes/Controller/SelectImageController.php
+++ b/Classes/Controller/SelectImageController.php
@@ -41,7 +41,7 @@ use TYPO3\CMS\Core\Utility\HttpUtility;
  */
 class SelectImageController extends ElementBrowserController
 {
-    protected $isInfoAction;
+    protected bool $isInfoAction;
 
     public function __construct()
     {
@@ -157,7 +157,7 @@ class SelectImageController extends ElementBrowserController
      * Get the processed image
      *
      * @param File $file
-     * @param array $params
+     * @param array<string, mixed> $params
      *
      * @return ProcessedFile
      */

--- a/Classes/Controller/SelectImageController.php
+++ b/Classes/Controller/SelectImageController.php
@@ -52,9 +52,6 @@ class SelectImageController extends ElementBrowserController
                 $bparams[3] = $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'];
                 $_GET['bparams'] = implode('|', $bparams);
             }
-            if (in_array('__construct', get_class_methods(get_parent_class($this)))) {
-                parent::__construct();
-            }
         }
         $this->mode = 'file';
     }

--- a/Classes/Controller/SelectImageController.php
+++ b/Classes/Controller/SelectImageController.php
@@ -112,12 +112,16 @@ class SelectImageController extends ElementBrowserController
     /**
      * Get the image url
      *
-     * @param string $imgUrl
+     * @param string|null $imgUrl
      *
-     * @return string image url
+     * @return string|null image url
      */
     protected function prettifyImgUrl($imgUrl)
     {
+        if ($imgUrl === null) {
+            return null;
+        }
+
         $siteUrl = GeneralUtility::getIndpEnv('TYPO3_SITE_URL');
         $sitePath = str_replace(GeneralUtility::getIndpEnv('TYPO3_REQUEST_HOST'), '', $siteUrl);
         $absoluteUrl = trim($imgUrl);

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -47,7 +47,7 @@ class RteImagesDbHook extends RteHtmlParser
      *
      *
      * @param string $value
-     * @return array
+     * @return string
      */
     public function transform_rte($value)
     {
@@ -84,7 +84,7 @@ class RteImagesDbHook extends RteHtmlParser
      *
      *
      * @param string $value
-     * @return array
+     * @return string
      */
     public function transform_db($value)
     {

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -120,7 +120,7 @@ class RteImagesDbHook extends RteHtmlParser
                     $absoluteUrl = trim($attribArray['src']);
                     // Make path absolute if it is relative and we have a site path which is not '/'
                     $pI = pathinfo($absoluteUrl);
-                    if ($sitePath && !$pI['scheme'] && GeneralUtility::isFirstPartOfStr($absoluteUrl, $sitePath)) {
+                    if ($sitePath && !($pI['scheme'] ?? null) && GeneralUtility::isFirstPartOfStr($absoluteUrl, $sitePath)) {
                         // If site is in a subpath (eg. /~user_jim/) this path needs to be removed because it will be added with $siteUrl
                         $absoluteUrl = substr($absoluteUrl, strlen($sitePath));
                         $absoluteUrl = $siteUrl . $absoluteUrl;
@@ -134,7 +134,7 @@ class RteImagesDbHook extends RteHtmlParser
                         $attribArray['height'] = $imgTagDimensions[1];
                     }
                     $originalImageFile = null;
-                    if ($attribArray['data-htmlarea-file-uid']) {
+                    if ($attribArray['data-htmlarea-file-uid'] ?? false) {
                         // An original image file uid is available
                         try {
                             $originalImageFile = $resourceFactory->getFileObject((int)$attribArray['data-htmlarea-file-uid']);
@@ -188,7 +188,7 @@ class RteImagesDbHook extends RteHtmlParser
 
                             $attribArray['src'] = $imgSrc;
                         }
-                    } elseif (!GeneralUtility::isFirstPartOfStr($absoluteUrl, $siteUrl) && !$this->procOptions['dontFetchExtPictures'] && TYPO3_MODE === 'BE') {
+                    } elseif (!GeneralUtility::isFirstPartOfStr($absoluteUrl, $siteUrl) && !($this->procOptions['dontFetchExtPictures'] ?? false) && TYPO3_MODE === 'BE') {
                         // External image from another URL: in that case, fetch image, unless the feature is disabled or we are not in backend mode
                         // Fetch the external image
                         $externalFile = GeneralUtility::getUrl($absoluteUrl);
@@ -199,8 +199,7 @@ class RteImagesDbHook extends RteHtmlParser
                             if ($extension === 'jpg' || $extension === 'jpeg' || $extension === 'gif' || $extension === 'png') {
                                 $fileName = GeneralUtility::shortMD5($absoluteUrl) . '.' . $pI['extension'];
                                 // We insert this image into the user default upload folder
-                                list($table, $field) = explode(':', $this->elRef);
-                                $folder = $GLOBALS['BE_USER']->getDefaultUploadFolder($this->recPid, $table, $field);
+                                $folder = $GLOBALS['BE_USER']->getDefaultUploadFolder();
                                 $fileObject = $folder->createFile($fileName)->setContents($externalFile);
                                 $imageConfiguration = [
                                     'width' => $attribArray['width'],

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -119,7 +119,7 @@ class RteImagesDbHook extends RteHtmlParser
                     $absoluteUrl = trim($attribArray['src']);
                     // Make path absolute if it is relative and we have a site path which is not '/'
                     $pI = pathinfo($absoluteUrl);
-                    if ($sitePath && !isset($pI['scheme']) && GeneralUtility::isFirstPartOfStr($absoluteUrl, $sitePath)) {
+                    if ($sitePath && GeneralUtility::isFirstPartOfStr($absoluteUrl, $sitePath)) {
                         // If site is in a subpath (eg. /~user_jim/) this path needs to be removed because it will be added with $siteUrl
                         $absoluteUrl = substr($absoluteUrl, strlen($sitePath));
                         $absoluteUrl = $siteUrl . $absoluteUrl;

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -120,7 +120,7 @@ class RteImagesDbHook extends RteHtmlParser
                     $absoluteUrl = trim($attribArray['src']);
                     // Make path absolute if it is relative and we have a site path which is not '/'
                     $pI = pathinfo($absoluteUrl);
-                    if ($sitePath && !($pI['scheme'] ?? null) && GeneralUtility::isFirstPartOfStr($absoluteUrl, $sitePath)) {
+                    if ($sitePath && !isset($pI['scheme']) && GeneralUtility::isFirstPartOfStr($absoluteUrl, $sitePath)) {
                         // If site is in a subpath (eg. /~user_jim/) this path needs to be removed because it will be added with $siteUrl
                         $absoluteUrl = substr($absoluteUrl, strlen($sitePath));
                         $absoluteUrl = $siteUrl . $absoluteUrl;

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -268,6 +268,41 @@ class RteImagesDbHook extends RteHtmlParser
     }
 
     /**
+     * Apply plain image settings to the dimensions of the image
+     *
+     * @param array $imageInfo: info array of the image
+     * @param array $attribArray: array of attributes of an image tag
+     *
+     * @return array a modified attributes array
+     */
+    protected function applyPlainImageModeSettings($imageInfo, $attribArray)
+    {
+        if (isset($this->procOptions['plainImageMode'])) {
+            // Perform corrections to aspect ratio based on configuration
+            switch ((string)$this->procOptions['plainImageMode']) {
+                case 'lockDimensions':
+                    $attribArray['width'] = $imageInfo[0];
+                    $attribArray['height'] = $imageInfo[1];
+                    break;
+                case 'lockRatioWhenSmaller':
+                    if ($attribArray['width'] > $imageInfo[0]) {
+                        $attribArray['width'] = $imageInfo[0];
+                    }
+                    if ($imageInfo[0] > 0) {
+                        $attribArray['height'] = round($attribArray['width'] * ($imageInfo[1] / $imageInfo[0]));
+                    }
+                    break;
+                case 'lockRatio':
+                    if ($imageInfo[0] > 0) {
+                        $attribArray['height'] = round($attribArray['width'] * ($imageInfo[1] / $imageInfo[0]));
+                    }
+                    break;
+            }
+        }
+        return $attribArray;
+    }
+
+    /**
      * Finds width and height from attrib-array
      * If the width and height is found in the style-attribute, use that!
      *

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -271,10 +271,10 @@ class RteImagesDbHook extends RteHtmlParser
     /**
      * Apply plain image settings to the dimensions of the image
      *
-     * @param array $imageInfo: info array of the image
-     * @param array $attribArray: array of attributes of an image tag
+     * @param array<int, mixed> $imageInfo: info array of the image
+     * @param array<string, mixed> $attribArray: array of attributes of an image tag
      *
-     * @return array a modified attributes array
+     * @return array<string, mixed> a modified attributes array
      */
     protected function applyPlainImageModeSettings($imageInfo, $attribArray)
     {
@@ -307,8 +307,8 @@ class RteImagesDbHook extends RteHtmlParser
      * Finds width and height from attrib-array
      * If the width and height is found in the style-attribute, use that!
      *
-     * @param array $attribArray Array of attributes from tag in which to search. More specifically the content of the key "style" is used to extract "width:xxx / height:xxx" information
-     * @return array Integer w/h in key 0/1. Zero is returned if not found.
+     * @param array<string,mixed> $attribArray Array of attributes from tag in which to search. More specifically the content of the key "style" is used to extract "width:xxx / height:xxx" information
+     * @return array{0: int, 1: int} Integer w/h in key 0/1. Zero is returned if not found.
      */
     protected function getWHFromAttribs($attribArray)
     {

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -138,9 +138,11 @@ class RteImagesDbHook extends RteHtmlParser
                         try {
                             $originalImageFile = $resourceFactory->getFileObject((int)$attribArray['data-htmlarea-file-uid']);
                         } catch (FileDoesNotExistException $fileDoesNotExistException) {
-                            // Log the fact the file could not be retrieved.
-                            $message = sprintf('Could not find file with uid "%s"', $attribArray['data-htmlarea-file-uid']);
-                            $this->logger->error($message);
+                            if ($this->logger !== null) {
+                                // Log the fact the file could not be retrieved.
+                                $message = sprintf('Could not find file with uid "%s"', $attribArray['data-htmlarea-file-uid']);
+                                $this->logger->error($message);
+                            }
                         }
                     }
                     if ($originalImageFile instanceof File) {
@@ -178,7 +180,7 @@ class RteImagesDbHook extends RteHtmlParser
 
                             // publicUrl like 'https://www.domain.xy/typo3/image/process?token=...'?
                             // -> generate img source from storage basepath and identifier instead
-                            if (strpos($imgSrc, 'process?token=') !== false) {
+                            if ($imgSrc !== null && strpos($imgSrc, 'process?token=') !== false) {
                                 $storageBasePath = $magicImage->getStorage()->getConfiguration()['basePath'];
                                 $imgUrlPre = (substr($storageBasePath, -1, 1) === '/') ? substr($storageBasePath, 0, -1) : $storageBasePath;
 

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -1,6 +1,7 @@
 <?php
 namespace Netresearch\RteCKEditorImage\Database;
 
+use TYPO3\CMS\Core\Resource\AbstractFile;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -45,8 +46,7 @@ class RteImagesDbHook extends RteHtmlParser
     /**
      *
      *
-     * @param array $parameters
-     * @param RteHtmlParser $parserObject
+     * @param string $value
      * @return array
      */
     public function transform_rte($value)
@@ -60,7 +60,7 @@ class RteImagesDbHook extends RteHtmlParser
                 // Image found
                 if ($k % 2) {
                     // Get the attributes of the img tag
-                    list($attribArray) = $this->get_tag_attributes($v, true);
+                    [$attribArray] = $this->get_tag_attributes($v, true);
                     $absoluteUrl = trim($attribArray['src']);
                     // Transform the src attribute into an absolute url, if it not already
                     if (stripos($absoluteUrl, 'http') !== 0) {
@@ -83,8 +83,7 @@ class RteImagesDbHook extends RteHtmlParser
     /**
      *
      *
-     * @param array $parameters
-     * @param RteHtmlParser $parserObject
+     * @param string $value
      * @return array
      */
     public function transform_db($value)
@@ -115,7 +114,7 @@ class RteImagesDbHook extends RteHtmlParser
                 // Image found, do processing:
                 if ($k % 2) {
                     // Get attributes
-                    list($attribArray) = $this->get_tag_attributes($v, true);
+                    [$attribArray] = $this->get_tag_attributes($v, true);
                     // It's always an absolute URL coming from the RTE into the Database.
                     $absoluteUrl = trim($attribArray['src']);
                     // Make path absolute if it is relative and we have a site path which is not '/'
@@ -238,12 +237,14 @@ class RteImagesDbHook extends RteHtmlParser
                                 if ($fileOrFolderObject instanceof FileInterface) {
                                     $fileIdentifier = $fileOrFolderObject->getIdentifier();
                                     $fileObject = $fileOrFolderObject->getStorage()->getFile($fileIdentifier);
-                                    $fileUid = $fileObject->getUid();
-                                    // if the retrieved file is a processed file, get the original file...
-                                    if($fileObject->hasProperty('original')){
-                                        $fileUid = $fileObject->getProperty('original');
+                                    if ($fileObject instanceof AbstractFile) {
+                                        $fileUid = $fileObject->getUid();
+                                        // if the retrieved file is a processed file, get the original file...
+                                        if($fileObject->hasProperty('original')){
+                                            $fileUid = $fileObject->getProperty('original');
+                                        }
+                                        $attribArray['data-htmlarea-file-uid'] = $fileUid;
                                     }
-                                    $attribArray['data-htmlarea-file-uid'] = $fileUid;
                                 }
                             } catch (ResourceDoesNotExistException $resourceDoesNotExistException) {
                                 // Nothing to be done if file/folder not found

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -193,10 +193,11 @@ class RteImagesDbHook extends RteHtmlParser
                         $externalFile = GeneralUtility::getUrl($absoluteUrl);
                         if ($externalFile) {
                             $pU = parse_url($absoluteUrl);
-                            $pI = pathinfo($pU['path']);
-                            $extension = strtolower($pI['extension']);
+                            $path = is_array($pU) ? ($pU['path'] ?? '') : '';
+                            $pI = pathinfo($path);
+                            $extension = strtolower($pI['extension'] ?? '');
                             if ($extension === 'jpg' || $extension === 'jpeg' || $extension === 'gif' || $extension === 'png') {
-                                $fileName = GeneralUtility::shortMD5($absoluteUrl) . '.' . $pI['extension'];
+                                $fileName = GeneralUtility::shortMD5($absoluteUrl) . '.' . ($pI['extension'] ?? '');
                                 // We insert this image into the user default upload folder
                                 $folder = $GLOBALS['BE_USER']->getDefaultUploadFolder();
                                 $fileObject = $folder->createFile($fileName)->setContents($externalFile);

--- a/Classes/Database/RteImagesSoftReferenceIndex.php
+++ b/Classes/Database/RteImagesSoftReferenceIndex.php
@@ -30,13 +30,15 @@ class RteImagesSoftReferenceIndex extends TypolinkSoftReferenceParser implements
 
     /**
      * Content splitted into images and other elements
+     *
+     * @var array<string, string>
      */
     public $splittedContentTags = [];
 
     /**
      * TYPO3 HTML Parser
      */
-    public $htmlParser;
+    public HtmlParser $htmlParser;
     
     /**
      * @var EventDispatcherInterface
@@ -51,10 +53,10 @@ class RteImagesSoftReferenceIndex extends TypolinkSoftReferenceParser implements
      * @param int    $uid           UID of the record
      * @param string $content       The content/value of the field
      * @param string $spKey         The softlink parser key. This is only interesting if more than one parser is grouped in the same class. That is the case with this parser.
-     * @param array  $spParams      Parameters of the softlink parser. Basically this is the content inside optional []-brackets after the softref keys. Parameters are exploded by ";
+     * @param array<mixed>  $spParams      Parameters of the softlink parser. Basically this is the content inside optional []-brackets after the softref keys. Parameters are exploded by ";
      * @param string $structurePath If running from inside a FlexForm structure, this is the path of the tag.
      *
-     * @return array|boolean Result array on positive matches. Otherwise FALSE
+     * @return array{content: string, elements: array<string, array{matchString: string, subst: array{type: string, recordRef: string, tokenID: string, tokenValue: mixed}}>}|boolean Result array on positive matches. Otherwise FALSE
      */
     public function findRef($table, $field, $uid, $content, $spKey, $spParams, $structurePath = '')
     {
@@ -78,7 +80,7 @@ class RteImagesSoftReferenceIndex extends TypolinkSoftReferenceParser implements
      *
      * @param string $content  The input content to analyse
      *
-     * @return array|boolean  Result array on positive matches, see description above. Otherwise FALSE
+     * @return array{content: string, elements: array<string, array{matchString: string, subst: array{type: string, recordRef: string, tokenID: string, tokenValue: mixed}}>}|boolean  Result array on positive matches, see description above. Otherwise FALSE
      */
     public function findRef_rtehtmlarea_images($content)
     {
@@ -116,7 +118,7 @@ class RteImagesSoftReferenceIndex extends TypolinkSoftReferenceParser implements
      * Finding image tags with data-htmlarea-file-uid attribute in the content.
      * All images that have an data-htmlarea-file-uid attribute will be returned with an info text
      *
-     * @return array
+     * @return array<string, array{matchString: string, subst: array{type: string, recordRef: string, tokenID: string, tokenValue: mixed}}>
      */
     private function findImagesWithDataUid()
     {

--- a/Classes/Database/RteImagesSoftReferenceIndex.php
+++ b/Classes/Database/RteImagesSoftReferenceIndex.php
@@ -106,12 +106,12 @@ class RteImagesSoftReferenceIndex extends TypolinkSoftReferenceParser implements
      * Checks for image tags
      *
      * @param string $element
-     * @return int
+     * @return bool
      */
     private function hasImageTag($element)
     {
         $pattern = "/^<img/";
-        return preg_match($pattern, $element);
+        return (bool)preg_match($pattern, $element);
     }
 
     /**

--- a/Classes/Database/RteImagesSoftReferenceIndex.php
+++ b/Classes/Database/RteImagesSoftReferenceIndex.php
@@ -103,7 +103,7 @@ class RteImagesSoftReferenceIndex extends TypolinkSoftReferenceParser implements
     /**
      * Checks for image tags
      *
-     * @param $element
+     * @param string $element
      * @return int
      */
     private function hasImageTag($element)

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
 	"homepage": "https://www.netresearch.de",
 	"license": ["GPL-2.0-or-later"],
 	"require": {
+		"php": "^7.4 || ^8.0",
 		"typo3/cms-core": "^11.5"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,10 @@
 		"typo3/cms-core": "^11.5"
 	},
 	"require-dev": {
-		"namelesscoder/typo3-repository-client": "^1.2"
+		"namelesscoder/typo3-repository-client": "^1.2",
+		"phpstan/phpstan": "^1.4",
+		"phpstan/extension-installer": "^1.1",
+		"saschaegerer/phpstan-typo3": "^1.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,6 +10,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '11.0.2',
     'constraints' => [
         'depends' => [
+            'php' => '7.4.0-8.9.99',
             'typo3' => '11.0.0-11.5.99',
             'rte_ckeditor' => '11.0.0-11.5.99',
         ],

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 6
+  level: 7
   reportUnmatchedIgnoredErrors: true
   ignoreErrors:
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 4
+  level: 6
   reportUnmatchedIgnoredErrors: true
   ignoreErrors:
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,9 @@
 parameters:
-  level: 0
+  level: 1
   reportUnmatchedIgnoredErrors: true
+  ignoreErrors:
+
+  # ignored errors for level 1
+  -
+    path: ext_emconf.php
+    message: '#Variable \$_EXTKEY might not be defined\.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 2
+  level: 3
   reportUnmatchedIgnoredErrors: true
   ignoreErrors:
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 1
+  level: 2
   reportUnmatchedIgnoredErrors: true
   ignoreErrors:
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 7
+  level: 8
   reportUnmatchedIgnoredErrors: true
   ignoreErrors:
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 3
+  level: 4
   reportUnmatchedIgnoredErrors: true
   ignoreErrors:
 
@@ -7,3 +7,10 @@ parameters:
   -
     path: ext_emconf.php
     message: '#Variable \$_EXTKEY might not be defined\.#'
+
+  # ignored errors for level 4
+  -
+    message: '#Right side of \\|\\| is always false#'
+    paths:
+      - ext_localconf.php
+      - Configuration/TCA/Overrides/*

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,3 @@
+parameters:
+  level: 0
+  reportUnmatchedIgnoredErrors: true


### PR DESCRIPTION
This pull request fixed invalid PHP/PHPDoc syntax, adds missing functionality which has been deprecated and already removed from TYPO3 core, and prevents some undetected bugs.

It is based on PR #153, since the errors fixed in there would also have been reported by PHPStan.

All error levels have been fixed in individual commits.
There are still 19 more errors on level 9, but fixing them is mostly adding them to the exclusion list, since TYPO3 core type annotations are not yet as perfect as they could be.