### PR TITLE
[BUGFIX] fileadmin path without slash won't output in 11LTS

### DIFF
--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -137,6 +137,14 @@ class ImageRenderingController extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
             $imageAttributes = array_diff_key($imageAttributes, array_flip($unsetParams));
         }
 
+        if (
+            $imageAttributes['src']
+            && stripos($imageAttributes['src'], 'http') !== 0
+            && strpos($imageAttributes['src'], '/') !== 0
+        ) {
+            $imageAttributes['src'] = '/' . $imageAttributes['src'];
+        }
+
         // Image template; empty attributes are removed by 3rd param 'false'
         $img = '<img ' . GeneralUtility::implodeAttributes($imageAttributes, true, false) . ' />';
 

--- a/Classes/Controller/SelectImageController.php
+++ b/Classes/Controller/SelectImageController.php
@@ -122,12 +122,9 @@ class SelectImageController extends ElementBrowserController
             return null;
         }
 
-        $siteUrl = GeneralUtility::getIndpEnv('TYPO3_SITE_URL');
-        $sitePath = str_replace(GeneralUtility::getIndpEnv('TYPO3_REQUEST_HOST'), '', $siteUrl);
         $absoluteUrl = trim($imgUrl);
-        if (strtolower(substr($absoluteUrl, 0, 4)) !== 'http') {
-            $imgUrl = preg_replace('#^' . preg_quote($sitePath, '#') . '#', '', $imgUrl);
-            $imgUrl = $siteUrl . $imgUrl;
+        if ((stripos($absoluteUrl, 'http') !== 0) && strpos($absoluteUrl, '/') !== 0) {
+            $absoluteUrl = '/' .$absoluteUrl;
         }
 
         return $imgUrl;


### PR DESCRIPTION
After switching to 11LTS I saw an issue: 

Some old RTE fields (last change >=5 years) exist which were never properly converted, so using `<img src="fileadmin/..."/>` (no slash prefix, no data attributes) instead of `<img src="/fileadmin/..." data-htmlarea-file-uid=.../>`. While in 10LTS they were rendered correctly, in 11LTS they are not processed, keeping the version without a slash, thus not working on subpages.

Diving into the code the `SelectImageController` as well as the `ImageRenderingController` use different approaches to manipulate the src. I propose to simplify this. The idea is basically: as long as it is no external URL, it should start with a slash, instead of allowing `fileadmin` without slash in frontend or force-prefixing a FQDN in backend RTE.

I wonder if that has something to do with https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.3/Deprecation-94193-PublicUrlWithRelativePathsInFALAPI.html which was a (IMHO breaking) change from 10LTS to 11LTS concerning the slash prefix for fileadmin.