### PR TITLE
[UPSTREAM] Propagate TYPO3_10 fixes to TYPO3_11

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -294,7 +294,7 @@
                             var dialogInfo = dialog.get(),
                                 filteredAttr = {},
                                 allowedAttributes = [
-                                    '!src', 'alt', 'title', 'class', 'rel', 'width', 'height', 'data-htmlarea-zoom', 'data-title-override', 'data-alt-override'
+                                    '!src', 'alt', 'title', 'class', 'rel', 'width', 'height', 'style', 'data-htmlarea-zoom', 'data-title-override', 'data-alt-override'
                                 ],
                                 additionalAttributes = getAdditionalAttributes(editor),
                                 attributesNew = $.extend({}, img, dialogInfo);


### PR DESCRIPTION
## Upstream Propagation: TYPO3_10 → TYPO3_11

This PR propagates bug fixes from TYPO3_10 that are missing in TYPO3_11.

### Commits Included (1)

#### ✅ f14068f - [BUGFIX] Allow `style` attribute on `img` tags
- **Author:** Thorben Nissen
- **Date:** 2022-06-21
- **Priority:** HIGH
- **Type:** Bugfix
- **Changes:** Adds 'style' to allowedAttributes array to support inline styling of images

### Impact

- Enables `style` attribute support for image tags in TYPO3_11
- Maintains consistency with TYPO3_10 functionality
- Low risk: Single-line change adding attribute to allow list

### Testing

- [x] Cherry-pick applied cleanly
- [ ] Manual testing of image style attributes
- [ ] No regressions in existing functionality

### References

- Part of systematic upstream propagation analysis
- See: /tmp/upstream_analysis.md for complete analysis

---
🤖 Automated upstream propagation