### PR TITLE
[BUGFIX] use URL of newly processed file

### DIFF
--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -88,8 +88,9 @@ class ImageRenderingController extends AbstractPlugin
                         $processedFile = $this->getMagicImageService()
                             ->createMagicImage($systemImage, $imageConfiguration);
 
+                        $imageSource = $processedFile->getPublicUrl();
                         $additionalAttributes = [
-                            'src'    => $processedFile->getPublicUrl(),
+                            'src'    => $imageSource,
                             'title'  => $this->getAttributeValue('title', $imageAttributes, $systemImage),
                             'alt'    => $this->getAttributeValue('alt', $imageAttributes, $systemImage),
                             'width'  => $processedFile->getProperty('width') ?? $imageConfiguration['width'],


### PR DESCRIPTION
We have RTE fields which contain images with a src like "fileadmin/processed/9/f/csm_image_b87be79882.png". If the image got updated meanwhile and for example the modification date changed, the newly processed file will have a new path as the checksum changes. But this new path is not used if the src attribute doesn't start with a slash. This PR will make use of the newly processed file.

fixes #232

