### PR TITLE
fix: namespace DoubleClickObserver to prevent conflicts with other plugins

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -20,7 +20,7 @@ import { default as Modal } from '@typo3/backend/modal.js';
 import $ from 'jquery';
 
 
-class DoubleClickObserver extends DomEventObserver {
+class Typo3ImageDoubleClickObserver extends DomEventObserver {
     constructor(view) {
         super(view);
 
@@ -28,7 +28,7 @@ class DoubleClickObserver extends DomEventObserver {
     }
 
     onDomEvent(domEvent) {
-        this.fire(domEvent.type, domEvent);
+        this.fire('dblclick:typo3image', domEvent);
     }
 }
 
@@ -552,7 +552,7 @@ export default class Typo3Image extends Plugin {
             }
         })
 
-        editor.editing.view.addObserver(DoubleClickObserver);
+        editor.editing.view.addObserver(Typo3ImageDoubleClickObserver);
 
         editor.model.schema.register('typo3image', {
             inheritAllFrom: '$blockObject',
@@ -723,7 +723,7 @@ export default class Typo3Image extends Plugin {
             }
         })
 
-        editor.listenTo(editor.editing.view.document, 'dblclick', (event, data) => {
+        editor.listenTo(editor.editing.view.document, 'dblclick:typo3image', (event, data) => {
             const modelElement = editor.editing.mapper.toModelElement(data.target);
             if (modelElement && modelElement.name === 'typo3image') {
                 // Select the clicked element


### PR DESCRIPTION
## Problem

Fixes #332

The generic `DoubleClickObserver` was causing conflicts with other CKEditor plugins (like [iconpack](https://github.com/quellenform/t3x-iconpack)) that also implement `DomEventObserver` for double-clicks. This resulted in modals/dialogs being triggered multiple times when both plugins were installed.

## Root Cause

Multiple plugins registering global `dblclick` event handlers caused all handlers to fire for the same event, even though each plugin only wanted to handle its own element type.

## Solution

This PR follows the same solution implemented by the iconpack extension in [commit 7e46c82](https://github.com/quellenform/t3x-iconpack/commit/7e46c823434e37428ca0861f15b4d8041ebf9bde):

### Changes:
1. **Renamed class**: `DoubleClickObserver` → `Typo3ImageDoubleClickObserver`
2. **Namespaced event**: `fire('dblclick')` → `fire('dblclick:typo3image')`
3. **Updated listener**: `'dblclick'` → `'dblclick:typo3image'`

This creates a plugin-specific event namespace that prevents interference with other plugins' double-click handlers.

## Impact

- ✅ Fixes modal/dialog duplication when used with other plugins
- ✅ No functional changes - double-click behavior remains the same
- ✅ Follows the established pattern from iconpack extension
- ✅ Backward compatible - only affects event naming internally

## Testing

1. Install both this extension and iconpack extension
2. Double-click on an image in the editor
3. Verify only one modal opens (not multiple)
4. Double-click on an icon
5. Verify only the icon modal opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)