### PR TITLE
fix: add missing DefaultUploadFolderResolver to SelectImageController DI config

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -13,6 +13,7 @@ services:
     tags: ['backend.controller']
     arguments:
       $resourceFactory: '@TYPO3\CMS\Core\Resource\ResourceFactory'
+      $uploadFolderResolver: '@TYPO3\CMS\Core\Resource\DefaultUploadFolderResolver'
       $elementBrowserRegistry: '@TYPO3\CMS\Backend\ElementBrowser\ElementBrowserRegistry'
 
   Netresearch\RteCKEditorImage\Controller\ImageLinkRenderingController:


### PR DESCRIPTION
## Summary
Fixes missing dependency injection configuration for `DefaultUploadFolderResolver` in `SelectImageController`, which caused a `TypeError` when accessing the RTE image selector.

## Problem
After PR #374 was merged, clicking the image button in the RTE backend resulted in:
```
TypeError: SelectImageController::__construct(): Argument #2 ($uploadFolderResolver) 
must be of type TYPO3\CMS\Core\Resource\DefaultUploadFolderResolver, 
TYPO3\CMS\Backend\ElementBrowser\ElementBrowserRegistry given
```

## Root Cause
During the rebase of PR #374, the constructor was correctly updated with three parameters:
1. `ResourceFactory`
2. `DefaultUploadFolderResolver` (new)
3. `ElementBrowserRegistry`

However, the `Services.yaml` DI configuration was not updated to include the new middle parameter (`$uploadFolderResolver`), causing TYPO3's DI container to inject dependencies in the wrong order.

## Solution
Added the missing `$uploadFolderResolver` argument configuration to `Services.yaml`:
```yaml
arguments:
  $resourceFactory: '@TYPO3\CMS\Core\Resource\ResourceFactory'
  $uploadFolderResolver: '@TYPO3\CMS\Core\Resource\DefaultUploadFolderResolver'  # ← Added
  $elementBrowserRegistry: '@TYPO3\CMS\Backend\ElementBrowser\ElementBrowserRegistry'
```

## Technical Details
- The DI container now correctly injects all three dependencies in the proper order
- This fix ensures non-admin users can access the image selector (from PR #374)
- Requires cache clear after deployment: `vendor/bin/typo3 cache:flush` or via backend

## Testing
✅ Tested in TYPO3 v13 backend
✅ Image selector opens without TypeError
✅ Both admin and non-admin users can select images
✅ All quality checks passed

## Related
- Fixes regression introduced during PR #374 rebase
- Complements fix for #290 (non-admin image selector access)

## Deployment Notes
⚠️ **Cache clear required** after deploying this fix:
- Via CLI: `vendor/bin/typo3 cache:flush`
- Via Backend: Admin Tools → Maintenance → Flush TYPO3 and PHP Cache
- Via Install Tool: Maintenance → Flush all caches