### PR TITLE
fix: allow empty width/height input during typing

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -165,7 +165,11 @@ function getImageDialog(editor, img, attributes) {
                 };
 
                 $el.on('input', function () {
-                    constrainDimensions(1);
+                    // Allow empty input during typing (fixes #140)
+                    var val = $el.val().replace(/[^0-9]/g, '');
+                    if (val !== '') {
+                        constrainDimensions(1);
+                    }
                 });
                 $el.on('change', function () {
                     constrainDimensions(min);


### PR DESCRIPTION
Fixes #140

## Problem

Users cannot delete all numbers from width/height fields before entering a new value. The field immediately repopulates with the original image dimensions when emptied, making it impossible to clear the field and type fresh values.

**Current UX Problem:**
- User tries to delete "1920" to type "800"  
- Deletes "0" → Field shows "192"
- Deletes "2" → Field shows "19"
- Deletes "9" → Field shows "1"
- Deletes "1" → **Field immediately shows "1920" again\!** 😞

**Workaround:** Users must use Ctrl+A (select all) then type the new value

## Root Cause

The `constrainDimensions` function runs on every keystroke (via `input` event). When the field becomes empty:

```javascript
value = parseInt($el.val().replace(/[^0-9]/g, '') || max);
```

- `parseInt("")` returns `NaN`
- The `|| max` fallback immediately restores original dimensions
- This happens on EVERY keystroke, preventing deletion

## Solution

Allow empty input during typing while still enforcing minimum values when editing completes:

```javascript
$el.on('input', function () {
    // Allow empty input during typing (fixes #140)
    var val = $el.val().replace(/[^0-9]/g, '');
    if (val \!== '') {
        constrainDimensions(1);
    }
});
```

The `change` event (fires on blur) still enforces minimum values, so validation is maintained.

## Testing Steps

1. Open image properties dialog in CKEditor
2. Focus on width or height field
3. Delete all numbers one by one
4. **Expected:** Field stays empty during deletion
5. Type new value (e.g., "800")
6. **Expected:** Value is constrained properly
7. Blur field
8. **Expected:** Minimum value enforcement still works

## Impact

- **Severity:** Low (workaround exists with Ctrl+A)
- **UX Impact:** Moderate improvement (natural editing behavior)
- **Versions Affected:** All (v10, v11, v12, v13)
- **Breaking Changes:** None
- **Backwards Compatible:** Yes ✅

## Technical Details

**File Changed:** `Resources/Public/JavaScript/Plugins/typo3image.js`  
**Lines Changed:** 5 insertions, 1 deletion  
**Validation:** Minimum value enforcement still works via `change` event