### PR TITLE
[BUGFIX] Add backend CSS for image scaling in Page module

### DIFF
--- a/Resources/Public/Css/backend.css
+++ b/Resources/Public/Css/backend.css
@@ -1,0 +1,11 @@
+/**
+ * Backend preview styling for RTE CKEditor images
+ *
+ * Fixes issue #301: Images are not scaled in Page module
+ * This CSS rule is provided by TYPO3 core in v12+ but missing in v11,
+ * so we provide it here for v11 compatibility.
+ */
+.t3-page-ce-body img {
+    max-width: 100%;
+    height: auto;
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -14,6 +14,10 @@ defined('TYPO3_MODE') or die();
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_parsehtml_proc.php']['transformation']['rtehtmlarea_images_db']
     = \Netresearch\RteCKEditorImage\Database\RteImagesDbHook::class;
 
+// Register backend CSS for image preview scaling (fixes #301)
+$GLOBALS['TYPO3_CONF_VARS']['BE']['stylesheets']['rte_ckeditor_image'] =
+    'EXT:rte_ckeditor_image/Resources/Public/Css/backend.css';
+
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
     'RTE.default.proc.overruleMode := addToList(default)'
 );


### PR DESCRIPTION
## Description

Fixes #301

Images inserted via RTE CKEditor were displayed at full size in the TYPO3 backend Page module, causing them to overflow the preview area. This PR adds the missing CSS rule to ensure images are automatically scaled to fit within the preview container.

## Root Cause

The CSS rule `.t3-page-ce-body img {max-width: 100%; height: auto}` is provided by TYPO3 core in **v12+** but is **missing in v11**. This causes images to display at their original size without any constraints.

## Solution

Added `Resources/Public/Css/backend.css` with the scaling rule and registered it in `ext_localconf.php` to be loaded in the backend.

## Changes

- ✅ Created `Resources/Public/Css/backend.css` with image scaling CSS
- ✅ Registered CSS file in `ext_localconf.php`
- ✅ Added documentation explaining this is a v11-specific fix

## Testing

1. Install extension from this branch in TYPO3 v11.5 instance
2. Add image to RTE content element in Page module
3. Verify images now scale to fit preview area (max-width: 100%)
4. Check browser dev tools - `.t3-page-ce-body img` CSS rule should be present

## Version Compatibility

| TYPO3 Version | Status | Notes |
|---------------|--------|-------|
| v11 | ✅ **Fixed by this PR** | CSS rule missing in core, provided by extension |
| v12 | ✅ Already works | TYPO3 core provides CSS rule |
| v13 | ✅ Already works | TYPO3 core provides CSS rule |

## References

- Issue: #301
- Reported for: TYPO3 11.5.40 with extension v11.0.15
- Related: #251 (RTE image preview issues in v11)

## Checklist

- [x] Code follows project conventions
- [x] Commit message follows format
- [x] Targets TYPO3_11 branch (v11-specific fix)
- [x] No breaking changes
- [x] Documentation included in CSS comments

---

**Note:** This fix is only needed for TYPO3 v11. Users on v12/v13 do not need this change as TYPO3 core already provides the CSS rule.