### PR TITLE
[BUGFIX] Fix RteImageSoftReferenceParserTest fixture data

### DIFF
--- a/Tests/Functional/DataHandling/Fixtures/ReferenceIndex/UpdateReferenceIndexImport.csv
+++ b/Tests/Functional/DataHandling/Fixtures/ReferenceIndex/UpdateReferenceIndexImport.csv
@@ -1,3 +1,11 @@
+"sys_file_storage",,,,
+,"uid","pid","name","driver"
+,1,0,"fileadmin","Local"
+
+"sys_file",,,,,,,
+,"uid","pid","storage","identifier","name","extension"
+,1,0,1,"/1.jpg","1.jpg","jpg"
+
 "tt_content",,,,,,
 ,"uid","pid","sys_language_uid","deleted","hidden","bodytext"
 ,1,1,0,0,0,<img data-htmlarea-file-table="sys_file" data-htmlarea-file-uid="1" data-title-override="true" src="/fileadmin/1.jpg" />

--- a/Tests/Functional/DataHandling/Fixtures/ReferenceIndex/UpdateReferenceIndexResult.csv
+++ b/Tests/Functional/DataHandling/Fixtures/ReferenceIndex/UpdateReferenceIndexResult.csv
@@ -1,3 +1,4 @@
 "sys_refindex",,,,,
 ,"tablename","recuid","field","softref_key","ref_table","ref_uid"
+,"sys_file","1","storage","","sys_file_storage","1"
 ,"tt_content","1","bodytext","rtehtmlarea_images","sys_file","1"


### PR DESCRIPTION
## Summary

Fixes #337 - RteImageSoftReferenceParserTest was failing on both TYPO3 v12 and v13 due to incomplete test fixtures.

## Root Cause

The test fixtures were missing required database records:
- The `tt_content` record referenced a `sys_file` with uid=1 via the `data-htmlarea-file-uid` attribute
- However, the `sys_file` record with uid=1 did not exist in the import fixture
- TYPO3's `ReferenceIndex::updateIndex()` requires target records to exist when creating reference index entries
- Without the referenced file record, the soft reference parser couldn't create the expected `sys_refindex` entry

## Changes

**Tests/Functional/DataHandling/Fixtures/ReferenceIndex/UpdateReferenceIndexImport.csv:**
- Added `sys_file_storage` record with uid=1 (required for file system access)
- Added `sys_file` record with uid=1 that the HTML content references

**Tests/Functional/DataHandling/Fixtures/ReferenceIndex/UpdateReferenceIndexResult.csv:**
- Added expected `sys_refindex` entry for the database relation (`sys_file` → `sys_file_storage`)
- This relation is automatically created by TYPO3's ReferenceIndex when processing file records

## Testing

✅ Functional tests pass on TYPO3 v12.4:
```bash
CI=true Build/Scripts/runTests.sh -p 8.3 -t 12 -s functional -d sqlite
# Result: OK (1 test, 2 assertions)
```

✅ Functional tests pass on TYPO3 v13:
```bash
CI=true Build/Scripts/runTests.sh -p 8.3 -t 13 -s functional -d sqlite
# Result: OK (1 test, 2 assertions)
```

## Impact

This fix unblocks PR #299 which was previously blocked by this failing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)