### PR TITLE
Revert the change "fix package name for cms_rte_ckeditor in ext_emconf.php"

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
         'depends' => [
             'php' => '8.1.0-8.9.99',
             'typo3' => '12.4.0-12.4.99',
-            'cms_rte_ckeditor' => '12.4.0-12.4.99',
+            'rte_ckeditor' => '12.4.0-12.4.99',
         ],
         'conflicts' => [],
         'suggests' => [


### PR DESCRIPTION
The extension name is "rte_ckeditor" not "cms_rte_ckeditor" => https://github.com/TYPO3-CMS/rte_ckeditor/blob/main/composer.json

Fixes commit: #271 5cff197