### PR TITLE
[BUGFIX] Fix broken images in RTEs inside flexform elements

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -83,7 +83,10 @@
                         }
 
                         $.getJSON(url, function(newImg) {
-                            var realEditor = $('#cke_' + editor.element.$.id).find('iframe').contents().find('body'),
+                            // RTEs in flexforms might contain dots in their ID, so we need to escape them
+                            var escapedEditorId = editor.element.$.id.replace('.', '\\.');
+
+                            var realEditor = $('#cke_' + escapedEditorId).find('iframe').contents().find('body'),
                                 newImgUrl = newImg.processed.url || newImg.url;
 
                             // Replace current url with updated one


### PR DESCRIPTION
Typo3 adds a period to the HTML ID of RTEs in flexforms.
This period needs to be escaped, so that is not interpreted as the start of a class name.

Closes #168 


