### PR TITLE
Add warning for missing static template

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Add issues or explore the project on [GitHub](https://github.com/netresearch/t3x
 5. Include extension Static Template file
 
     1. go to Template » Info/Modify » Edit whole template record » Includes
-    2. choose `CKEditor Image Support` for `Include static (from extensions)` before the Fluid Styled content 
+    2. choose `CKEditor Image Support` for `Include static (from extensions)` before the Fluid Styled content
+    3. The Install Tool warns if this order is not respected
 
 ## Configuration
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -20,3 +20,64 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_parsehtml_proc.php'
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
     'RTE.default.proc.overruleMode := addToList(rtehtmlarea_images_db)'
 );
+
+// Warn if static template order is wrong
+call_user_func(function () {
+    $environmentService = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+        \TYPO3\CMS\Extbase\Service\EnvironmentService::class
+    );
+    if (!$environmentService->isEnvironmentInBackendMode()) {
+        return;
+    }
+
+    $queryBuilder = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+        \TYPO3\CMS\Core\Database\ConnectionPool::class
+    )->getQueryBuilderForTable('sys_template');
+
+    $templates = $queryBuilder
+        ->select('uid', 'title', 'include_static_file')
+        ->from('sys_template')
+        ->where(
+            $queryBuilder->expr()->neq(
+                'include_static_file',
+                $queryBuilder->createNamedParameter('')
+            )
+        )
+        ->executeQuery()
+        ->fetchAllAssociative();
+
+    foreach ($templates as $template) {
+        $paths = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(
+            ',',
+            (string)$template['include_static_file'],
+            true
+        );
+        $rteImagePos = null;
+        $fluidStyledPos = null;
+        foreach ($paths as $index => $path) {
+            if (strpos($path, 'rte_ckeditor_image/Configuration/TypoScript') !== false) {
+                $rteImagePos = $index;
+            }
+            if (strpos($path, 'fluid_styled_content') !== false) {
+                $fluidStyledPos = $index;
+            }
+        }
+        if ($fluidStyledPos !== null && ($rteImagePos === null || $rteImagePos > $fluidStyledPos)) {
+            $message = new \TYPO3\CMS\Core\Messaging\FlashMessage(
+                'Include "CKEditor Image Support" before "fluid_styled_content" in your TypoScript template.',
+                'Static template order',
+                \TYPO3\CMS\Core\Messaging\FlashMessage::WARNING,
+                true
+            );
+            \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+                \TYPO3\CMS\Core\Messaging\FlashMessageService::class
+            )->getMessageQueueByIdentifier()->addMessage($message);
+
+            \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+                \TYPO3\CMS\Core\Log\LogManager::class
+            )->getLogger('rte_ckeditor_image')
+                ->warning('CKEditor Image Support static template should be included before fluid_styled_content');
+            break;
+        }
+    }
+});


### PR DESCRIPTION
## Summary
- ensure TS templates include CKEditor Image Support before fluid_styled_content
- document the new Install Tool warning

## Testing
- `phpstan analyse -c phpstan.neon` *(fails: Found 3 errors)*
- `phpcs Classes/ --standard=PSR12`
- `phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml` *(no tests executed)*

------
https://chatgpt.com/codex/tasks/task_b_6842df51795c8333817b358c8fb015e5