### PR TITLE
Fix output of alt and title attribute when overriden

### DIFF
--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -262,9 +262,7 @@ class ImageRenderingController extends AbstractPlugin
     {
         $attributeNameOverride = 'data-' . $attributeName . '-override';
 
-        if (isset($attributes[$attributeNameOverride])) {
-            $attributeValue = $attributes[$attributeNameOverride];
-        } elseif (isset($attributes[$attributeName])) {
+        if (isset($attributes[$attributeNameOverride]) && isset($attributes[$attributeName])) {
             $attributeValue = $attributes[$attributeName];
         } else {
             $attributeValue = $image->getProperty($attributeName);


### PR DESCRIPTION
**Explain the details**

When the alt- or title-attribute is overriden, a data attribute like data-title-override with the value true is added to the img tag in the editor. While outputting the image this value was used instead of the entered value, which caused the alt- and title-attributes to contain the value "true" in the frontend.

**Closing issues**
Closes #224
