### PR TITLE
[BUGFIX] width and height get ignored and set to 1920px

### DIFF
--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -306,18 +306,6 @@ class RteImagesDbHook
                     $absoluteUrl = $siteUrl . $absoluteUrl;
                 }
 
-                // Get image dimensions set in the image tag, if any
-                $imageWidth  = $this->getImageWidthFromAttributes($attribArray);
-                $imageHeight = $this->getImageHeightFromAttributes($attribArray);
-
-                if ($imageWidth > 0) {
-                    $attribArray['width'] = $imageWidth;
-                }
-
-                if ($imageHeight > 0) {
-                    $attribArray['height'] = $imageHeight;
-                }
-
                 $originalImageFile = null;
                 if (isset($attribArray['data-htmlarea-file-uid'])) {
                     // An original image file uid is available
@@ -336,6 +324,12 @@ class RteImagesDbHook
                         }
                     }
                 }
+
+                $imageWidth = $this->getImageWidthFromAttributes($attribArray) ?: $originalImageFile->getProperty('width');
+                $imageHeight = $this->getImageHeightFromAttributes($attribArray) ?: $originalImageFile->getProperty('height');
+
+                $attribArray['width'] = $imageWidth;
+                $attribArray['height'] = $imageHeight;
 
                 $isBackend = false;
 

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -330,10 +330,10 @@ class RteImagesDbHook
                 }
                 // If empty image dimensions but file exists, take file dimensions
                 if ($originalImageFile instanceof File) {
-                    if (!$imageWidth) {
+                    if ($imageWidth === 0) {
                         $imageWidth = $originalImageFile->getProperty('width');
                     }
-                    if (!$imageHeight) {
+                    if (!$imageHeight === 0) {
                         $imageHeight = $originalImageFile->getProperty('height');
                     }
                 }

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -333,7 +333,7 @@ class RteImagesDbHook
                     if ($imageWidth === 0) {
                         $imageWidth = $originalImageFile->getProperty('width');
                     }
-                    if (!$imageHeight === 0) {
+                    if ($imageHeight === 0) {
                         $imageHeight = $originalImageFile->getProperty('height');
                     }
                 }

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -306,6 +306,10 @@ class RteImagesDbHook
                     $absoluteUrl = $siteUrl . $absoluteUrl;
                 }
 
+                // Get image dimensions set in the image tag, if any
+                $imageWidth  = $this->getImageWidthFromAttributes($attribArray);
+                $imageHeight = $this->getImageHeightFromAttributes($attribArray);
+
                 $originalImageFile = null;
                 if (isset($attribArray['data-htmlarea-file-uid'])) {
                     // An original image file uid is available
@@ -324,12 +328,23 @@ class RteImagesDbHook
                         }
                     }
                 }
+                // If empty image dimensions but file exists, take file dimensions
+                if ($originalImageFile instanceof File) {
+                    if (!$imageWidth) {
+                        $imageWidth = $originalImageFile->getProperty('width');
+                    }
+                    if (!$imageHeight) {
+                        $imageHeight = $originalImageFile->getProperty('height');
+                    }
+                }
 
-                $imageWidth = $this->getImageWidthFromAttributes($attribArray) ?: $originalImageFile->getProperty('width');
-                $imageHeight = $this->getImageHeightFromAttributes($attribArray) ?: $originalImageFile->getProperty('height');
+                if ($imageWidth > 0) {
+                    $attribArray['width'] = $imageWidth;
+                }
 
-                $attribArray['width'] = $imageWidth;
-                $attribArray['height'] = $imageHeight;
+                if ($imageHeight > 0) {
+                    $attribArray['height'] = $imageHeight;
+                }
 
                 $isBackend = false;
 


### PR DESCRIPTION
See #319 - it could be the case that the hook only receives an img tag without width and height. Due to the check being in the current order, this would prevent the original image dimensions to be taken into account resulting in using `maxWidth` for the magic image.

Changing the order here, so if nothing is defined, the original image dimensions are used.

**Closing issues**

closes #319