### PR TITLE
Correctly handle embedded images (data:image)

### DIFF
--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -140,6 +140,7 @@ class ImageRenderingController extends AbstractPlugin
             ($imageSource !== '')
             && strncasecmp($imageSource, 'http', 4) !== 0
             && strncmp($imageSource, '/', 1) !== 0
+            && strpos($imageSource, 'data:image') !== 0
         ) {
             $imageAttributes['src'] = '/' . $imageSource;
         }

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -127,7 +127,7 @@ class RteImagesDbHook
 
                     // Transform the src attribute into an absolute url, if it not already
                     if (
-                        $imageSource
+                        $imageSource !== ''
                         && strncasecmp($imageSource, 'http', 4) !== 0
                         && strpos($imageSource, 'data:image') !== 0
                     ) {

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -123,10 +123,12 @@ class RteImagesDbHook
                 if (($key % 2) === 1) {
                     // Get the attributes of the img tag
                     [$attribArray] = $rteHtmlParser->get_tag_attributes($v, true);
-                    $absoluteUrl = trim($attribArray['src']);
+                    $imageSource = trim($attribArray['src']);
 
                     // Transform the src attribute into an absolute url, if it not already
-                    if (strncasecmp($absoluteUrl, 'http', 4) !== 0) {
+                    if (strncasecmp($imageSource, 'http', 4) !== 0
+                        && strpos($imageSource, 'data:image') !== 0
+                    ) {
                         // If site is in a sub path (e.g. /~user_jim/) this path needs to be
                         // removed because it will be added with $siteUrl
                         $attribArray['src'] = preg_replace(

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -123,22 +123,25 @@ class RteImagesDbHook
                 if (($key % 2) === 1) {
                     // Get the attributes of the img tag
                     [$attribArray] = $rteHtmlParser->get_tag_attributes($v, true);
-                    $imageSource = trim($attribArray['src']);
+                    $imageSource = trim($attribArray['src'] ?? '');
 
                     // Transform the src attribute into an absolute url, if it not already
                     if (
-                        strncasecmp($imageSource, 'http', 4) !== 0
+                        $imageSource
+                        && strncasecmp($imageSource, 'http', 4) !== 0
                         && strpos($imageSource, 'data:image') !== 0
                     ) {
                         // If site is in a sub path (e.g. /~user_jim/) this path needs to be
                         // removed because it will be added with $siteUrl
-                        $attribArray['src'] = preg_replace(
+                        $imageSource = preg_replace(
                             '#^' . preg_quote($sitePath, '#') . '#',
                             '',
-                            $attribArray['src']
+                            $imageSource
                         );
 
-                        $attribArray['src'] = $siteUrl . $attribArray['src'];
+                        $attribArray['src'] = $siteUrl . $imageSource;
+                    } else {
+                        $attribArray['src'] = $imageSource;
                     }
 
                     // Must have alt attribute

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -126,7 +126,8 @@ class RteImagesDbHook
                     $imageSource = trim($attribArray['src']);
 
                     // Transform the src attribute into an absolute url, if it not already
-                    if (strncasecmp($imageSource, 'http', 4) !== 0
+                    if (
+                        strncasecmp($imageSource, 'http', 4) !== 0
                         && strpos($imageSource, 'data:image') !== 0
                     ) {
                         // If site is in a sub path (e.g. /~user_jim/) this path needs to be


### PR DESCRIPTION
Handles 2 related problems:

1. If images contain an embedded image (beginning with data:image) and not  a path, a slash should not be prepended. Otherwise this breaks the rendering.
2. Do not prepend the site URL to embedded image in RTE pre-processing hook (when loading from DB to RTE)

Resolves: #226
Resolves: #228

