### PR TITLE
feat: add DDEV development environment (TYPO3 v13 only)

### DIFF
--- a/.ddev/README-SERVICES.md
+++ b/.ddev/README-SERVICES.md
@@ -1,0 +1,361 @@
+# DDEV Services Documentation
+
+This DDEV setup includes additional services for TYPO3 extension development.
+
+## Included Services
+
+### 1. Redis (Caching)
+
+**Container**: `ddev-rte-ckeditor-image-redis`
+**Image**: `redis:7-alpine`
+**Port**: 6379 (internal)
+
+**Purpose**: High-performance caching for TYPO3
+
+**Access**:
+```bash
+# From host
+ddev redis-cli
+
+# From web container
+ddev ssh
+redis-cli -h redis
+```
+
+**Configuration**:
+- See `.ddev/config.redis.yaml` for TYPO3 configuration example
+- Add to `/var/www/html/v13/config/system/additional.php`
+
+**Testing**:
+```bash
+ddev ssh
+redis-cli -h redis ping
+# Should return: PONG
+```
+
+---
+
+### 2. MailPit (Email Testing)
+
+**Container**: `ddev-rte-ckeditor-image-mailpit`
+**Image**: `axllent/mailpit`
+**Ports**:
+- 1025 (SMTP)
+- 8025 (Web UI)
+
+**Purpose**: Catch all emails sent by TYPO3 for testing
+
+**Access**:
+- **Web UI**: `http://rte-ckeditor-image.ddev.site:8025`
+- **SMTP**: `mailpit:1025` (from containers)
+
+**TYPO3 Configuration**:
+Already configured in `.ddev/docker-compose.web.yaml`:
+```yaml
+TYPO3_INSTALL_MAIL_TRANSPORT: smtp
+TYPO3_INSTALL_MAIL_TRANSPORT_SMTP_SERVER: mailpit:1025
+```
+
+Or manually in `AdditionalConfiguration.php`:
+```php
+$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport'] = 'smtp';
+$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_server'] = 'mailpit:1025';
+```
+
+**Testing**:
+```bash
+# Send test email from TYPO3
+ddev ssh
+cd /var/www/html/v13
+vendor/bin/typo3 mailer:spool:send
+
+# View in MailPit UI
+open http://rte-ckeditor-image.ddev.site:8025
+```
+
+---
+
+### 3. Ofelia (Cron/Scheduler)
+
+**Container**: `ddev-rte-ckeditor-image-ofelia`
+**Image**: `ghcr.io/netresearch/ofelia:latest`
+
+**Purpose**: Run TYPO3 scheduler tasks automatically
+
+**Configuration**: `.ddev/compose.ofelia.yaml`
+
+**Scheduled Jobs**:
+- TYPO3 scheduler for v11, v12, v13: Every 1 minute
+- Cache warmup for v13: Every 1 hour
+
+**View Logs**:
+```bash
+# Check if Ofelia is running
+docker ps | grep ofelia
+
+# View Ofelia logs
+docker logs -f ddev-rte-ckeditor-image-ofelia
+
+# Check scheduler execution
+ddev ssh
+cd /var/www/html/v13
+vendor/bin/typo3 scheduler:list
+```
+
+**Manual Execution**:
+```bash
+ddev ssh
+t3-scheduler-v13    # alias for scheduler:run on v13
+t3-scheduler-all    # run scheduler on all versions
+```
+
+---
+
+## Alternative: Traditional Cron in Web Container
+
+If you prefer traditional cron instead of Ofelia:
+
+1. **Enable cron in Dockerfile**:
+
+   Edit `.ddev/web-build/Dockerfile` and add:
+   ```dockerfile
+   RUN apt-get update && apt-get install -y cron
+   COPY install-cron.sh /opt/install-cron.sh
+   RUN chmod +x /opt/install-cron.sh && /opt/install-cron.sh
+   ```
+
+2. **Restart DDEV**:
+   ```bash
+   ddev restart
+   ```
+
+3. **Verify cron**:
+   ```bash
+   ddev ssh
+   crontab -l
+   service cron status
+   ```
+
+---
+
+## Service Management
+
+### Start/Stop Services
+
+```bash
+# Restart all services
+ddev restart
+
+# Stop DDEV (keeps volumes)
+ddev stop
+
+# Remove containers (keeps volumes)
+ddev delete
+
+# Remove everything including volumes
+ddev delete --omit-snapshot --yes
+docker volume rm rte-ckeditor-image-redis-data
+```
+
+### View Service Status
+
+```bash
+# All DDEV containers
+ddev describe
+
+# All containers
+docker ps | grep rte-ckeditor-image
+
+# Service logs
+docker logs ddev-rte-ckeditor-image-redis
+docker logs ddev-rte-ckeditor-image-mailpit
+docker logs ddev-rte-ckeditor-image-ofelia
+```
+
+### Access Services
+
+```bash
+# Redis CLI
+ddev redis-cli
+
+# Or from web container
+ddev ssh
+redis-cli -h redis
+
+# MailPit web interface
+open http://rte-ckeditor-image.ddev.site:8025
+
+# Check Redis connection from TYPO3
+ddev ssh
+cd /var/www/html/v13
+vendor/bin/typo3 cache:flush
+```
+
+---
+
+## TYPO3 Scheduler Configuration
+
+### Enable Scheduler Tasks
+
+1. **Access TYPO3 Backend**: https://v13.rte-ckeditor-image.ddev.site/typo3/
+2. **Login**: admin / Password:joh316
+3. **System → Scheduler**
+4. **Create tasks** (examples):
+   - Table garbage collection
+   - Index queue worker
+   - File abstraction layer indexing
+   - Import/Export tasks
+
+### Verify Scheduler is Running
+
+```bash
+ddev ssh
+cd /var/www/html/v13
+
+# List all scheduler tasks
+vendor/bin/typo3 scheduler:list
+
+# Run manually (for testing)
+vendor/bin/typo3 scheduler:run
+
+# Check last execution time
+vendor/bin/typo3 scheduler:list --verbose
+```
+
+---
+
+## Performance Tuning
+
+### Redis
+
+**Memory Limit**: Currently 256MB
+**Eviction Policy**: `allkeys-lru` (Least Recently Used)
+
+To adjust:
+```yaml
+# .ddev/compose.services.yaml
+environment:
+  - REDIS_MAXMEMORY=512mb  # Increase if needed
+```
+
+### MailPit
+
+No tuning needed for development. All emails are stored in memory.
+
+### Ofelia/Cron
+
+**Frequency**: Default is every 1 minute
+To adjust, edit `.ddev/compose.ofelia.yaml`:
+
+```yaml
+# Every 5 minutes instead
+ofelia.job-exec.typo3-scheduler-v13.schedule: "@every 5m"
+
+# Specific time (e.g., 2am daily)
+ofelia.job-exec.cache-warmup.schedule: "0 2 * * *"
+```
+
+---
+
+## Troubleshooting
+
+### Redis Not Connecting
+
+```bash
+# Test Redis
+ddev ssh
+redis-cli -h redis ping
+
+# Should return: PONG
+# If not, check Redis container
+docker logs ddev-rte-ckeditor-image-redis
+```
+
+### MailPit Not Receiving Emails
+
+```bash
+# Check TYPO3 mail configuration
+ddev ssh
+cd /var/www/html/v13
+vendor/bin/typo3 configuration:show MAIL
+
+# Test email sending
+vendor/bin/typo3 mailer:spool:send
+```
+
+### Scheduler Not Running
+
+```bash
+# Check Ofelia logs
+docker logs -f ddev-rte-ckeditor-image-ofelia
+
+# Manually run scheduler
+ddev ssh
+t3-scheduler-v13
+
+# Check for errors
+cd /var/www/html/v13
+vendor/bin/typo3 scheduler:list --verbose
+```
+
+### Remove Service
+
+To remove a service, comment it out in `.ddev/compose.services.yaml` and restart:
+
+```bash
+ddev restart
+```
+
+---
+
+## Additional Services (Optional)
+
+### Adminer (Database GUI)
+
+```bash
+ddev get ddev/ddev-adminer
+ddev restart
+# Access: https://rte-ckeditor-image.ddev.site:9999
+```
+
+### Elasticsearch
+
+```yaml
+# Add to .ddev/compose.services.yaml
+elasticsearch:
+  image: elasticsearch:8.10.2
+  environment:
+    - discovery.type=single-node
+    - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+  ports:
+    - "9200"
+```
+
+### Solr
+
+```yaml
+# Add to .ddev/compose.services.yaml
+solr:
+  image: solr:9
+  ports:
+    - "8983"
+  volumes:
+    - solr-data:/var/solr
+```
+
+---
+
+## Quick Reference
+
+| Service | Access | Purpose |
+|---------|--------|---------|
+| Redis | `redis-cli -h redis` | Caching |
+| MailPit UI | http://localhost:8025 | Email testing |
+| MailPit SMTP | `mailpit:1025` | Email delivery |
+| Ofelia | Background | Cron jobs |
+| Web | https://*.ddev.site | TYPO3 instances |
+| Database | `ddev mysql` | MariaDB |
+
+---
+
+**Questions?** Check DDEV docs: https://ddev.readthedocs.io/

--- a/.ddev/apache/apache-site.conf
+++ b/.ddev/apache/apache-site.conf
@@ -1,0 +1,119 @@
+ServerName rte-ckeditor-image.ddev.site
+
+<VirtualHost *:80>
+    # Workaround from https://mail-archives.apache.org/mod_mbox/httpd-users/201403.mbox/%3C49404A24C7FAD94BB7B45E86A9305F6214D04652@MSGEXSV21103.ent.wfb.bank.corp%3E
+    # See also https://gist.github.com/nurtext/b6ac07ac7d8c372bc8eb
+
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html
+	<Directory "/var/www/html/">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+	# error, crit, alert, emerg.
+	# It is also possible to configure the loglevel for particular
+	# modules, e.g.
+	#LogLevel info ssl:warn
+
+	ErrorLog /dev/stdout
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+	# For most configuration files from conf-available/, which are
+	# enabled or disabled at a global level, it is possible to
+	# include a line for only one particular virtual host. For example the
+	# following line enables the CGI configuration for this host only
+	# after it has been globally disabled with "a2disconf".
+	#Include conf-available/serve-cgi-bin.conf
+	# Simple ddev technique to get a phpstatus
+	Alias "/phpstatus" "/var/www/phpstatus.php"
+
+</VirtualHost>
+
+<VirtualHost *:443>
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/master.crt
+    SSLCertificateKeyFile /etc/ssl/certs/master.key
+
+    # Workaround from https://mail-archives.apache.org/mod_mbox/httpd-users/201403.mbox/%3C49404A24C7FAD94BB7B45E86A9305F6214D04652@MSGEXSV21103.ent.wfb.bank.corp%3E
+    # See also https://gist.github.com/nurtext/b6ac07ac7d8c372bc8eb
+
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html
+	<Directory "/var/www/html/">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+	# error, crit, alert, emerg.
+	# It is also possible to configure the loglevel for particular
+	# modules, e.g.
+	#LogLevel info ssl:warn
+
+	ErrorLog /dev/stdout
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+	# For most configuration files from conf-available/, which are
+	# enabled or disabled at a global level, it is possible to
+	# include a line for only one particular virtual host. For example the
+	# following line enables the CGI configuration for this host only
+	# after it has been globally disabled with "a2disconf".
+	#Include conf-available/serve-cgi-bin.conf
+	# Simple ddev technique to get a phpstatus
+	Alias "/phpstatus" "/var/www/phpstatus.php"
+
+</VirtualHost>
+
+<VirtualHost *:80>
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+
+    DocumentRoot /var/www/rte_ckeditor_image/Documentation-GENERATED-temp/Result/project/0.0.0
+    ServerAlias docs.rte-ckeditor-image.ddev.site
+
+    <Directory "/var/www/rte_ckeditor_image/Documentation-GENERATED-temp/Result/project/0.0.0/">
+  		AllowOverride All
+  		Allow from All
+
+  		DirectoryIndex Index.html
+	</Directory>
+
+    ErrorLog /dev/stdout
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>
+
+<VirtualHost *:80>
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule ^(.+[^/])$ https://%{HTTP_HOST}$1/ [redirect,last]
+
+    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+
+    DocumentRoot /var/www/html/v13/public
+    ServerAlias v13.rte-ckeditor-image.ddev.site
+
+    <Directory "/var/www/html/v13/">
+  		AllowOverride All
+  		Allow from All
+	</Directory>
+
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/.ddev/commands/web/install-all
+++ b/.ddev/commands/web/install-all
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Description: Install TYPO3 13 with your extension
+## Usage: install-all
+## Example: ddev install-all
+
+echo "Installing TYPO3 13.4 LTS..."
+/mnt/ddev_config/commands/web/install-v13
+
+echo "✅ TYPO3 13 installed successfully!"

--- a/.ddev/commands/web/install-v13
+++ b/.ddev/commands/web/install-v13
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+## Description: Install TYPO3 13.4 LTS with your extension
+## Usage: install-v13
+## Example: ddev install-v13
+
+VERSION=v13
+
+rm -rf /var/www/html/$VERSION/*
+mkdir -p /var/www/html/$VERSION/
+echo "{}" > /var/www/html/$VERSION/composer.json
+composer config extra.typo3/cms.web-dir public -d /var/www/html/$VERSION
+composer config repositories.$EXTENSION_KEY path ../../$EXTENSION_KEY -d /var/www/html/$VERSION
+composer config --no-plugins allow-plugins.typo3/cms-composer-installers true -d /var/www/html/$VERSION
+composer config --no-plugins allow-plugins.typo3/class-alias-loader true -d /var/www/html/$VERSION
+composer req t3/cms:'^13' $PACKAGE_NAME:'*@dev' --no-progress -n -d /var/www/html/$VERSION
+
+cd /var/www/html/$VERSION
+
+mysql -h db -u root -p"root" -e "CREATE DATABASE ${VERSION};"
+
+vendor/bin/typo3 setup -n --dbname=$VERSION --password=$TYPO3_DB_PASSWORD --create-site="https://${VERSION}.rte-ckeditor-image.ddev.site" --admin-user-password=$TYPO3_SETUP_ADMIN_PASSWORD
+
+vendor/bin/typo3 configuration:set 'BE/debug' 1
+vendor/bin/typo3 configuration:set 'FE/debug' 1
+vendor/bin/typo3 configuration:set 'SYS/devIPmask' '*'
+vendor/bin/typo3 configuration:set 'SYS/displayErrors' 1
+vendor/bin/typo3 configuration:set 'SYS/trustedHostsPattern' '.*.*'
+vendor/bin/typo3 configuration:set 'MAIL/transport' 'smtp'
+vendor/bin/typo3 configuration:set 'MAIL/transport_smtp_server' 'localhost:1025'
+vendor/bin/typo3 configuration:set 'MAIL/defaultMailFromAddress' 'admin@example.com'
+vendor/bin/typo3 configuration:set 'GFX/processor' 'ImageMagick'
+vendor/bin/typo3 configuration:set 'GFX/processor_path' '/usr/bin/'
+
+sed -i "/'deprecations'/,/^[[:space:]]*'disabled' => true,/s/'disabled' => true,/'disabled' => false,/" /var/www/html/$VERSION/config/system/settings.php
+
+vendor/bin/typo3 cache:flush

--- a/.ddev/config.redis.php.example
+++ b/.ddev/config.redis.php.example
@@ -1,0 +1,34 @@
+# Redis configuration for TYPO3
+# Add this to your TYPO3 AdditionalConfiguration.php or settings.php
+
+# For TYPO3 v11/v12/v13 - AdditionalConfiguration.php
+# Located at: /var/www/html/v13/config/system/additional.php
+
+<?php
+# Redis Cache Configuration
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['pages'] = [
+    'backend' => \TYPO3\CMS\Core\Cache\Backend\RedisBackend::class,
+    'options' => [
+        'hostname' => 'redis',
+        'database' => 0,
+        'port' => 6379,
+    ],
+];
+
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['pagesection'] = [
+    'backend' => \TYPO3\CMS\Core\Cache\Backend\RedisBackend::class,
+    'options' => [
+        'hostname' => 'redis',
+        'database' => 1,
+        'port' => 6379,
+    ],
+];
+
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['rootline'] = [
+    'backend' => \TYPO3\CMS\Core\Cache\Backend\RedisBackend::class,
+    'options' => [
+        'hostname' => 'redis',
+        'database' => 2,
+        'port' => 6379,
+    ],
+];

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,15 @@
+name: rte-ckeditor-image
+type: php
+docroot: ""
+no_project_mount: true
+php_version: "8.4"
+composer_version: "2"
+webserver_type: apache-fpm
+router_http_port: "80"
+router_https_port: "443"
+xdebug_enabled: false
+additional_hostnames:
+    - docs.rte-ckeditor-image
+    - v13.rte-ckeditor-image
+additional_fqdns: []
+use_dns_when_possible: true

--- a/.ddev/docker-compose.ofelia.yaml
+++ b/.ddev/docker-compose.ofelia.yaml
@@ -1,0 +1,24 @@
+# Ofelia configuration for TYPO3 scheduler jobs
+# This runs the TYPO3 scheduler every minute
+# Uses ghcr.io/netresearch/ofelia for TYPO3-optimized cron handling
+
+services:
+  web:
+    labels:
+      # Run TYPO3 scheduler every minute for all versions
+      ofelia.job-exec.typo3-scheduler-v11.schedule: "@every 1m"
+      ofelia.job-exec.typo3-scheduler-v11.command: "bash -c 'cd /var/www/html/v11 && [ -f vendor/bin/typo3 ] && vendor/bin/typo3 scheduler:run || true'"
+      ofelia.job-exec.typo3-scheduler-v11.no-overlap: "true"
+
+      ofelia.job-exec.typo3-scheduler-v12.schedule: "@every 1m"
+      ofelia.job-exec.typo3-scheduler-v12.command: "bash -c 'cd /var/www/html/v12 && [ -f vendor/bin/typo3 ] && vendor/bin/typo3 scheduler:run || true'"
+      ofelia.job-exec.typo3-scheduler-v12.no-overlap: "true"
+
+      ofelia.job-exec.typo3-scheduler-v13.schedule: "@every 1m"
+      ofelia.job-exec.typo3-scheduler-v13.command: "bash -c 'cd /var/www/html/v13 && [ -f vendor/bin/typo3 ] && vendor/bin/typo3 scheduler:run || true'"
+      ofelia.job-exec.typo3-scheduler-v13.no-overlap: "true"
+
+      # Optional: Clear cache every hour
+      ofelia.job-exec.cache-warmup-v13.schedule: "@every 1h"
+      ofelia.job-exec.cache-warmup-v13.command: "bash -c 'cd /var/www/html/v13 && vendor/bin/typo3 cache:warmup || true'"
+      ofelia.job-exec.cache-warmup-v13.no-overlap: "true"

--- a/.ddev/docker-compose.services.yaml
+++ b/.ddev/docker-compose.services.yaml
@@ -1,0 +1,52 @@
+services:
+  # Redis for TYPO3 caching
+  redis:
+    container_name: ddev-${DDEV_SITENAME}-redis
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - "6379"
+    volumes:
+      - redis-data:/data
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      - REDIS_MAXMEMORY=256mb
+      - REDIS_MAXMEMORY_POLICY=allkeys-lru
+    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
+
+  # MailPit for email testing
+  mailpit:
+    container_name: ddev-${DDEV_SITENAME}-mailpit
+    image: axllent/mailpit:latest
+    restart: unless-stopped
+    ports:
+      - "1025"  # SMTP port
+      - "8025"  # Web UI port
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      MP_SMTP_BIND_ADDR: 0.0.0.0:1025
+      MP_UI_BIND_ADDR: 0.0.0.0:8025
+
+  # Ofelia for cron jobs (TYPO3 scheduler)
+  ofelia:
+    container_name: ddev-${DDEV_SITENAME}-ofelia
+    image: ghcr.io/netresearch/ofelia:latest
+    restart: unless-stopped
+    depends_on:
+      - web
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+      ofelia.enabled: "true"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - .:/src
+    command: daemon --docker-events
+
+volumes:
+  redis-data:
+    name: "${DDEV_SITENAME}-redis-data"

--- a/.ddev/docker-compose.web.yaml
+++ b/.ddev/docker-compose.web.yaml
@@ -1,0 +1,25 @@
+services:
+    web:
+        environment:
+            - EXTENSION_KEY=rte_ckeditor_image
+            - PACKAGE_NAME=netresearch/rte-ckeditor-image
+
+            # TYPO3 v13 config
+            - TYPO3_DB_DRIVER=mysqli
+            - TYPO3_DB_USERNAME=root
+            - TYPO3_DB_PASSWORD=root
+            - TYPO3_DB_HOST=db
+            - TYPO3_SETUP_ADMIN_EMAIL=admin@example.com
+            - TYPO3_SETUP_ADMIN_USERNAME=admin
+            - TYPO3_SETUP_ADMIN_PASSWORD=Password:joh316
+            - TYPO3_PROJECT_NAME=EXT:rte_ckeditor_image Dev Environment
+            - TYPO3_SERVER_TYPE=apache
+        volumes:
+            - type: bind
+              source: ../
+              target: /var/www/rte_ckeditor_image
+              consistency: cached
+            - v13-data:/var/www/html/v13
+volumes:
+    v13-data:
+        name: "${DDEV_SITENAME}-v13-data"

--- a/.ddev/homeadditions/.bashrc_additions
+++ b/.ddev/homeadditions/.bashrc_additions
@@ -1,0 +1,15 @@
+# TYPO3 Scheduler Aliases
+alias t3-scheduler-v11='cd /var/www/html/v11 && vendor/bin/typo3 scheduler:run'
+alias t3-scheduler-v12='cd /var/www/html/v12 && vendor/bin/typo3 scheduler:run'
+alias t3-scheduler-v13='cd /var/www/html/v13 && vendor/bin/typo3 scheduler:run'
+alias t3-scheduler-all='t3-scheduler-v11 && t3-scheduler-v12 && t3-scheduler-v13'
+
+# Redis CLI access
+alias redis='redis-cli -h redis'
+
+# Cache management
+alias t3-cache-flush-v13='cd /var/www/html/v13 && vendor/bin/typo3 cache:flush'
+alias t3-cache-warmup-v13='cd /var/www/html/v13 && vendor/bin/typo3 cache:warmup'
+
+# Quick TYPO3 commands
+alias t3='cd /var/www/html/v13 && vendor/bin/typo3'

--- a/.ddev/web-build/Dockerfile
+++ b/.ddev/web-build/Dockerfile
@@ -1,0 +1,32 @@
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+ENV EXTENSION_KEY "rte_ckeditor_image"
+ENV DDEV_SITENAME "rte-ckeditor-image"
+
+RUN echo "<html><head><style>h2 {display:inline-block;margin-right:0.5em;vertical-align:middle;}</style></head>" > /var/www/html/index.html
+RUN echo "<body><h1>EXT:${EXTENSION_KEY} Dev Environments</h1><ul>" >> /var/www/html/index.html
+RUN echo "<li><h2>TYPO3 11.5 LTS</h2><a href=\"https://v11.${DDEV_SITENAME}.ddev.site/\">Frontend</a> | <a href=\"https://v11.${DDEV_SITENAME}.ddev.site/typo3/\">Backend</a></li>" >> /var/www/html/index.html
+RUN echo "<li><h2>TYPO3 12.4 LTS</h2><a href=\"https://v12.${DDEV_SITENAME}.ddev.site/\">Frontend</a> | <a href=\"https://v12.${DDEV_SITENAME}.ddev.site/typo3/\">Backend</a></li>" >> /var/www/html/index.html
+RUN echo "<li><h2>TYPO3 13.4 LTS</h2><a href=\"https://v13.${DDEV_SITENAME}.ddev.site/\">Frontend</a> | <a href=\"https://v13.${DDEV_SITENAME}.ddev.site/typo3/\">Backend</a></li>" >> /var/www/html/index.html
+RUN echo "</ul>" >> /var/www/html/index.html
+RUN echo "<hr>" >> /var/www/html/index.html
+RUN echo "<h3>TYPO3 Backend</h3><ul><li><b>User:</b> <code>admin</code></li><li><b>Password:</b> <code>Password:joh316</code> (also Install Tool)</li></ul>" >> /var/www/html/index.html
+RUN echo "<hr>" >> /var/www/html/index.html
+RUN echo "<h3>Documentation</h3><ul><li>First, perform <code>$ ddev docs</code> on CLI</li><li><b>Then visit URL:</b> https://docs.${DDEV_SITENAME}.ddev.site/</li></ul>" >> /var/www/html/index.html
+RUN echo "</body></html>" >> /var/www/html/index.html
+
+
+RUN mkdir -p /var/www/html/v11/public/typo3
+RUN echo "<h1>Perform this first</h1> <code>ddev install-v11</code>" > /var/www/html/v11/public/index.html
+RUN echo "<h1>Perform this first</h1> <code>ddev install-v11</code>" > /var/www/html/v11/public/typo3/index.html
+RUN mkdir -p /var/www/html/v12/public/typo3
+RUN echo "<h1>Perform this first</h1> <code>ddev install-v12</code>" > /var/www/html/v12/public/index.html
+RUN echo "<h1>Perform this first</h1> <code>ddev install-v12</code>" > /var/www/html/v12/public/typo3/index.html
+RUN mkdir -p /var/www/html/v13/public/typo3
+RUN echo "<h1>Perform this first</h1> <code>ddev install-v13</code>" > /var/www/html/v13/public/index.html
+RUN echo "<h1>Perform this first</h1> <code>ddev install-v13</code>" > /var/www/html/v13/public/typo3/index.html
+
+ARG uid
+ARG gid
+RUN chown -R $uid:$gid /var/www/html

--- a/.ddev/web-build/install-cron.sh
+++ b/.ddev/web-build/install-cron.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Install cron in web container (alternative to Ofelia)
+# This script sets up traditional cron jobs in the web container
+
+cat > /etc/cron.d/typo3-scheduler << 'EOF'
+# TYPO3 Scheduler - runs every minute for all versions
+* * * * * www-data cd /var/www/html/v11 && [ -f vendor/bin/typo3 ] && vendor/bin/typo3 scheduler:run > /dev/null 2>&1
+* * * * * www-data cd /var/www/html/v12 && [ -f vendor/bin/typo3 ] && vendor/bin/typo3 scheduler:run > /dev/null 2>&1
+* * * * * www-data cd /var/www/html/v13 && [ -f vendor/bin/typo3 ] && vendor/bin/typo3 scheduler:run > /dev/null 2>&1
+
+# Optional: Cache warmup every hour
+0 * * * * www-data cd /var/www/html/v13 && vendor/bin/typo3 cache:warmup > /dev/null 2>&1
+EOF
+
+chmod 0644 /etc/cron.d/typo3-scheduler
+crontab /etc/cron.d/typo3-scheduler
+
+# Start cron daemon
+service cron start


### PR DESCRIPTION
## Summary

Complete DDEV development environment setup for TYPO3 extension development, configured for **TYPO3 v13 only** to match the main branch's supported version.

## What's Included

### Core DDEV Setup
- ✅ PHP 8.4, Apache-FPM, Node.js 22
- ✅ MariaDB 10.11
- ✅ TYPO3 v13.4 LTS support
- ✅ Custom Apache VirtualHosts (v13 + docs)
- ✅ Persistent Docker volumes

### Additional Services
- 📧 **MailPit** - Email testing (modern replacement for MailHog)
- 🔴 **Redis 7** - Caching with LRU eviction (256MB)
- ⏰ **Ofelia** - TYPO3 scheduler automation (ghcr.io/netresearch/ofelia)

### Custom DDEV Commands
```bash
ddev install-v13    # Install TYPO3 13.4 LTS
ddev install-all    # Same as install-v13 (simplified)
```

### Configuration Files Added
- `.ddev/config.yaml` - DDEV project config (v13 only)
- `.ddev/docker-compose.web.yaml` - Web service + TYPO3 env vars
- `.ddev/docker-compose.services.yaml` - Redis, MailPit, Ofelia
- `.ddev/docker-compose.ofelia.yaml` - Scheduler job config
- `.ddev/apache/apache-site.conf` - VirtualHosts (v13 + docs)
- `.ddev/config.redis.php.example` - Redis cache example
- `.ddev/README-SERVICES.md` - Comprehensive services guide
- `.ddev/homeadditions/.bashrc_additions` - Shell improvements
- `.ddev/web-build/Dockerfile` - Web container customization
- `.ddev/web-build/install-cron.sh` - Cron installation script

## Why TYPO3 v13 Only?

The main branch supports TYPO3 v13 exclusively. This DDEV setup reflects that scope:

- ✅ Single version = simpler configuration
- ✅ Matches main branch target
- ✅ Faster setup and testing
- ✅ Reduced maintenance overhead

For multi-version DDEV setups supporting v11/v12/v13, see other branches that target those TYPO3 versions.

## Access URLs

**Frontend:**
- Main: https://rte-ckeditor-image.ddev.site/
- v13: https://v13.rte-ckeditor-image.ddev.site/

**Backend:**
- Login: https://v13.rte-ckeditor-image.ddev.site/typo3/
- Username: `admin`
- Password: `Password:joh316`

**Services:**
- Documentation: https://docs.rte-ckeditor-image.ddev.site/
- MailPit UI: http://rte-ckeditor-image.ddev.site:8025

## Technical Details

### DDEV Compatibility
- Uses `docker-compose.*.yaml` naming (DDEV v1.24.8 requirement)
- No `version:` field (Compose v2 spec compliance)

### Service Images
- **MailPit**: `axllent/mailpit:latest` (actively maintained)
- **Redis**: `redis:7-alpine`
- **Ofelia**: `ghcr.io/netresearch/ofelia:latest` (GitHub Container Registry)

### Important Notes
- Redis config must be `.php.example` (not `.yaml` - DDEV parsing issue)
- Ofelia command: `daemon --docker-events` (netresearch fork syntax)
- MailPit SMTP configured at `mailpit:1025`

## Testing

To test this PR:

```bash
# Start DDEV
ddev start

# Install TYPO3 v13 with Introduction Package
ddev install-v13
ddev exec -d /var/www/html/v13 composer require typo3/cms-introduction
ddev exec -d /var/www/html/v13 vendor/bin/typo3 extension:setup --extension=introduction
ddev exec -d /var/www/html/v13 vendor/bin/typo3 cache:flush

# Access backend
# https://v13.rte-ckeditor-image.ddev.site/typo3/
# Username: admin | Password: Password:joh316

# Verify services
docker ps --filter "name=ddev-rte-ckeditor-image"
```

## Documentation

See `.ddev/README-SERVICES.md` for:
- Service configuration details
- Performance tuning options
- Troubleshooting common issues
- Redis cache setup
- MailPit usage
- Ofelia scheduler configuration