### PR TITLE
#205: Fix PHP warning about undefined array key access

### DIFF
--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -156,8 +156,7 @@ class RteImagesDbHook extends RteHtmlParser
                     }
                     if ($originalImageFile instanceof File) {
                         // Public url of local file is relative to the site url, absolute otherwise
-                        if ($absoluteUrl == $originalImageFile->getPublicUrl() || $absoluteUrl == $siteUrl . $originalImageFile->getPublicUrl()) {
-                        } else {
+                        if ($absoluteUrl != $originalImageFile->getPublicUrl() && $absoluteUrl != $siteUrl . $originalImageFile->getPublicUrl()) {
                             // Magic image case: get a processed file with the requested configuration
                             $imageConfiguration = [
                                 'width' => $imgTagDimensions[0],

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -159,7 +159,7 @@ class RteImagesDbHook extends RteHtmlParser
                         $imageFileUrl = $siteUrl . $originalImageFile->getPublicUrl();
 
                         // Public url of local file is relative to the site url, absolute otherwise
-                        if (($absoluteUrl !== $originalImageFile->getPublicUrl()) && ($absoluteUrl !== $imageFileUrl)) {
+                        if (($absoluteUrl !== $imageFileUrl) && ($absoluteUrl !== $originalImageFile->getPublicUrl())) {
                             // Magic image case: get a processed file with the requested configuration
                             $imageConfiguration = [
                                 'width' => $imgTagDimensions[0],

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -158,7 +158,7 @@ class RteImagesDbHook extends RteHtmlParser
                         // Public url of local file is relative to the site url, absolute otherwise
                         if ($absoluteUrl == $originalImageFile->getPublicUrl() || $absoluteUrl == $siteUrl . $originalImageFile->getPublicUrl()) {
                             // This is a plain image, i.e. reference to the original image
-                            if ($this->procOptions['plainImageMode']) {
+                            if (isset($this->procOptions['plainImageMode'])) {
                                 // "plain image mode" is configured
                                 // Find the dimensions of the original image
                                 $imageInfo = [
@@ -242,7 +242,7 @@ class RteImagesDbHook extends RteHtmlParser
                         // Check file existence (in relative directory to this installation!)
                         if ($filepath && @is_file($filepath)) {
                             // Treat it as a plain image
-                            if ($this->procOptions['plainImageMode']) {
+                            if (isset($this->procOptions['plainImageMode'])) {
                                 // If "plain image mode" has been configured
                                 // Find the original dimensions of the image
                                 $imageInfoObject = GeneralUtility::makeInstance(ImageInfo::class, $filepath);

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -14,7 +14,6 @@ use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Resource\Service\MagicImageService;
-use TYPO3\CMS\Core\Type\File\ImageInfo;
 use TYPO3\CMS\Backend\Configuration\TypoScript\ConditionMatching\ConditionMatcher;
 use TYPO3\CMS\Core\Configuration\Loader\PageTsConfigLoader;
 use TYPO3\CMS\Core\Configuration\Parser\PageTsConfigParser;

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -155,8 +155,11 @@ class RteImagesDbHook extends RteHtmlParser
                         }
                     }
                     if ($originalImageFile instanceof File) {
+                        // Build public URL to image, remove trailing slash from site URL
+                        $imageFileUrl = $siteUrl . $originalImageFile->getPublicUrl();
+
                         // Public url of local file is relative to the site url, absolute otherwise
-                        if ($absoluteUrl !== $originalImageFile->getPublicUrl() && $absoluteUrl !== $siteUrl . $originalImageFile->getPublicUrl()) {
+                        if (($absoluteUrl !== $originalImageFile->getPublicUrl()) && ($absoluteUrl !== $imageFileUrl)) {
                             // Magic image case: get a processed file with the requested configuration
                             $imageConfiguration = [
                                 'width' => $imgTagDimensions[0],

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -34,9 +34,11 @@ use TYPO3\CMS\Extbase\Configuration\BackendConfigurationManager;
  * @author     Stefan Galinski <stefan@sgalinski.de>
  * @license    http://www.gnu.de/documents/gpl-2.0.de.html GPL 2.0+
  * @link       http://www.netresearch.de
+ *
+ * @deprecated in TYPO3 v12
+ * @see https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/ApiOverview/Rte/Transformations/CustomApi.html
+ * @see https://docs.typo3.org/m/typo3/reference-tsconfig/10.4/en-us/PageTsconfig/Rte.html#pagetsrte
  */
-
-
 class RteImagesDbHook extends RteHtmlParser
 {
     /**

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -156,7 +156,7 @@ class RteImagesDbHook extends RteHtmlParser
                     }
                     if ($originalImageFile instanceof File) {
                         // Public url of local file is relative to the site url, absolute otherwise
-                        if ($absoluteUrl != $originalImageFile->getPublicUrl() && $absoluteUrl != $siteUrl . $originalImageFile->getPublicUrl()) {
+                        if ($absoluteUrl !== $originalImageFile->getPublicUrl() && $absoluteUrl !== $siteUrl . $originalImageFile->getPublicUrl()) {
                             // Magic image case: get a processed file with the requested configuration
                             $imageConfiguration = [
                                 'width' => $imgTagDimensions[0],

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -156,7 +156,7 @@ class RteImagesDbHook extends RteHtmlParser
                     }
                     if ($originalImageFile instanceof File) {
                         // Build public URL to image, remove trailing slash from site URL
-                        $imageFileUrl = $siteUrl . $originalImageFile->getPublicUrl();
+                        $imageFileUrl = rtrim($siteUrl, '/') . $originalImageFile->getPublicUrl();
 
                         // Public url of local file is relative to the site url, absolute otherwise
                         if (($absoluteUrl !== $imageFileUrl) && ($absoluteUrl !== $originalImageFile->getPublicUrl())) {


### PR DESCRIPTION
Couldn't reproduce the issue on my system, but added an additional `isset` to the if condition to check if the array element is declared or not.