### PR TITLE
fix: inject ElementBrowserRegistry in SelectImageController

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -217,12 +217,6 @@ parameters:
 			path: ../Classes/Controller/SelectImageController.php
 
 		-
-			message: '#^Netresearch\\RteCKEditorImage\\Controller\\SelectImageController\:\:__construct\(\) does not call parent constructor from TYPO3\\CMS\\Backend\\Controller\\ElementBrowserController\.$#'
-			identifier: constructor.missingParentCall
-			count: 1
-			path: ../Classes/Controller/SelectImageController.php
-
-		-
 			message: '#^Parameter \#1 \$params of method Netresearch\\RteCKEditorImage\\Controller\\SelectImageController\:\:getMaxDimensions\(\) expects array\<string\>, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/Classes/Controller/SelectImageController.php
+++ b/Classes/Controller/SelectImageController.php
@@ -16,6 +16,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use TYPO3\CMS\Backend\Controller\ElementBrowserController;
+use TYPO3\CMS\Backend\ElementBrowser\ElementBrowserRegistry;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Http\Response;
@@ -60,11 +61,15 @@ class SelectImageController extends ElementBrowserController
     /**
      * Constructor with dependency injection.
      *
-     * @param ResourceFactory $resourceFactory Factory for file resources
+     * @param ResourceFactory        $resourceFactory        Factory for file resources
+     * @param ElementBrowserRegistry $elementBrowserRegistry Registry for element browsers (required by parent)
      */
     public function __construct(
         private readonly ResourceFactory $resourceFactory,
-    ) {}
+        ElementBrowserRegistry $elementBrowserRegistry,
+    ) {
+        parent::__construct($elementBrowserRegistry);
+    }
 
     /**
      * Forward to infoAction if wanted.

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -13,6 +13,7 @@ services:
     tags: ['backend.controller']
     arguments:
       $resourceFactory: '@TYPO3\CMS\Core\Resource\ResourceFactory'
+      $elementBrowserRegistry: '@TYPO3\CMS\Backend\ElementBrowser\ElementBrowserRegistry'
 
   Netresearch\RteCKEditorImage\Controller\ImageLinkRenderingController:
     public: true

--- a/Tests/Unit/Controller/SelectImageControllerTest.php
+++ b/Tests/Unit/Controller/SelectImageControllerTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ServerRequestInterface;
 use ReflectionMethod;
 use RuntimeException;
+use TYPO3\CMS\Backend\ElementBrowser\ElementBrowserRegistry;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\ProcessedFile;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
@@ -44,8 +45,14 @@ final class SelectImageControllerTest extends UnitTestCase
         /** @var ResourceFactory&MockObject $resourceFactoryMock */
         $resourceFactoryMock = $this->createMock(ResourceFactory::class);
 
+        /** @var ElementBrowserRegistry&MockObject $elementBrowserRegistryMock */
+        $elementBrowserRegistryMock = $this->createMock(ElementBrowserRegistry::class);
+
         $this->resourceFactoryMock = $resourceFactoryMock;
-        $this->subject             = new SelectImageController($this->resourceFactoryMock);
+        $this->subject             = new SelectImageController(
+            $this->resourceFactoryMock,
+            $elementBrowserRegistryMock,
+        );
     }
 
     /**


### PR DESCRIPTION
## Problem

Clicking the image selector icon in backend CKEditor results in error:
```
Typed property ElementBrowserController::$elementBrowserRegistry 
must not be accessed before initialization
```

## Root Cause

`SelectImageController` extends `ElementBrowserController` which requires `ElementBrowserRegistry` to be injected via constructor in TYPO3 13. This dependency was missing, causing the property to remain uninitialized when `parent::mainAction()` was called.

## Solution

- ✅ Add `ElementBrowserRegistry` parameter to `SelectImageController` constructor
- ✅ Call `parent::__construct()` to properly initialize parent class
- ✅ Configure DI in `Services.yaml` to inject `ElementBrowserRegistry`
- ✅ Update `SelectImageControllerTest` to mock `ElementBrowserRegistry`
- ✅ Remove obsolete PHPStan baseline entry for missing parent constructor

## Testing

After clearing TYPO3 cache (`vendor/bin/typo3 cache:flush`), the image selector icon in backend CKEditor now works correctly.

## Files Changed

- `Classes/Controller/SelectImageController.php` - Add DI and parent constructor call
- `Configuration/Services.yaml` - Configure ElementBrowserRegistry injection
- `Tests/Unit/Controller/SelectImageControllerTest.php` - Update test setup
- `Build/phpstan-baseline.neon` - Remove obsolete baseline entry

Resolves image selector functionality in TYPO3 13 backend.