### PR TITLE
Fix creation of processed files for frontend pages

### DIFF
--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -89,35 +89,33 @@ class ImageRenderingController extends AbstractPlugin
                     ];
                     $processedFile = $checkProcessed->createProcessedFile($systemImage, $imageConfiguration);
 
-                    if ($processedFile instanceof ProcessedFile) {
-                        $imageSource = $processedFile->getPublicUrl();
+                    $imageSource = $processedFile->getPublicUrl();
 
-                        if (null === $imageSource) {
-                            throw new FileDoesNotExistException();
-                        }
-
-                        $additionalAttributes = [
-                            'src'    => $imageSource,
-                            'title'  => $this->getAttributeValue('title', $imageAttributes, $systemImage),
-                            'alt'    => $this->getAttributeValue('alt', $imageAttributes, $systemImage),
-                            'width'  => $processedFile->getProperty('width') ?? $imageConfiguration['width'],
-                            'height' => $processedFile->getProperty('height') ?? $imageConfiguration['height'],
-                        ];
-
-                        $lazyLoading = $this->getLazyLoadingConfiguration();
-
-                        if ($lazyLoading !== null) {
-                            $additionalAttributes['loading'] = $lazyLoading;
-                        }
-
-                        // Remove internal attributes
-                        unset(
-                            $imageAttributes['data-title-override'],
-                            $imageAttributes['data-alt-override']
-                        );
-
-                        $imageAttributes = array_merge($imageAttributes, $additionalAttributes);
+                    if (null === $imageSource) {
+                        throw new FileDoesNotExistException();
                     }
+
+                    $additionalAttributes = [
+                        'src'    => $imageSource,
+                        'title'  => $this->getAttributeValue('title', $imageAttributes, $systemImage),
+                        'alt'    => $this->getAttributeValue('alt', $imageAttributes, $systemImage),
+                        'width'  => $processedFile->getProperty('width') ?? $imageConfiguration['width'],
+                        'height' => $processedFile->getProperty('height') ?? $imageConfiguration['height'],
+                    ];
+
+                    $lazyLoading = $this->getLazyLoadingConfiguration();
+
+                    if ($lazyLoading !== null) {
+                        $additionalAttributes['loading'] = $lazyLoading;
+                    }
+
+                    // Remove internal attributes
+                    unset(
+                        $imageAttributes['data-title-override'],
+                        $imageAttributes['data-alt-override']
+                    );
+
+                    $imageAttributes = array_merge($imageAttributes, $additionalAttributes);
                 } catch (FileDoesNotExistException $fileDoesNotExistException) {
                     // Log in fact the file could not be retrieved
                     $this->getLogger()->log(
@@ -161,7 +159,7 @@ class ImageRenderingController extends AbstractPlugin
         // Popup rendering (support new `zoom` and legacy `clickenlarge` attributes)
         if (
             (isset($imageAttributes['data-htmlarea-zoom'])
-            || isset($imageAttributes['data-htmlarea-clickenlarge']))
+                || isset($imageAttributes['data-htmlarea-clickenlarge']))
             && isset($systemImage)
         ) {
             $config = $GLOBALS['TSFE']->tmpl->setup['lib.']['contentElement.']['settings.']['media.']['popup.'] ?? [];

--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -91,7 +91,7 @@ class ImageRenderingController extends AbstractPlugin
                         $processedFile = $checkProcessed->createProcessedFile($systemImage, $imageConfiguration);
                     }
 
-                    if ($processedFile !== false && $processedFile instanceof ProcessedFile) {
+                    if ($processedFile !== false) {
                         $imageSource = $processedFile->getPublicUrl();
 
                         if (null === $imageSource) {

--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Netresearch\RteCKEditorImage\Controller;
 
+use Netresearch\RteCKEditorImage\Utils\ProcessedFilesHandler;
 use Psr\Log\LogLevel as PsrLogLevel;
 use TYPO3\CMS\Core\Log\Logger;
 use TYPO3\CMS\Core\Log\LogManager;
@@ -82,8 +83,8 @@ class ImageRenderingController extends AbstractPlugin
                     // check if there is a processed variant, if not, create one
                     $processedFile = null;
                     if ($systemImage instanceof File) {
-                        /** @var \Netresearch\RteCKEditorImage\Utils\ProcessedFilesHandler $checkProcessed */
-                        $checkProcessed = GeneralUtility::makeInstance(\Netresearch\RteCKEditorImage\Utils\ProcessedFilesHandler::class);
+                        /** @var ProcessedFilesHandler $checkProcessed */
+                        $checkProcessed = GeneralUtility::makeInstance(ProcessedFilesHandler::class);
                         $imageConfiguration = [
                             'width'  => (int) ($imageAttributes['width']  ?? $systemImage->getProperty('width') ?? 0),
                             'height' => (int) ($imageAttributes['height'] ?? $systemImage->getProperty('height') ?? 0),
@@ -91,7 +92,7 @@ class ImageRenderingController extends AbstractPlugin
                         $processedFile = $checkProcessed->createProcessedFile($systemImage, $imageConfiguration);
                     }
 
-                    if ($processedFile !== false) {
+                    if ($processedFile instanceof ProcessedFile) {
                         $imageSource = $processedFile->getPublicUrl();
 
                         if (null === $imageSource) {

--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -78,7 +78,19 @@ class ImageRenderingController extends AbstractPlugin
                     $resourceFactory = GeneralUtility::makeInstance(ResourceFactory::class);
                     $systemImage     = $resourceFactory->getFileObject($fileUid);
 
-                    if ($imageSource !== $systemImage->getPublicUrl()) {
+                    // check if there is a processed variant
+                    $hasProcessedVariant = false;
+                    if ($systemImage instanceof File) {
+                        /** @var \Netresearch\RteCKEditorImage\Utils\CheckProcessed $checkProcessed */
+                        $checkProcessed = GeneralUtility::makeInstance(\Netresearch\RteCKEditorImage\Utils\CheckProcessed::class);
+                        $imageConfiguration = [
+                            'width'  => (int) ($imageAttributes['width']  ?? $systemImage->getProperty('width') ?? 0),
+                            'height' => (int) ($imageAttributes['height'] ?? $systemImage->getProperty('height') ?? 0),
+                        ];
+                        $hasProcessedVariant = $checkProcessed->hasProcessedVariant($systemImage, $imageConfiguration);
+                    }
+
+                    if ($hasProcessedVariant) { //$imageSource !== $systemImage->getPublicUrl()) {
                         // Source file is a processed image
                         $imageConfiguration = [
                             'width'  => (int) ($imageAttributes['width']  ?? $systemImage->getProperty('width') ?? 0),

--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -81,16 +81,13 @@ class ImageRenderingController extends AbstractPlugin
                     $systemImage     = $resourceFactory->getFileObject($fileUid);
 
                     // check if there is a processed variant, if not, create one
-                    $processedFile = null;
-                    if ($systemImage instanceof File) {
-                        /** @var ProcessedFilesHandler $checkProcessed */
-                        $checkProcessed = GeneralUtility::makeInstance(ProcessedFilesHandler::class);
-                        $imageConfiguration = [
-                            'width'  => (int) ($imageAttributes['width']  ?? $systemImage->getProperty('width') ?? 0),
-                            'height' => (int) ($imageAttributes['height'] ?? $systemImage->getProperty('height') ?? 0),
-                        ];
-                        $processedFile = $checkProcessed->createProcessedFile($systemImage, $imageConfiguration);
-                    }
+                    /** @var ProcessedFilesHandler $checkProcessed */
+                    $checkProcessed = GeneralUtility::makeInstance(ProcessedFilesHandler::class);
+                    $imageConfiguration = [
+                        'width'  => (int) ($imageAttributes['width']  ?? $systemImage->getProperty('width') ?? 0),
+                        'height' => (int) ($imageAttributes['height'] ?? $systemImage->getProperty('height') ?? 0),
+                    ];
+                    $processedFile = $checkProcessed->createProcessedFile($systemImage, $imageConfiguration);
 
                     if ($processedFile instanceof ProcessedFile) {
                         $imageSource = $processedFile->getPublicUrl();

--- a/Classes/Controller/ImageRenderingController.php
+++ b/Classes/Controller/ImageRenderingController.php
@@ -81,13 +81,13 @@ class ImageRenderingController extends AbstractPlugin
                     $systemImage     = $resourceFactory->getFileObject($fileUid);
 
                     // check if there is a processed variant, if not, create one
-                    /** @var ProcessedFilesHandler $checkProcessed */
-                    $checkProcessed = GeneralUtility::makeInstance(ProcessedFilesHandler::class);
+                    /** @var ProcessedFilesHandler $processedHandler */
+                    $processedHandler = GeneralUtility::makeInstance(ProcessedFilesHandler::class);
                     $imageConfiguration = [
                         'width'  => (int) ($imageAttributes['width']  ?? $systemImage->getProperty('width') ?? 0),
                         'height' => (int) ($imageAttributes['height'] ?? $systemImage->getProperty('height') ?? 0),
                     ];
-                    $processedFile = $checkProcessed->createProcessedFile($systemImage, $imageConfiguration);
+                    $processedFile = $processedHandler->createProcessedFile($systemImage, $imageConfiguration);
 
                     $imageSource = $processedFile->getPublicUrl();
 

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -286,7 +286,7 @@ class RteImagesDbHook
         $magicImageService = GeneralUtility::makeInstance(MagicImageService::class);
 
         $pageTsConfig = BackendUtility::getPagesTSconfig(0);
-        $magicImageService->setMagicImageMaximumDimensions($pageTsConfig['TCEFORM.']['RTE.']['default.'] ?? []);
+        $magicImageService->setMagicImageMaximumDimensions($pageTsConfig['RTE.']['default.'] ?? []);
 
         foreach ($imgSplit as $key => $v) {
             // Odd numbers contains the <img> tags

--- a/Classes/Utils/CheckProcessed.php
+++ b/Classes/Utils/CheckProcessed.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Netresearch\RteCKEditorImage\Utils;
+
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Service\ImageService;
+
+class CheckProcessed
+{
+    /**
+     * Check if a file has a processed variant
+     *
+     *   $processingConfiguration = [
+     *     'width' => '200c',
+     *     'height' => '200c',
+     *   ];
+     *
+     * @param File $file The file object
+     * @param array $imageConfiguration The image configuration
+     * @return bool True if there is a processed variant, otherwise false
+     */
+    function hasProcessedVariant(File $file, array $imageConfiguration): bool
+    {
+        /** @var ImageService $imageService */
+        $imageService = GeneralUtility::makeInstance(ImageService::class);
+
+        // Process the file with the given configuration
+        try {
+            $processedImage = $imageService->applyProcessingInstructions($file, $imageConfiguration);
+
+            // Check if the processed file exists
+            return $processedImage !== null && $processedImage->getOriginalFile()->exists();
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+}

--- a/Classes/Utils/ProcessedFilesHandler.php
+++ b/Classes/Utils/ProcessedFilesHandler.php
@@ -12,7 +12,7 @@ class ProcessedFilesHandler
 {
     /**
      * Create a processed variant of a file based on the given configuration.
-     * Returns the processedFile or false if the file could not be created
+     * Returns the ProcessedFile or throws an exception if creation failed.
      *
      * Example for the image configuration:
      *   $imageConfiguration = [

--- a/Classes/Utils/ProcessedFilesHandler.php
+++ b/Classes/Utils/ProcessedFilesHandler.php
@@ -34,7 +34,7 @@ class ProcessedFilesHandler
             $processedImage = $imageService->applyProcessingInstructions($file, $imageConfiguration);
 
             // Check if the processed file exists
-            if ($processedImage instanceof ProcessedFile && $processedImage->getOriginalFile()->exists()) {
+            if ($processedImage->getOriginalFile()->exists()) {
                 return $processedImage;
             }
 

--- a/Classes/Utils/ProcessedFilesHandler.php
+++ b/Classes/Utils/ProcessedFilesHandler.php
@@ -2,25 +2,29 @@
 
 namespace Netresearch\RteCKEditorImage\Utils;
 
+use Symfony\Component\Process\Process;
 use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ProcessedFile;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Service\ImageService;
 
-class CheckProcessed
+class ProcessedFilesHandler
 {
     /**
-     * Check if a file has a processed variant
+     * Create a processed variant of a file based on the given configuration.
+     * Returns the processedFile or false if the file could not be created
      *
-     *   $processingConfiguration = [
+     * Example for the image configuration:
+     *   $imageConfiguration = [
      *     'width' => '200c',
      *     'height' => '200c',
      *   ];
      *
      * @param File $file The file object
      * @param array $imageConfiguration The image configuration
-     * @return bool True if there is a processed variant, otherwise false
+     * @return ProcessedFile|bool
      */
-    function hasProcessedVariant(File $file, array $imageConfiguration): bool
+    function createProcessedFile(File $file, array $imageConfiguration): ProcessedFile|bool
     {
         /** @var ImageService $imageService */
         $imageService = GeneralUtility::makeInstance(ImageService::class);
@@ -30,7 +34,11 @@ class CheckProcessed
             $processedImage = $imageService->applyProcessingInstructions($file, $imageConfiguration);
 
             // Check if the processed file exists
-            return $processedImage !== null && $processedImage->getOriginalFile()->exists();
+            if ($processedImage instanceof ProcessedFile && $processedImage->getOriginalFile()->exists()) {
+                return $processedImage;
+            }
+
+            return false;
         } catch (\Exception $e) {
             return false;
         }

--- a/Classes/Utils/ProcessedFilesHandler.php
+++ b/Classes/Utils/ProcessedFilesHandler.php
@@ -22,25 +22,18 @@ class ProcessedFilesHandler
      *
      * @param File $file The file object
      * @param array $imageConfiguration The image configuration
-     * @return ProcessedFile|bool
+     * @return ProcessedFile
      */
-    public function createProcessedFile(File $file, array $imageConfiguration): ProcessedFile|bool
+    public function createProcessedFile(File $file, array $imageConfiguration): ProcessedFile
     {
         /** @var ImageService $imageService */
         $imageService = GeneralUtility::makeInstance(ImageService::class);
 
         // Process the file with the given configuration
         try {
-            $processedImage = $imageService->applyProcessingInstructions($file, $imageConfiguration);
-
-            // Check if the processed file exists
-            if ($processedImage->getOriginalFile()->exists()) {
-                return $processedImage;
-            }
-
-            return false;
+            return $imageService->applyProcessingInstructions($file, $imageConfiguration);
         } catch (\Exception $e) {
-            return false;
+            throw new \Exception('Could not create processed file', 1716565499);
         }
     }
 }

--- a/Classes/Utils/ProcessedFilesHandler.php
+++ b/Classes/Utils/ProcessedFilesHandler.php
@@ -24,7 +24,7 @@ class ProcessedFilesHandler
      * @param array $imageConfiguration The image configuration
      * @return ProcessedFile|bool
      */
-    function createProcessedFile(File $file, array $imageConfiguration): ProcessedFile|bool
+    public function createProcessedFile(File $file, array $imageConfiguration): ProcessedFile|bool
     {
         /** @var ImageService $imageService */
         $imageService = GeneralUtility::makeInstance(ImageService::class);


### PR DESCRIPTION
Fixes #284 and #286 

The current version of rte_ckeditor_image (tested up to 12.0.2) does not create processed files inside `fileadmin/_processed_` anymore (frontend and backend).

The reason is a comparison inside ImageRenderingcontroller (`if ($imageSource !== $systemImage->getPublicUrl())`).

But imageService and $systemImage->getPublicUrl() always point to the original file and never to the processed file and are therefore always the same.

This PR adds code that always tries to create a processed file and then proceeds inside the if block from above. This results in the creation of images inside `fileadmin/_processed_` as expected.

This was tested with normal TYPO3 text and text/image plugins and also with custom extensions that use the CKeditor for text and image input. In the frontend templates one has to use `<f:format.html>{ckeditorcontent}</f:format.html>` to use processing.