### PR TITLE
fix: add link toolbar configuration to prevent linkProperties error

### DIFF
--- a/Configuration/RTE/Plugin.yaml
+++ b/Configuration/RTE/Plugin.yaml
@@ -4,6 +4,13 @@ editor:
     importModules:
       -  '@netresearch/rte-ckeditor-image/Plugins/typo3image.js'
 
+    # Fix linkProperties error: CKEditor 5 default includes 'linkProperties'
+    # but TYPO3's Typo3Link plugin doesn't provide it
+    link:
+      decorators: []
+      # Override default toolbar to remove 'linkProperties'
+      toolbar: ['linkPreview', '|', 'editLink', 'unlink']
+
   externalPlugins:
     typo3image: { route: "rteckeditorimage_wizard_select_image" }
 


### PR DESCRIPTION
## Problem

CKEditor 5's default link configuration includes a `linkProperties` button in the toolbar, but TYPO3's `Typo3Link` plugin doesn't provide this button, causing console errors:

```
toolbarview-item-unavailable {item: 'linkProperties'}
```

This happens because:
- CKEditor 5's core link plugin defines: `toolbar: ["linkPreview", "|", "editLink", "linkProperties", "unlink"]`
- TYPO3's Typo3Link plugin only provides: `linkPreview`, `editLink`, `unlink` (no `linkProperties`)

## Solution

This PR adds explicit link toolbar configuration to `Configuration/RTE/Plugin.yaml` that overrides CKEditor's default to only include the buttons that TYPO3's Typo3Link plugin actually provides:

- `linkPreview`
- `editLink`
- `unlink`

## Impact

- ✅ Fixes console error `toolbarview-item-unavailable`
- ✅ No functional changes - same buttons are available
- ✅ Not extension-specific - this affects any TYPO3 site using TYPO3's custom link system

## Testing

1. Open any RTE with the image plugin enabled
2. Use link functionality
3. Check browser console - no `linkProperties` error should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)