### PR TITLE
Fix issue that reference index is not created for image soft references

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -24,4 +24,4 @@ jobs:
 
       - run: composer validate
       - run: composer install --no-progress
-      - run: vendor/bin/phpstan analyse -c phpstan.neon
+      - run: .Build/bin/phpstan analyse -c phpstan.neon

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,4 @@
-name: PHPStan
+name: FunctionalTests
 
 on: [push, pull_request]
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,4 @@
-name: PHP_CodeSniffer
+name: PHPStan
 
 on: [push, pull_request]
 
@@ -9,7 +9,8 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-22.04]
-        php-version: ['7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.4', '8.0', '8.1']
+        db: ['mariadb', 'postgres']
 
     name: Testing PHP ${{ matrix.php-version }} on ${{ matrix.operating-system }}
 
@@ -22,6 +23,5 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - run: composer validate
-      - run: composer install --no-progress
-      - run: .Build/bin/phpcs Classes/ --standard=PSR12
+      - run: Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s composerInstall
+      - run: Build/Scripts/runTests.sh -p ${{ matrix.php-version }} -s functional -d ${{matrix.db}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.Build/
+Build/testing-docker/.env
 composer.lock
 .idea/
 vendor/

--- a/Build/Scripts/ci.sh
+++ b/Build/Scripts/ci.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Convenience script to run CI tests locally
+# default: PHP 8.1 and composer latest (uses TYPO3 v11)
+
+# abort on error
+set -e
+set -x
+
+# --------
+# defaults
+# --------
+PHP_VERSION="8.1"
+
+# -------------------
+# automatic variables
+# -------------------
+thisdir=$(dirname $0)
+cd $thisdir
+thisdir=$(pwd)
+progname=$(basename $0)
+
+echo "Running with PHP version${PHP_VERSION}"
+
+echo "composer install"
+${thisdir}/runTests.sh -p ${PHP_VERSION} -s composerInstall
+
+echo "composer validate"
+${thisdir}/runTests.sh -p ${PHP_VERSION} -s composerValidate
+
+#echo "cgl"
+#Build/Scripts/runTests.sh -p ${PHP_VERSION} -s cgl -n
+
+#echo "lint"
+#Build/Scripts/runTests.sh -p ${PHP_VERSION} -s lint
+
+#echo "phpstan"
+#Build/Scripts/runTests.sh -p ${PHP_VERSION} -s phpstan
+
+#echo "Unit tests"
+#Build/Scripts/runTests.sh -p ${PHP_VERSION} -s unit
+
+echo "functional tests"
+${thisdir}/runTests.sh -p ${PHP_VERSION} -d mariadb -s functional
+
+# -------
+# cleanup
+# -------
+
+$thisdir/cleanup.sh
+
+echo "done: ok"

--- a/Build/Scripts/cleanup.sh
+++ b/Build/Scripts/cleanup.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
-
 # convenience script for cleaning up after running test suite locally
 
-composer config --unset platform.php
-composer config --unset platform
-
-echo "--------------------------------------------------------------------------------"
-echo "!!!! Make sure to revert changes to composer.json by test suite e.g. by git checkout composer.json"
-git diff composer.json
-echo "--------------------------------------------------------------------------------"
+# currently not necessary, but might be if ci adds platform requirement
+#composer config --unset platform.php
+#composer config --unset platform
 
 rm -rf .Build
 rm -f composer.lock

--- a/Build/Scripts/cleanup.sh
+++ b/Build/Scripts/cleanup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# convenience script for cleaning up after running test suite locally
+
+composer config --unset platform.php
+composer config --unset platform
+
+echo "--------------------------------------------------------------------------------"
+echo "!!!! Make sure to revert changes to composer.json by test suite e.g. by git checkout composer.json"
+git diff composer.json
+echo "--------------------------------------------------------------------------------"
+
+rm -rf .Build
+rm -f composer.lock
+rm -f Build/testing-docker/.env

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+
+# copied from EXT:enetcache:
+#  https://github.com/lolli42/enetcache/blob/master/Build/Scripts/runTests.sh
+
+#
+# TYPO3 core test runner based on docker and docker-compose.
+#
+
+# Function to write a .env file in Build/testing-docker/local
+# This is read by docker-compose and vars defined here are
+# used in Build/testing-docker/local/docker-compose.yml
+setUpDockerComposeDotEnv() {
+    # Delete possibly existing local .env file if exists
+    [ -e .env ] && rm .env
+    # Set up a new .env file for docker-compose
+    {
+        echo "COMPOSE_PROJECT_NAME=local"
+
+        # To prevent access rights of files created by the testing, the docker image later
+        # runs with the same user that is currently executing the script. docker-compose can't
+        # use $UID directly itself since it is a shell variable and not an env variable, so
+        # we have to set it explicitly here.
+        echo "HOST_UID=`id -u`"
+
+        # Your local home directory for composer and npm caching
+        echo "HOST_HOME=${HOME}"
+
+        # Your local user
+        echo "CORE_VERSION=${CORE_VERSION}"
+        echo "ROOT_DIR=${ROOT_DIR}"
+        echo "HOST_USER=${USER}"
+        echo "TEST_FILE=${TEST_FILE}"
+        echo "CGLCHECK_DRY_RUN=${CGLCHECK_DRY_RUN}"
+        echo "PHP_XDEBUG_ON=${PHP_XDEBUG_ON}"
+        echo "PHP_XDEBUG_PORT=${PHP_XDEBUG_PORT}"
+        echo "PHP_VERSION=${PHP_VERSION}"
+        echo "DOCKER_PHP_IMAGE=${DOCKER_PHP_IMAGE}"
+        echo "EXTRA_TEST_OPTIONS=${EXTRA_TEST_OPTIONS}"
+        echo "SCRIPT_VERBOSE=${SCRIPT_VERBOSE}"
+        echo "PASSWD_PATH=${PASSWD_PATH}"
+    } > .env
+}
+
+# Load help text into $HELP
+read -r -d '' HELP <<EOF
+extension test runner. Execute unit, functional and other test suites in
+a docker based test environment. Handles execution of single test files, sending
+xdebug information to a local IDE and more.
+Also used by github actions for test execution.
+
+Recommended docker version is >=20.10 for xdebug break pointing to work reliably, and
+a recent docker-compose (tested >=1.21.2) is needed.
+
+Usage: $0 [options] [file]
+
+No arguments: Run all unit tests with PHP 7.2
+
+Options:
+    -s <...>
+        Specifies which test suite to run
+            - composerInstall: "composer install"
+            - composerInstallMax: "composer update", with no platform.php config.
+            - composerInstallMin: "composer update --prefer-lowest", with platform.php set to PHP version x.x.0.
+            - composerValidate: "composer validate"
+            - composerCoreVersion: "composer require --no-install typo3/minimal:"coreVersion"
+            - cgl: test and fix all core php files
+            - cglGit: test and fix latest committed patch for CGL compliance
+            - lint: PHP linting
+            - phpstan: phpstan tests
+            - phpstanGenerateBaseline: regenerate phpstan baseline, handy after phpstan updates
+            - unit (default): PHP unit tests
+            - functional: functional tests
+
+    -t <composer-core-version-constraint>
+        Only with -s composerCoreVersion
+        Specifies the Typo3 core version to be used
+            - '^11.5' (default)
+            - ...
+
+    -d <mariadb|mssql|postgres|sqlite>
+        Only with -s functional
+        Specifies on which DBMS tests are performed
+            - mariadb (default): use mariadb
+            - mssql: use mssql microsoft sql server
+            - postgres: use postgres
+            - sqlite: use sqlite
+
+    -p <7.2|7.3|7.4|8.0|8.1>
+        Specifies the PHP minor version to be used
+            - 7.2 (default): use PHP 7.2
+            - 7.3: use PHP 7.3
+            - 7.4: use PHP 7.4
+            - 8.0: use PHP 8.0
+            - 8.1: use PHP 8.1
+
+    -e "<phpunit|phpstan options>"
+        Only with -s functional|unit|phpstan
+        Additional options to send to phpunit tests.
+        For phpunit, options starting with "--" must be added after options starting with "-".
+        Example -e "-v --filter canRetrieveValueWithGP" to enable verbose output AND filter tests
+        named "canRetrieveValueWithGP"
+
+    -x
+        Only with -s unit | function
+        Send information to host instance for test or system under test break points. This is especially
+        useful if a local PhpStorm instance is listening on default xdebug port 9003. A different port
+        can be selected with -y
+
+    -y <port>
+        Send xdebug information to a different port than default 9003 if an IDE like PhpStorm
+        is not listening on default port.
+
+    -n
+        Only with -s cgl|cglGit
+        Activate dry-run in CGL check that does not actively change files and only prints broken ones.
+
+    -u
+        Update existing typo3gmbh/phpXY:latest docker images. Maintenance call to docker pull latest
+        versions of the main php images. The images are updated once in a while and only the youngest
+        ones are supported by core testing. Use this if weird test errors occur. Also removes obsolete
+        image versions of typo3gmbh/phpXY.
+
+    -v
+        Enable verbose script output. Shows variables and docker commands.
+
+    -h
+        Show this help.
+
+Examples:
+    # Run unit tests using default PHP
+    ./Build/Scripts/runTests.sh
+
+    # Run unit tests using PHP 8.1
+    ./Build/Scripts/runTests.sh -p 8.1
+
+    # Run functional tests using sqlite
+    ./Build/Scripts/runTests.sh -s functional -d sqlite
+
+    # Run functional tests in phpunit with a filtered test method name in a specified file and xdebug enabled.
+    ./Build/Scripts/runTests.sh -s functional -x -e "--filter getLinkStatisticsFindOnlyPageBrokenLinks" Tests/Functional/LinkAnalyzerTest.php
+EOF
+
+# Test if docker-compose exists, else exit out with error
+if ! type "docker-compose" > /dev/null; then
+  echo "This script relies on docker and docker-compose. Please install" >&2
+  exit 1
+fi
+
+# Go to the directory this script is located, so everything else is relative
+# to this dir, no matter from where this script is called.
+THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+cd "$THIS_SCRIPT_DIR" || exit 1
+
+# Go to directory that contains the local docker-compose.yml file
+cd ../testing-docker || exit 1
+
+# Option defaults
+if ! command -v realpath &> /dev/null; then
+  echo "This script works best with realpath installed" >&2
+  ROOT_DIR="${PWD}/../../"
+else
+  ROOT_DIR=`realpath ${PWD}/../../`
+fi
+CORE_VERSION="11.5"
+TEST_SUITE="unit"
+DBMS="mariadb"
+PHP_VERSION="8.1"
+PHP_XDEBUG_ON=0
+PHP_XDEBUG_PORT=9003
+EXTRA_TEST_OPTIONS=""
+SCRIPT_VERBOSE=0
+CGLCHECK_DRY_RUN=""
+PASSWD_PATH=/etc/passwd
+
+# Option parsing
+# Reset in case getopts has been used previously in the shell
+OPTIND=1
+# Array for invalid options
+INVALID_OPTIONS=();
+# Simple option parsing based on getopts (! not getopt)
+while getopts ":s:t:d:p:e:xy:huvn" OPT; do
+    case ${OPT} in
+        s)
+            TEST_SUITE=${OPTARG}
+            ;;
+        t)
+            CORE_VERSION=${OPTARG}
+            ;;
+        d)
+            DBMS=${OPTARG}
+            ;;
+        p)
+            PHP_VERSION=${OPTARG}
+            if ! [[ ${PHP_VERSION} =~ ^(7.2|7.3|7.4|8.0|8.1)$ ]]; then
+                INVALID_OPTIONS+=("${OPT} ${OPTARG} : unsupported php version")
+            fi
+            ;;
+        e)
+            EXTRA_TEST_OPTIONS=${OPTARG}
+            ;;
+        x)
+            PHP_XDEBUG_ON=1
+            ;;
+        y)
+            PHP_XDEBUG_PORT=${OPTARG}
+            ;;
+        h)
+            echo "${HELP}"
+            exit 0
+            ;;
+        n)
+            CGLCHECK_DRY_RUN="-n"
+            ;;
+        u)
+            TEST_SUITE=update
+            ;;
+        v)
+            SCRIPT_VERBOSE=1
+            ;;
+        \?)
+            INVALID_OPTIONS+=("${OPTARG}")
+            ;;
+        :)
+            INVALID_OPTIONS+=("${OPTARG}")
+            ;;
+    esac
+done
+
+# Exit on invalid options
+if [ ${#INVALID_OPTIONS[@]} -ne 0 ]; then
+    echo "Invalid option(s):" >&2
+    for I in "${INVALID_OPTIONS[@]}"; do
+        echo "-"${I} >&2
+    done
+    echo >&2
+    echo "${HELP}" >&2
+    exit 1
+fi
+
+# Move "7.2" to "php72", the latter is the docker container name
+DOCKER_PHP_IMAGE=`echo "php${PHP_VERSION}" | sed -e 's/\.//'`
+
+# Set $1 to first mass argument, this is the optional test file or test directory to execute
+shift $((OPTIND - 1))
+if [ -n "${1}" ]; then
+    TEST_FILE="../${1}"
+else
+    case ${TEST_SUITE} in
+        functional)
+            TEST_FILE="../Tests/Functional"
+            ;;
+        unit)
+            TEST_FILE="../Tests/Unit"
+            ;;
+    esac
+fi
+
+if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+    set -x
+fi
+
+# Suite execution
+case ${TEST_SUITE} in
+    composerCoreVersion)
+        setUpDockerComposeDotEnv
+        docker-compose run composer_coreversion_require
+        SUITE_EXIT_CODE=$?
+        ;;
+    composerInstall)
+        setUpDockerComposeDotEnv
+        docker-compose run composer_install
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    composerInstallMax)
+        setUpDockerComposeDotEnv
+        docker-compose run composer_install_max
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    composerInstallMin)
+        setUpDockerComposeDotEnv
+        docker-compose run composer_install_min
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    composerValidate)
+        setUpDockerComposeDotEnv
+        docker-compose run composer_validate
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    cgl)
+        # Active dry-run for cglAll needs not "-n" but specific options
+        if [[ ! -z ${CGLCHECK_DRY_RUN} ]]; then
+            CGLCHECK_DRY_RUN="--dry-run --diff"
+        fi
+        setUpDockerComposeDotEnv
+        docker-compose run cgl_all
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    cglGit)
+        # Active dry-run for cglAll needs not "-n" but specific options
+        setUpDockerComposeDotEnv
+        docker-compose run cgl_git
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    functional)
+        setUpDockerComposeDotEnv
+        case ${DBMS} in
+            mariadb)
+                docker-compose run functional_mariadb10
+                SUITE_EXIT_CODE=$?
+                ;;
+            mssql)
+                docker-compose run functional_mssql2019latest
+                SUITE_EXIT_CODE=$?
+                ;;
+            postgres)
+                docker-compose run functional_postgres10
+                SUITE_EXIT_CODE=$?
+                ;;
+            sqlite)
+                # sqlite has a tmpfs as typo3temp/var/tests/functional-sqlite-dbs/
+                # Since docker is executed as root (yay!), the path to this dir is owned by
+                # root if docker creates it. Thank you, docker. We create the path beforehand
+                # to avoid permission issues on host filesystem after execution.
+                mkdir -p "${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/"
+                docker-compose run functional_sqlite
+                SUITE_EXIT_CODE=$?
+                ;;
+            *)
+                echo "Invalid -d option argument ${DBMS}" >&2
+                echo >&2
+                echo "${HELP}" >&2
+                exit 1
+        esac
+        docker-compose down
+        ;;
+    lint)
+        setUpDockerComposeDotEnv
+        docker-compose run lint
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    phpstan)
+        setUpDockerComposeDotEnv
+        docker-compose run phpstan
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    phpstanGenerateBaseline)
+        setUpDockerComposeDotEnv
+        docker-compose run phpstan_generate_baseline
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    unit)
+        setUpDockerComposeDotEnv
+        docker-compose run unit
+        SUITE_EXIT_CODE=$?
+        docker-compose down
+        ;;
+    update)
+        # pull typo3gmbh/phpXY:latest versions of those ones that exist locally
+        docker images typo3gmbh/php*:latest --format "{{.Repository}}:latest" | xargs -I {} docker pull {}
+        # remove "dangling" typo3gmbh/phpXY images (those tagged as <none>)
+        docker images typo3gmbh/php* --filter "dangling=true" --format "{{.ID}}" | xargs -I {} docker rmi {}
+        ;;
+    *)
+        echo "Invalid -s option argument ${TEST_SUITE}" >&2
+        echo >&2
+        echo "${HELP}" >&2
+        exit 1
+esac
+
+exit $SUITE_EXIT_CODE

--- a/Build/phpunit/FunctionalTests.xml
+++ b/Build/phpunit/FunctionalTests.xml
@@ -1,0 +1,62 @@
+<!--
+    Boilerplate for a functional test suite setup.
+
+    This file is loosely maintained within TYPO3 testing-framework, extensions
+    are encouraged to not use it directly, but to copy it to an own place,
+    for instance Build/FunctionalTests.xml.
+    Note FunctionalTestsBootstrap.php should be copied along the way.
+
+    Functional tests should extend \TYPO3\TestingFramework\Core\Tests\FunctionalTestCase,
+    take a look at this class for further documentation on how to run the suite.
+
+    TYPO3 CMS functional test suite also needs phpunit bootstrap code, the
+    file is located next to this .xml as FunctionalTestsBootstrap.php
+
+-->
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    backupGlobals="true"
+    bootstrap="FunctionalTestsBootstrap.php"
+    cacheResult="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertWarningsToExceptions="true"
+    convertDeprecationsToExceptions="true"
+    convertNoticesToExceptions="true"
+    forceCoversAnnotation="false"
+    processIsolation="false"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="false"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+    failOnWarning="true"
+    failOnRisky="true"
+>
+    <testsuites>
+        <testsuite name="Functional tests">
+            <!--
+                This path either needs an adaption in extensions, or an extension's
+                test location path needs to be given to phpunit.
+            -->
+            <directory>../../Tests/Functional/</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <!--
+            @deprecated: Set this to not suppress warnings, notices and deprecations in functional tests
+                         with TYPO3 core v11 and up.
+                         Will always be done with next major version.
+                         To still suppress warnings, notices and deprecations, do NOT define the constant at all.
+            @todo Upgrade BrokenLinkRepository to incorporate core v11 changes and avoid deprecation messages, which
+                  are silenced away. Afterwards define following constant to find out which other places needs to be
+                  fixed and are silenced through error handler usage.
+            <const name="TYPO3_TESTING_FUNCTIONAL_REMOVE_ERROR_HANDLER" value="true" />
+         -->
+        <ini name="display_errors" value="1" />
+        <ini name="error_reporting" value="E_ALL" />
+        <env name="TYPO3_CONTEXT" value="Testing" />
+    </php>
+</phpunit>

--- a/Build/phpunit/FunctionalTestsBootstrap.php
+++ b/Build/phpunit/FunctionalTestsBootstrap.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Boilerplate for a functional test phpunit boostrap file.
+ *
+ * This file is loosely maintained within TYPO3 testing-framework, extensions
+ * are encouraged to not use it directly, but to copy it to an own place,
+ * usually in parallel to a FunctionalTests.xml file.
+ *
+ * This file is defined in FunctionalTests.xml and called by phpunit
+ * before instantiating the test suites.
+ */
+(static function () {
+    $testbase = new \TYPO3\TestingFramework\Core\Testbase();
+    $testbase->defineOriginalRootPath();
+    $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/tests');
+    $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/transient');
+})();

--- a/Build/phpunit/UnitTests.xml
+++ b/Build/phpunit/UnitTests.xml
@@ -1,0 +1,64 @@
+<!--
+    Boilerplate for a unit test suite setup.
+
+    This file is loosely maintained within TYPO3 testing-framework, extensions
+    are encouraged to not use it directly, but to copy it to an own place,
+    for instance Build/UnitTests.xml.
+    Note UnitTestsBootstrap.php should be copied along the way.
+
+    Functional tests should extend \TYPO3\TestingFramework\Core\Tests\FunctionalTestCase,
+    take a look at this class for further documentation on how to run the suite.
+
+    TYPO3 CMS functional test suite also needs phpunit bootstrap code, the
+    file is located next to this .xml as FunctionalTestsBootstrap.php
+
+-->
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    backupGlobals="true"
+    bootstrap="UnitTestsBootstrap.php"
+    cacheResult="false"
+    colors="true"
+    convertDeprecationsToExceptions="true"
+    convertErrorsToExceptions="true"
+    convertWarningsToExceptions="true"
+    convertNoticesToExceptions="true"
+    forceCoversAnnotation="false"
+    processIsolation="false"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    verbose="false"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+    failOnWarning="true"
+    failOnRisky="true"
+>
+    <testsuites>
+        <testsuite name="Unit tests">
+            <!--
+                This path either needs an adaption in extensions, or an extension's
+                test location path needs to be given to phpunit.
+            -->
+            <directory>../../Tests/Unit/</directory>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <include>
+            <!--
+                This path needs an adaption in extensions, when coverage statistics are wanted.
+            -->
+            <directory>../../Classes/</directory>
+        </include>
+    </coverage>
+    <php>
+        <ini name="display_errors" value="1" />
+        <!--
+            Set E_ALL after tests failing for E_ALL are fixed.
+        <ini name="error_reporting" value="E_ALL" />
+        -->
+        <ini name="error_reporting" value="E_ALL" />
+        <env name="TYPO3_CONTEXT" value="Testing" />
+    </php>
+</phpunit>

--- a/Build/phpunit/UnitTestsBootstrap.php
+++ b/Build/phpunit/UnitTestsBootstrap.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Boilerplate for a functional test phpunit boostrap file.
+ *
+ * This file is loosely maintained within TYPO3 testing-framework, extensions
+ * are encouraged to not use it directly, but to copy it to an own place,
+ * usually in parallel to a UnitTests.xml file.
+ *
+ * This file is defined in UnitTests.xml and called by phpunit
+ * before instantiating the test suites.
+ *
+ * The recommended way to execute the suite is "runTests.sh". See the
+ * according script within TYPO3 core's Build/Scripts directory and
+ * adapt to extensions needs.
+ */
+(static function () {
+    $testbase = new \TYPO3\TestingFramework\Core\Testbase();
+
+    // These if's are for core testing (package typo3/cms) only. cms-composer-installer does
+    // not create the autoload-include.php file that sets these env vars and sets composer
+    // mode to true. testing-framework can not be used without composer anyway, so it is safe
+    // to do this here. This way it does not matter if 'bin/phpunit' or 'vendor/phpunit/phpunit/phpunit'
+    // is called to run the tests since the 'relative to entry script' path calculation within
+    // SystemEnvironmentBuilder is not used. However, the binary must be called from the document
+    // root since getWebRoot() uses 'getcwd()'.
+    if (!getenv('TYPO3_PATH_ROOT')) {
+        putenv('TYPO3_PATH_ROOT=' . rtrim($testbase->getWebRoot(), '/'));
+    }
+    if (!getenv('TYPO3_PATH_WEB')) {
+        putenv('TYPO3_PATH_WEB=' . rtrim($testbase->getWebRoot(), '/'));
+    }
+
+    $testbase->defineSitePath();
+
+    $requestType = \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE | \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_CLI;
+    \TYPO3\TestingFramework\Core\SystemEnvironmentBuilder::run(0, $requestType);
+
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/ext');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/assets');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/tests');
+    $testbase->createDirectory(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3temp/var/transient');
+
+    // Retrieve an instance of class loader and inject to core bootstrap
+    $classLoader = require $testbase->getPackagesPath() . '/autoload.php';
+    \TYPO3\CMS\Core\Core\Bootstrap::initializeClassLoader($classLoader);
+
+    // Initialize default TYPO3_CONF_VARS
+    $configurationManager = new \TYPO3\CMS\Core\Configuration\ConfigurationManager();
+    $GLOBALS['TYPO3_CONF_VARS'] = $configurationManager->getDefaultConfiguration();
+
+    $cache = new \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend(
+        'core',
+        new \TYPO3\CMS\Core\Cache\Backend\NullBackend('production', [])
+    );
+
+    // Set all packages to active
+    if (interface_exists(\TYPO3\CMS\Core\Package\Cache\PackageCacheInterface::class)) {
+        $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(\TYPO3\CMS\Core\Package\UnitTestPackageManager::class, \TYPO3\CMS\Core\Core\Bootstrap::createPackageCache($cache));
+    } else {
+        // v10 compatibility layer
+        // @deprecated Will be removed when v10 compat is dropped from testing-framework
+        $packageManager = \TYPO3\CMS\Core\Core\Bootstrap::createPackageManager(\TYPO3\CMS\Core\Package\UnitTestPackageManager::class, $cache);
+    }
+
+    \TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Package\PackageManager::class, $packageManager);
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::setPackageManager($packageManager);
+
+    $testbase->dumpClassLoadingInformation();
+
+    \TYPO3\CMS\Core\Utility\GeneralUtility::purgeInstances();
+})();

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -1,0 +1,372 @@
+# copied from EXT:enetcache
+#  https://github.com/lolli42/enetcache/blob/master/Build/testing-docker/docker-compose.yml
+
+
+version: '2.3'
+services:
+  mariadb10:
+    image: mariadb:10
+    environment:
+      MYSQL_ROOT_PASSWORD: funcp
+    tmpfs:
+      - /var/lib/mysql/:rw,noexec,nosuid
+
+  mssql2019latest:
+    image: typo3/core-testing-mssql2019:latest
+    environment:
+      ACCEPT_EULA: Y
+      SA_PASSWORD: "Test1234!"
+      MSSQL_PID: Developer
+
+  postgres10:
+    image: postgres:10-alpine
+    environment:
+      POSTGRES_PASSWORD: funcp
+      POSTGRES_USER: ${HOST_USER}
+    tmpfs:
+      - /var/lib/postgresql/data:rw,noexec,nosuid
+
+  composer_coreversion_require:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_CACHE_DIR: ".Build/.cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        composer require --no-progress --no-interaction --no-install typo3/minimal:"${CORE_VERSION}";
+      "
+  composer_install:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_CACHE_DIR: ".Build/.cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        composer install --no-progress --no-interaction;
+      "
+  composer_install_max:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_CACHE_DIR: ".Build/.cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        if [ ${PHP_VERSION} == "8.0" ]; then
+          composer req --dev typo3/cms-core:"dev-main" \
+            typo3/cms-backend:"dev-main" \
+            typo3/cms-frontend:"dev-main" \
+            typo3/cms-extbase:"dev-main" \
+            typo3/cms-fluid:"dev-main" \
+            typo3/cms-recordlist:"dev-main"
+        fi
+        composer config --unset platform.php;
+        composer update --no-progress --no-interaction;
+        composer dumpautoload;
+      "
+
+  composer_install_min:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_CACHE_DIR: ".Build/.cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        if [ ${PHP_VERSION} == "8.0" ]; then
+          composer req --dev typo3/cms-core:"dev-main" \
+            typo3/cms-backend:"dev-main" \
+            typo3/cms-frontend:"dev-main" \
+            typo3/cms-extbase:"dev-main" \
+            typo3/cms-fluid:"dev-main" \
+            typo3/cms-recordlist:"dev-main"
+        fi
+        composer config platform.php ${PHP_VERSION}.0;
+        composer update --prefer-lowest --no-progress --no-interaction;
+        composer dumpautoload;
+      "
+
+  composer_validate:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    environment:
+      COMPOSER_CACHE_DIR: ".Build/.cache/composer"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        composer validate;
+      "
+
+  functional_mariadb10:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    links:
+      - mariadb10
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    environment:
+      typo3DatabaseName: func_test
+      typo3DatabaseUsername: root
+      typo3DatabasePassword: funcp
+      typo3DatabaseHost: mariadb10
+    working_dir: ${ROOT_DIR}/.Build
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        echo Waiting for database start...;
+        while ! nc -z mariadb10 3306; do
+          sleep 1;
+        done;
+        echo Database is up;
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          bin/phpunit -c ../Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        else
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
+          bin/phpunit -c ../Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        fi
+      "
+
+  functional_mssql2019latest:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    links:
+      - mssql2019latest
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    environment:
+      typo3DatabaseDriver: sqlsrv
+      typo3DatabaseName: func
+      typo3DatabasePassword: "Test1234!"
+      typo3DatabaseUsername: SA
+      typo3DatabasePort: 1433
+      typo3DatabaseCharset: utf-8
+      typo3DatabaseHost: mssql2019latest
+    working_dir: ${ROOT_DIR}/.Build
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        echo Waiting for database start...;
+        while ! nc -z mssql2019latest 1433; do
+          sleep 1;
+        done;
+        sleep 5;
+        echo Database is up;
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          bin/phpunit -c ../Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-mssql ${TEST_FILE};
+        else
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
+          bin/phpunit -c ../Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-mssql ${TEST_FILE};
+        fi
+      "
+
+  functional_postgres10:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    links:
+      - postgres10
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    environment:
+      typo3DatabaseDriver: pdo_pgsql
+      typo3DatabaseName: bamboo
+      typo3DatabaseUsername: ${HOST_USER}
+      typo3DatabaseHost: postgres10
+      typo3DatabasePassword: funcp
+    working_dir: ${ROOT_DIR}/.Build
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        echo Waiting for database start...;
+        while ! nc -z postgres10 5432; do
+          sleep 1;
+        done;
+        echo Database is up;
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          bin/phpunit -c ../Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-postgres ${TEST_FILE};
+        else
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
+          bin/phpunit -c ../Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-postgres ${TEST_FILE};
+        fi
+      "
+
+  functional_sqlite:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    tmpfs:
+      - ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,uid=${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    environment:
+      typo3DatabaseDriver: pdo_sqlite
+    working_dir: ${ROOT_DIR}/.Build
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          bin/phpunit -c ../Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-sqlite ${TEST_FILE};
+        else
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
+          bin/phpunit -c ../Build/phpunit/FunctionalTests.xml ${EXTRA_TEST_OPTIONS} --exclude-group not-sqlite ${TEST_FILE};
+        fi
+      "
+
+  cgl_git:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        Build/Scripts/cglFixMyCommit.sh ${CGLCHECK_DRY_RUN};
+      "
+
+  cgl_all:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -dxdebug.mode=off .Build/bin/php-cs-fixer fix -v ${CGLCHECK_DRY_RUN} --path-mode intersection \
+          --config=Build/.php-cs-fixer.php .
+      "
+  lint:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+      - /etc/passwd:/etc/passwd:ro
+      - /etc/group:/etc/group:ro
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP';
+        find . -name \\*.php ! -path "./.Build/\\*" -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null
+      "
+
+  phpstan:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        mkdir -p .Build/.cache
+        php -v | grep '^PHP';
+        php -dxdebug.mode=off .Build/bin/phpstan analyse --no-progress --no-interaction --memory-limit 4G -c Build/phpstan/phpstan.neon ${EXTRA_TEST_OPTIONS}
+      "
+
+  phpstan_generate_baseline:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        mkdir -p .Build/.cache
+        php -v | grep '^PHP';
+        php -dxdebug.mode=off .Build/bin/phpstan analyse --no-progress --no-interaction --memory-limit 4G -c Build/phpstan/phpstan.neon --generate-baseline=Build/phpstan/phpstan-baseline.neon --allow-empty-baseline ${EXTRA_TEST_OPTIONS}
+      "
+
+  unit:
+    image: typo3/core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: ${HOST_UID}
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}/.Build
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        php -v | grep '^PHP'
+        if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+          XDEBUG_MODE=\"off\" \
+          bin/phpunit -c ../Build/phpunit/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        else
+          XDEBUG_MODE=\"debug,develop\" \
+          XDEBUG_TRIGGER=\"foo\" \
+          XDEBUG_CONFIG=\"client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal\" \
+          bin/phpunit -c ../Build/phpunit/UnitTests.xml ${EXTRA_TEST_OPTIONS} ${TEST_FILE};
+        fi
+      "

--- a/Classes/DataHandling/SoftReference/RteImageSoftReferenceParser.php
+++ b/Classes/DataHandling/SoftReference/RteImageSoftReferenceParser.php
@@ -99,11 +99,7 @@ class RteImageSoftReferenceParser extends AbstractSoftReferenceParser
             return [];
         }
 
-        // Assemble result array
-        return [
-            'content'  => implode('', $this->splitContentTags),
-            'elements' => $images,
-        ];
+        return $images;
     }
 
     /**

--- a/Tests/Functional/DataHandling/Fixtures/ReferenceIndex/UpdateReferenceIndexImport.csv
+++ b/Tests/Functional/DataHandling/Fixtures/ReferenceIndex/UpdateReferenceIndexImport.csv
@@ -1,0 +1,3 @@
+"tt_content",,,,,,
+,"uid","pid","sys_language_uid","deleted","hidden","bodytext"
+,1,1,0,0,0,<img data-htmlarea-file-table="sys_file" data-htmlarea-file-uid="1" data-title-override="true" src="/fileadmin/1.jpg" />

--- a/Tests/Functional/DataHandling/Fixtures/ReferenceIndex/UpdateReferenceIndexResult.csv
+++ b/Tests/Functional/DataHandling/Fixtures/ReferenceIndex/UpdateReferenceIndexResult.csv
@@ -1,0 +1,3 @@
+"sys_refindex",,,,,
+,"tablename","recuid","field","softref_key","ref_table","ref_uid"
+,"tt_content","1","bodytext","rtehtmlarea_images","sys_file","1"

--- a/Tests/Functional/DataHandling/RteImageSoftReferenceParserTest.php
+++ b/Tests/Functional/DataHandling/RteImageSoftReferenceParserTest.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+namespace Netresearch\RteCKEditorImage\Tests\Functional\DataHandling;
+
+use TYPO3\CMS\Core\Database\ReferenceIndex;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+class RteImageSoftReferenceParserTest extends FunctionalTestCase
+{
+    protected $testExtensionsToLoad = [
+        'typo3conf/ext/rte_ckeditor_image',
+    ];
+
+    /**
+     * @test
+     */
+    public function updateReferenceIndexAddsIndexEntryForImage(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ReferenceIndex/UpdateReferenceIndexImport.csv');
+        $result = (new ReferenceIndex())->updateIndex(false);
+        //self::assertSame( 'Record tt_content:1 had 1 added indexes and 0 deleted indexes', $result['errors'][0]);
+        $this->assertCSVDataSet(__DIR__ . '/Fixtures/ReferenceIndex/UpdateReferenceIndexResult.csv');
+    }
+}

--- a/Tests/Functional/DataHandling/RteImageSoftReferenceParserTest.php
+++ b/Tests/Functional/DataHandling/RteImageSoftReferenceParserTest.php
@@ -17,8 +17,7 @@ class RteImageSoftReferenceParserTest extends FunctionalTestCase
     public function updateReferenceIndexAddsIndexEntryForImage(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/ReferenceIndex/UpdateReferenceIndexImport.csv');
-        $result = (new ReferenceIndex())->updateIndex(false);
-        //self::assertSame( 'Record tt_content:1 had 1 added indexes and 0 deleted indexes', $result['errors'][0]);
+        (new ReferenceIndex())->updateIndex(false);
         $this->assertCSVDataSet(__DIR__ . '/Fixtures/ReferenceIndex/UpdateReferenceIndexResult.csv');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,12 @@
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-strict-rules": "^1.4",
         "phpstan/phpstan-phpunit": "^1.3",
-        "squizlabs/php_codesniffer": "^3.7"
+        "squizlabs/php_codesniffer": "^3.7",
+        "typo3/testing-framework": "^6.16.7"
     },
     "config": {
+        "vendor-dir": ".Build/vendor",
+        "bin-dir": ".Build/bin",
         "allow-plugins": {
             "typo3/cms-composer-installers": true,
             "typo3/class-alias-loader": true
@@ -35,7 +38,8 @@
             "dev-master": "11.0.x-dev"
         },
         "typo3/cms": {
-            "extension-key": "rte_ckeditor_image"
+            "extension-key": "rte_ckeditor_image",
+            "web-dir": ".Build/Web"
         }
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,6 @@
 
 includes:
-    - vendor/phpstan/phpstan-strict-rules/rules.neon
+    - .Build/vendor/phpstan/phpstan-strict-rules/rules.neon
 
 parameters:
     # You can currently choose from 10 levels (0 is the loosest and 9 is the strictest).
@@ -13,8 +13,8 @@ parameters:
         - ext_localconf.php
 
     excludePaths:
-        - vendor/*
         - ext_emconf.php
+        - vendor
 
     checkMissingIterableValueType: false
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,7 +14,6 @@ parameters:
 
     excludePaths:
         - ext_emconf.php
-        - vendor
 
     checkMissingIterableValueType: false
 


### PR DESCRIPTION
**Note** (not in commit): main goal here is to add a fix and one functional test to check. I have used the procedure with runTests.sh as documented in [TYPO3 Explained "Extension Testing"](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Testing/ExtensionTesting.html).


If a different procedure should be used to execute the functional tests, I would be happy to make the necessary changes to this PR (easiest would be to point to an example extension which can be used as blueprint).


---------------------

Fix RteImageSoftReferenceParser
    
The reference index entry was previously not created, because
a SoftReferenceParserResult was created with the wrong format.
    
Resolves: #45

--------------------


Add functional tests
    
- add .gitattributes
- set web-dir to .Build/Web in composer.json
- add functional tests for issue #45 (reference index not created)
- add testing.yml which runs the functional tests
- add Build directory with runTests.sh (similar to already used in
  EXT:styleguide and TYPO3 core)
    
Related: #45


