### PR TITLE
Add .attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+/.crowdin.yaml export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.github export-ignore
+/.gitignore export-ignore
+/.stylelintrc  export-ignore
+/crowdin.yml export-ignore
+/Build export-ignore
+/Gruntfile.js export-ignore
+/package.json export-ignore
+/phpstan-baseline.neon export-ignore
+/phpstan.neon  export-ignore
+/Resources/Private/Sass/ export-ignore
+/Resources/Private/TypeScript/ export-ignore
+/Tests/ export-ignore


### PR DESCRIPTION
When packaging the extension or installing via Composer, development files such as .editorconfig or Tests should be excluded.

The .gitattributes file added contains some files not in this project - this makes it easier to maintain: even if files are added later, it is not always necessary to change .gitattributes

Resolves: #230
