### PR TITLE
bugfix: incorrect parse indexes leading to dynamic image URL not to b…

### DIFF
--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -120,7 +120,7 @@ class RteImagesDbHook
 
             foreach ($imgSplit as $key => $v) {
                 // Image found
-                if (($key % 2) === 1) {
+                if (($key % 2) !== 0) {
                     // Get the attributes of the img tag
                     [$attribArray] = $rteHtmlParser->get_tag_attributes($v, true);
                     $imageSource = trim($attribArray['src'] ?? '');


### PR DESCRIPTION
Issued by https://github.com/netresearch/t3x-rte_ckeditor_image/issues/187

Incorrect processing of indexes caused images not  to be processed in RteImagesDbHook.php

Content split of Images via rteHtmlParser->splitTags returned an array of content with odd indexes for images.
Matching even indexes in transform_db function caused images not to be processed.