### PR TITLE
chore: Fix current build/tests in pipeline/actions.

### DIFF
--- a/Classes/Backend/Preview/RteImagePreviewRenderer.php
+++ b/Classes/Backend/Preview/RteImagePreviewRenderer.php
@@ -143,10 +143,7 @@ class RteImagePreviewRenderer extends TextPreviewRenderer
             }
 
             // If node has children, walk its child elements
-            if (
-                ($node->childNodes !== null)
-                && ($node->childNodes->count() > 0)
-            ) {
+            if ($node->childNodes->count() > 0) {
                 foreach ($node->childNodes as $child) {
                     $this->walk($child, $maxLength);
                 }

--- a/Classes/Controller/ImageLinkRenderingController.php
+++ b/Classes/Controller/ImageLinkRenderingController.php
@@ -90,7 +90,7 @@ class ImageLinkRenderingController extends AbstractPlugin
             //
             // But we leave this as fallback for older render versions.
             if ((count($imageAttributes) > 0) && isset($imageAttributes['data-htmlarea-file-uid'])) {
-                $fileUid = (int) ($imageAttributes['data-htmlarea-file-uid'] ?? 0);
+                $fileUid = (int) ($imageAttributes['data-htmlarea-file-uid']);
 
                 if ($fileUid > 0) {
                     try {

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -136,7 +136,7 @@ class RteImagesDbHook
                     $imageSource = trim($attribArray['src'] ?? '');
 
                     if ($attribArray['data-htmlarea-file-uid'] ?? false) {
-                        if ($imageSource === '' || !is_file($imageSource) ) {
+                        if ($imageSource === '' || !is_file($imageSource)) {
                             $imageSource = $this->getProcessedFile($attribArray);
                         }
                     }

--- a/Tests/Functional/DataHandling/RteImageSoftReferenceParserTest.php
+++ b/Tests/Functional/DataHandling/RteImageSoftReferenceParserTest.php
@@ -7,7 +7,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 class RteImageSoftReferenceParserTest extends FunctionalTestCase
 {
-    protected $testExtensionsToLoad = [
+    protected array $testExtensionsToLoad = [
         'typo3conf/ext/rte_ckeditor_image',
     ];
 


### PR DESCRIPTION
Fix current build/test pipeline/actions.

- style: phpstan error "Offset 'data-htmlarea-file…' on non-empty-array<string, string> on left side of ?? always exists and is not nullable." by removing superfluous null check.
- tests: fix PHP Fatal error: Type of testExtensionsToLoad must be array
- style: fix superfluous space before closing parenthesis