### PR TITLE
Load Image when inserted to editor

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -238,7 +238,8 @@
         }
 
         if (url.indexOf("http://") !== -1 || url.indexOf("https://") !== -1) {
-            return new URL(url).pathname;
+            var u = new URL(url);
+            return u.pathname + u.search;
         } else {
             if (url[0] !== "/") {
                 return "/" + url;

--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -244,6 +244,8 @@
                 return "/" + url;
             }
         }
+        
+        return url;
     }
 
     /**


### PR DESCRIPTION
On TYPO3v3 images aren't loaded in editor after inserting.
There is just a white Placeholder, the image is loaded after saving or switching to code view.

This is a fix for images stored on public and non public filestorages.