### PR TITLE
Fix undefined variable in double-click handler

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -583,7 +583,7 @@ export default class Typo3Image extends Core.Plugin {
                     {
                         width: modelElement.getAttribute('width'),
                         height: modelElement.getAttribute('height'),
-                        class: selectedElement.getAttribute('class'),
+                        class: modelElement.getAttribute('class'),
                         alt: modelElement.getAttribute('alt'),
                         title: modelElement.getAttribute('title'),
                         'data-htmlarea-zoom': modelElement.getAttribute('enableZoom'),


### PR DESCRIPTION
## Summary
- fix reference to `selectedElement` inside double-click handler

## Testing
- `composer run-script ci:test:php:lint --no-interaction`
- `composer run-script ci:test:php:phpstan --no-interaction`
- `composer run-script ci:test:php:rector --no-interaction` *(fails: Rector reports diffs)*
- `composer run-script ci:test:php:cgl --no-interaction`


------
https://chatgpt.com/codex/tasks/task_b_683a9f403d088333966020976520bb23