### PR TITLE
[BUGFIX] Fix onclick event for select image modal

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -422,18 +422,32 @@
 
                         };
 
-                        $.extend(AddImage.elements, _getElementsList($(this)));
-
-
-                        $(this).contents().find('[data-close]').on('click', function (e) {
-                            e.stopImmediatePropagation();
-                            var selectedItems = [];
-                            selectedItems.push({
-                                uid: AddImage.elements['file_' + $(this).data('file-uid')].uid,
-                                table: AddImage.elements['file_' + $(this).data('file-uid')].table
+                        function handleImageItemsOnClose(openmodal) {
+                            $.extend(AddImage.elements, _getElementsList(openmodal));
+                            openmodal.contents().find('[data-close]').on('click', function (e) {
+                                e.stopImmediatePropagation();
+                                var selectedItems = [];
+                                selectedItems.push({
+                                    uid: AddImage.elements['file_' + $(this).data('file-uid')].uid,
+                                    table: AddImage.elements['file_' + $(this).data('file-uid')].table
+                                });
+                                AddImage.addedImage(selectedItems);
                             });
-                            AddImage.addedImage(selectedItems);
+                        }
+                        const modal = $(this);
+
+                        handleImageItemsOnClose(modal);
+
+                        const fileadminTree = modal.contents().find('.element-browser-main-content');
+                        const config = {attributes: false, childList: true, subtree: true};
+                        const observer = new MutationObserver((mutationList) => {
+                            for (const mutation of mutationList) {
+                                if (mutation.type === "childList") {
+                                    handleImageItemsOnClose(modal);
+                                }
+                            }
                         });
+                        observer.observe(fileadminTree.get(0), config);
                         $(this).contents().find('button[data-multi-record-selection-action=import]').on('click',  function (e) {
                             e.stopImmediatePropagation();
 


### PR DESCRIPTION
The problem is that when you open the plugin, aka click on the image module in the RTE, the currently viewed images are provided with an event listner that inserts the image when clicked. However, if you change to another folder in the Fileadmin, the other images have to be reloaded and thus replace the images in the Dom - these then have no "onClick" method.

The result is that images are no longer inserted and the popup with the image properties does not appear. If you open the image plugin again, the just viewed images get the onClick method and work as expected.

Therefore I wrote an observer for the filelist and on change it readds the images to
AddImage.elements and adds the event listner.

Related: #238
