### PR TITLE
[BUGFIX] Fixes #254: handle deleted files

### DIFF
--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -182,8 +182,12 @@ class RteImagesDbHook
 
         $siteUrl  = GeneralUtility::getIndpEnv('TYPO3_SITE_URL');
 
-        $originalImageFile = $resourceFactory
-            ->getFileObject((int)$attribArray['data-htmlarea-file-uid']);
+        try {
+            $originalImageFile = $resourceFactory
+                ->getFileObject((int)$attribArray['data-htmlarea-file-uid']);
+        } catch (\Exception $e) {
+            return '';
+        }
 
         if ($originalImageFile instanceof File) {
             // Magic image case: get a processed file with the requested configuration


### PR DESCRIPTION
This change simply catches the exception TYPO3 may throw when trying to retrieve a already deleted file.

fixes #254
