### PR TITLE
[BUGFIX] fix misuse of 11LTS BE processing middleware URLs

### DIFF
--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -195,6 +195,10 @@ class ImageRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
     protected function isExternalImage()
     {
         $srcAbsoluteUrl = $this->cObj->parameters['src'];
+        if (strpos($srcAbsoluteUrl, '/typo3/image/process?token') !== false) {
+            // is a 11LTS backend processing url only valid for BE users, thus reprocessing needed
+            return false;
+        }
         return strtolower(substr($srcAbsoluteUrl, 0, 4)) === 'http' || substr($srcAbsoluteUrl, 0, 2) === '//';
     }
 


### PR DESCRIPTION
this fixes #187

The situation is as follows: starting with 11LTS in the backend processed images get not a `/fileaadmin/_processed/` "resulting image" style url but a new `/typo3/image/process?token` "middleware" style url. However that is only available for logged in BE users. Thus this can be saved to RTE and displayed there, however will break the frontend output.

Now I tried to fix what is saved in the backend/db, but came to the conclusion that this shouldn't be the aim, as there are probably reasons for the backend using that new URL.

Thus my approach here is to accept this new URL, accept the "bug" that this new URL gets converted to an absolute URL and rather tackle the problem while generating frontend output, where the generation is skipped formerly, because it sees "external URL". Now an if just checks for the string `'/typo3/image/process?token'` and starts reprocessing.
