### PR TITLE
[BUGFIX] Loading RTE throws PHP Runtime Deprecation Notice

### DIFF
--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -59,6 +59,8 @@ class RteImagesDbHook
 {
     use LoggerAwareTrait;
 
+    public RteHtmlParser $pObj;
+
     /**
      * @var bool
      */

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -60,6 +60,7 @@ class RteImagesDbHook
     use LoggerAwareTrait;
 
     public RteHtmlParser $pObj;
+    public string transformationKey;
 
     /**
      * @var bool


### PR DESCRIPTION
Dynamic properties are deprecated as of PHP 8.2.0. Either properties have to be declared or a class has to be marked with the `#[\AllowDynamicProperties]` attribute.

Closes #235