### PR TITLE
docs: refresh README.md with v13.0.0+ updates and comprehensive improvements

### DIFF
--- a/Documentation/Index.md
+++ b/Documentation/Index.md
@@ -108,6 +108,17 @@ static get requires() {
 
 **Important:** Missing either plugin will disable the style dropdown for images. See [Style Integration](CKEditor/Style-Integration.md) for details.
 
+## Quick Navigation by Role
+
+| Role | Start Here | Then Read | Advanced |
+|------|-----------|-----------|----------|
+| **Integrator** | [Configuration Guide](Integration/Configuration.md) | [Examples](Examples/Common-Use-Cases.md) | [Troubleshooting](Troubleshooting/Common-Issues.md) |
+| **PHP Developer** | [Architecture Overview](Architecture/Overview.md) | [API Reference](API/Controllers.md) | [../AGENTS.md](../AGENTS.md) + [../Classes/AGENTS.md](../Classes/AGENTS.md) |
+| **JS Developer** | [CKEditor Plugin](CKEditor/Plugin-Development.md) | [Style Integration](CKEditor/Style-Integration.md) | [../Resources/AGENTS.md](../Resources/AGENTS.md) |
+| **Contributor** | [../CONTRIBUTING.md](../CONTRIBUTING.md) | [../AGENTS.md](../AGENTS.md) | [Testing](../Tests/AGENTS.md) |
+
+---
+
 ## Documentation Use Cases
 
 ### For Integrators
@@ -119,10 +130,19 @@ static get requires() {
 
 ### For Developers
 
-- **Extend the CKEditor plugin** → [Plugin Development](CKEditor/Plugin-Development.md)
+#### PHP Backend Development
+- **Understand the architecture** → [Architecture Overview](Architecture/Overview.md)
+- **Controller APIs** → [Controllers API](API/Controllers.md)
 - **Customize image processing** → [Data Handling API](API/DataHandling.md)
 - **Listen to extension events** → [Event Listeners](API/EventListeners.md)
-- **Understand the architecture** → [Architecture Overview](Architecture/Overview.md)
+- **Code standards & patterns** → [../Classes/AGENTS.md](../Classes/AGENTS.md)
+
+#### JavaScript/CKEditor Development
+- **Extend the CKEditor plugin** → [Plugin Development](CKEditor/Plugin-Development.md)
+- **Style system integration** → [Style Integration](CKEditor/Style-Integration.md)
+- **Custom model element** → [Model Element](CKEditor/Model-Element.md)
+- **Conversion system** → [Conversions](CKEditor/Conversions.md)
+- **Code standards & patterns** → [../Resources/AGENTS.md](../Resources/AGENTS.md)
 
 ### For Troubleshooters
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,40 @@
 
 # Image support for CKEditor for TYPO3
 
-This extension adds the TYPO3 image browser to CKEditor.\
+**Version 13.0.x** for TYPO3 13.4+
+**License:** AGPL-3.0-or-later
+
+This extension adds comprehensive image handling capabilities to CKEditor for TYPO3.\
 Add issues or explore the project on [GitHub](https://github.com/netresearch/t3x-rte_ckeditor_image).
 
 <kbd>![](Resources/Public/Images/demo.gif?raw=true)</kbd>
 
-- Same image handling as rtehtmlarea (magic images, usual RTE TSConfig supported)
-- Image browser as usual in e.g. FAL file selector
-- Dialog for changing width, height, alt and title (aspect ratio automatically maintained)
+## Features
+
+- **TYPO3 FAL Integration**: Native file browser with full File Abstraction Layer support
+- **Magic Images**: Same image processing as rtehtmlarea (cropping, scaling, TSConfig supported)
+- **Image Dialog**: Configure width, height, alt, and title (aspect ratio automatically maintained)
+- **Custom Styles**: Configurable image styles with CKEditor 5 style system
+- **Lazy Loading**: TYPO3 native browser lazyload support
+- **Event-Driven**: PSR-14 events for extensibility
+
+## Requirements
+
+- **TYPO3:** 13.4 or later
+- **PHP:** 8.2, 8.3, or 8.4
+- **Extensions:** cms-rte-ckeditor (included in TYPO3 core)
+
+### Critical Dependencies (v13.0.0+)
+
+The CKEditor plugin requires these dependencies for style functionality:
+
+```yaml
+# In your RTE YAML configuration
+importModules:
+  - '@ckeditor/ckeditor5-html-support'
+```
+
+**Important:** Missing `GeneralHtmlSupport` will disable the style dropdown for images. See [Documentation](Documentation/Index.md) for details.
 
 ## Installation
 
@@ -49,12 +75,15 @@ Add issues or explore the project on [GitHub](https://github.com/netresearch/t3x
 
     editor:
       config:
-        # RTE default config removes image plugin - restore it:
-        removePlugins: null
         toolbar:
           items:
+            - heading
             - '|'
-            - insertImage
+            - typo3image
+            - link
+            - '|'
+            - bold
+            - italic
     ```
 
 3. Enable RTE config preset (e.g. `default`)
@@ -134,8 +163,34 @@ editor:
         allowedExtensions: "jpg,jpeg,png"
 ```
 
+## Documentation
+
+For comprehensive documentation, see [Documentation/Index.md](Documentation/Index.md):
+
+- **Integrators**: [Configuration Guide](Documentation/Integration/Configuration.md) | [Examples](Documentation/Examples/Common-Use-Cases.md) | [Troubleshooting](Documentation/Troubleshooting/Common-Issues.md)
+- **PHP Developers**: [Architecture Overview](Documentation/Architecture/Overview.md) | [API Reference](Documentation/API/Controllers.md) | [AGENTS.md](AGENTS.md)
+- **JS Developers**: [CKEditor Plugin](Documentation/CKEditor/Plugin-Development.md) | [Style Integration](Documentation/CKEditor/Style-Integration.md) | [Resources/AGENTS.md](Resources/AGENTS.md)
+- **Contributors**: [CONTRIBUTING.md](CONTRIBUTING.md) | [AGENTS.md](AGENTS.md) | [Tests/AGENTS.md](Tests/AGENTS.md)
+
+## Development
+
+```bash
+# Quick start
+composer install
+make help                    # See all available targets
+
+# Development workflow
+make lint                    # Run all linters
+make format                  # Fix code style
+make test                    # Run tests
+make ci                      # Full CI check (pre-commit)
+```
+
+See [AGENTS.md](AGENTS.md) for complete development guide, code standards, and PR checklist.
+
 ## Deployment
 
-- developed on [GitHub](https://github.com/netresearch/t3x-rte_ckeditor_image)
-- [composer repository](https://packagist.org/packages/netresearch/rte-ckeditor-image)
-- new version will automatically be uploaded to TER via Github Action when creating a new Github release
+- Developed on [GitHub](https://github.com/netresearch/t3x-rte_ckeditor_image)
+- [Composer repository](https://packagist.org/packages/netresearch/rte-ckeditor-image)
+- [TYPO3 Extension Repository](https://extensions.typo3.org/extension/rte_ckeditor_image)
+- New versions automatically uploaded to TER via GitHub Action when creating a release


### PR DESCRIPTION
## Summary

Comprehensive refresh of README.md and Documentation/Index.md to reflect current v13.0.0+ state and improve documentation discoverability.

## Changes

### README.md Enhancements

**Version & Requirements** (Lines 16-49):
- ✅ Added version info: **13.0.x for TYPO3 13.4+**
- ✅ Added license: **AGPL-3.0-or-later**
- ✅ New **Features** section highlighting FAL, magic images, custom styles, lazy loading
- ✅ New **Requirements** section: PHP 8.2-8.4, TYPO3 13.4+
- ✅ **Critical Dependencies** note: v13.0.0+ requires GeneralHtmlSupport for style dropdown

**Fixed Configuration** (Line 82):
- 🔧 Fixed plugin name: `insertImage` → `typo3image` (v13.0.0+ breaking change)
- ✨ Enhanced toolbar example with proper structure

**Documentation Section** (Lines 166-173):
- 📚 Added role-based navigation links (Integrators, PHP/JS Developers, Contributors)
- 🔗 Cross-referenced to Documentation/Index.md, AGENTS.md hierarchy

**Development Section** (Lines 175-189):
- 🛠️ Added quick start commands (`make lint`, `make format`, `make test`, `make ci`)
- 📖 Referenced AGENTS.md for complete development guide

**Enhanced Deployment** (Lines 191-196):
- 🔗 Added TYPO3 Extension Repository link
- ✨ Clarified GitHub Action automation

### Documentation/Index.md Enhancements

- 📊 Added "Quick Navigation by Role" table for easy access
- 🎯 Expanded "For Developers" section with PHP vs JavaScript separation
- 🔗 Integrated cross-references to AGENTS.md hierarchy

## Impact

- Fixes critical plugin name issue from v13.0.0 breaking change
- Improves discoverability of comprehensive documentation hierarchy
- Provides clear entry points for different user roles
- Ensures requirements are accurate for TYPO3 13.4 and PHP 8.2-8.4

## Validation

✅ All 18 documentation files verified to exist
✅ Cross-references validated (AGENTS.md, Documentation/, CONTRIBUTING.md)
✅ Requirements match composer.json (PHP ^8.2, TYPO3 ^13.4)
✅ Version info consistent with ext_emconf.php (13.0.0)
✅ Configuration examples updated for v13.0.0+
✅ Pre-commit hooks passed (PHP lint, PHP-CS-Fixer, PHPStan)

## Files Changed

- `README.md`: 142 → 197 lines (+55 lines)
- `Documentation/Index.md`: Added navigation table and expanded developer sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)