### PR TITLE
fix: preserve remote storage URLs (S3, Azure, CDN) in RTE

### DIFF
--- a/Classes/Controller/SelectImageController.php
+++ b/Classes/Controller/SelectImageController.php
@@ -136,13 +136,14 @@ class SelectImageController extends ElementBrowserController
         $processedFile = $this->processImage($file, $params, $maxDimensions);
 
         return new JsonResponse([
-            'uid'       => $file->getUid(),
-            'alt'       => $file->getProperty('alternative') ?? '',
-            'title'     => $file->getProperty('title') ?? '',
-            'width'     => min($file->getProperty('width'), $maxDimensions['width']),
-            'height'    => min($file->getProperty('height'), $maxDimensions['height']),
-            'url'       => $file->getPublicUrl(),
-            'processed' => [
+            'uid'           => $file->getUid(),
+            'alt'           => $file->getProperty('alternative') ?? '',
+            'title'         => $file->getProperty('title') ?? '',
+            'width'         => min($file->getProperty('width'), $maxDimensions['width']),
+            'height'        => min($file->getProperty('height'), $maxDimensions['height']),
+            'url'           => $file->getPublicUrl(),
+            'storageDriver' => $file->getStorage()->getDriverType(),
+            'processed'     => [
                 'width'  => $processedFile->getProperty('width'),
                 'height' => $processedFile->getProperty('height'),
                 'url'    => $processedFile->getPublicUrl(),

--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -32,18 +32,26 @@ class DoubleClickObserver extends Engine.DomEventObserver {
 
 
 /**
+ * Convert URL to relative format for local storage only.
+ * Remote storage URLs (S3, Azure, CDN) must remain absolute.
  *
  * @param url
- * @return relativeUrl
+ * @param storageDriver The TYPO3 storage driver type (e.g., 'Local', 'S3')
+ * @return relativeUrl for local storage, absolute URL for remote storage
  */
-function urlToRelative(url) {
-
-    // check for absolute URL first
+function urlToRelative(url, storageDriver) {
 
     if (!url) {
         return;
     }
 
+    // Only convert to relative for Local storage
+    // Remote storages (S3, Azure, CDN) must remain absolute
+    if (storageDriver && storageDriver !== 'Local') {
+        return url;
+    }
+
+    // Convert local storage URLs to relative for site portability
     if (url.indexOf("http://") !== -1 || url.indexOf("https://") !== -1) {
         var u = new URL(url);
         return u.pathname + u.search;
@@ -310,7 +318,7 @@ function askImageAttributes(editor, img, attributes, table) {
                         .then(function (getImg) {
 
                             $.extend(filteredAttr, {
-                                src: urlToRelative(getImg.url),
+                                src: urlToRelative(getImg.url, getImg.storageDriver),
                                 width: getImg.processed.width || getImg.width,
                                 height: getImg.processed.height || getImg.height,
                                 fileUid: img.uid,


### PR DESCRIPTION
## Summary

Fixes #156 - Images from remote storage (S3, CDN, Azure) are broken because `urlToRelative()` strips all hostnames indiscriminately.

## Problem

In TYPO3 v11+, `getPublicUrl()` returns absolute URLs. The `urlToRelative()` function (added in commit 29947f5 for TYPO3 11.5 support) converts all absolute URLs to relative paths to maintain site portability for local storage. However, it blindly strips ALL hostnames, including remote storage URLs:

**Before (broken):**
- Input: `https://s3.amazonaws.com/bucket/image.jpg`
- Output: `/bucket/image.jpg` ❌ (invalid local path)

## Solution

Use TYPO3's storage driver architecture to distinguish local from remote storage:

**Backend (SelectImageController.php):**
- Include `storageDriver` type in JSON response

**Frontend (typo3image.js):**
- Only convert URLs to relative for `Local` storage driver
- Keep URLs absolute for remote drivers (S3, Azure, etc.)

**After (fixed):**
- Local storage: `https://example.com/fileadmin/img.jpg` → `/fileadmin/img.jpg` ✅
- Remote storage: `https://s3.amazonaws.com/bucket/img.jpg` → unchanged ✅

## Benefits

- ✅ Maintains site portability for local files (relative URLs)
- ✅ Preserves remote storage URLs (absolute required)
- ✅ Multi-domain TYPO3 compatible (no hostname checking)
- ✅ Follows TYPO3 architecture (driver-based detection)

## Testing

Tested with:
- Local storage (fileadmin) - URLs converted to relative ✅
- Remote storage detection logic - non-Local drivers keep absolute URLs ✅