### PR TITLE
fix(i18n): translate 18 language files with native translations

### DIFF
--- a/Resources/Private/Language/af.locallang_be.xlf
+++ b/Resources/Private/Language/af.locallang_be.xlf
@@ -5,75 +5,75 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>Aangepaste CSS-klas</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>Wydte</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>Hoogte</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>Adviserende titel</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>Alternatiewe teks</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>Klik om te vergroot</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>Geaktiveer</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>Slaan beeldverwerking oor</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>Beeldeienskappe</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>Kanselleer</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>Stoor</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>Voeg beeld in</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>Geen verstek %s beskikbaar in lêermetadata nie. Kan nie leë waarde oorskryf nie.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>Aktiveer klik-om-te-vergroot/ligboks-funksionaliteit. Verstek opspringvenster-konfigurasie word outomaties verskaf. Sien dokumentasie vir aangepaste ligboks-biblioteekintegrasie.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>Slaan beeldverwerking oor en gebruik die oorspronklike lêer. Nuttig vir nuusbriewe, PDF's, maksimum resolusie-skerms en SVG-grafika. Konfigureer globaal via TypoScript of aktiveer per beeld.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>Beeldkwaliteit</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>Geen skaalverandering</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
-				<target>Standard (1.0x)</target>
+				<target>Standaard (1.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina" xml:space="preserve">
 				<source>Retina (2.0x)</source>
@@ -85,23 +85,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>Druk (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>Laag</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>Lae kwaliteit (%sx) - Beeld kan vaag voorkom</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
-				<target>Standard</target>
+				<target>Standaard</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>Standaard kwaliteit (%sx) - Skerp op basiese skerms</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,7 +109,7 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>Retina-kwaliteit (%sx) - Optimaal vir moderne skerms</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
@@ -117,23 +117,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>Ultra-kwaliteit (%sx) - Vir ultra-hoë DPI of klein druk</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>Druk</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>Drukkwaliteit (%sx) - Geskik vir hoëkwaliteit-drukwerk (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>Oormatig</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>Oormatige resolusie (%sx) - Onnodig hoog</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/ar.locallang_be.xlf
+++ b/Resources/Private/Language/ar.locallang_be.xlf
@@ -5,135 +5,135 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>فئة CSS مخصصة</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>العرض</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>الارتفاع</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>العنوان الاستشاري</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>نص بديل</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>انقر للتكبير</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>مفعّل</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>تخطي معالجة الصورة</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>خصائص الصورة</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>إلغاء</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>حفظ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>إدراج صورة</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>لا يوجد %s افتراضي متاح في بيانات الملف. لا يمكن تجاوز القيمة الفارغة.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>يتيح وظيفة النقر للتكبير/صندوق الإضاءة. يتم توفير تكوين النافذة المنبثقة الافتراضية تلقائيًا. راجع الوثائق لدمج مكتبة صندوق الإضاءة المخصصة.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>يتخطى معالجة الصورة ويستخدم الملف الأصلي. مفيد للنشرات الإخبارية وملفات PDF وشاشات الدقة القصوى ورسومات SVG. قم بالتكوين عالميًا عبر TypoScript أو قم بالتمكين لكل صورة.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>جودة الصورة</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>بدون تحجيم</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
-				<target>Standard (1.0x)</target>
+				<target>قياسي (1.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina" xml:space="preserve">
 				<source>Retina (2.0x)</source>
-				<target>Retina (2.0x)</target>
+				<target>ريتينا (2.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra" xml:space="preserve">
 				<source>Ultra (3.0x)</source>
-				<target>Ultra (3.0x)</target>
+				<target>فائق (3.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>طباعة (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>منخفض</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>جودة منخفضة (%sx) - قد تظهر الصورة غير واضحة</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
-				<target>Standard</target>
+				<target>قياسي</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>جودة قياسية (%sx) - واضح على الشاشات الأساسية</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
-				<target>Retina</target>
+				<target>ريتينا</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>جودة ريتينا (%sx) - مثالية للشاشات الحديثة</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
-				<target>Ultra</target>
+				<target>فائق</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>جودة فائقة (%sx) - لنقاط DPI فائقة العالية أو الطباعة الصغيرة</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>طباعة</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>جودة الطباعة (%sx) - مناسبة للطباعة عالية الجودة (300 نقطة لكل بوصة)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>مفرط</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>دقة مفرطة (%sx) - عالية بشكل غير ضروري</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/cs.locallang_be.xlf
+++ b/Resources/Private/Language/cs.locallang_be.xlf
@@ -5,75 +5,75 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>Vlastní CSS třída</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>Šířka</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>Výška</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>Poradní titulek</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>Alternativní text</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>Kliknutím zvětšíte</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>Povoleno</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>Přeskočit zpracování obrázku</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>Vlastnosti obrázku</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>Zrušit</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>Uložit</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>Vložit obrázek</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>V metadatech souboru není k dispozici výchozí %s. Nelze přepsat prázdnou hodnotu.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>Umožňuje funkci zvětšení po kliknutí/lightbox. Výchozí konfigurace vyskakovacího okna je poskytována automaticky. Pro vlastní integraci knihovny lightbox viz dokumentace.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>Přeskočí zpracování obrázku a použije původní soubor. Užitečné pro newslettery, PDF, displeje s maximálním rozlišením a grafiku SVG. Konfigurujte globálně přes TypoScript nebo aktivujte pro jednotlivé obrázky.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>Kvalita obrázku</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>Bez škálování</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
-				<target>Standard (1.0x)</target>
+				<target>Standardní (1.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina" xml:space="preserve">
 				<source>Retina (2.0x)</source>
@@ -85,23 +85,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>Tisk (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>Nízká</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>Nízká kvalita (%sx) - Obrázek může být rozmazaný</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
-				<target>Standard</target>
+				<target>Standardní</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>Standardní kvalita (%sx) - Ostrý na základních displejích</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,7 +109,7 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>Kvalita Retina (%sx) - Optimální pro moderní displeje</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
@@ -117,23 +117,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>Ultra kvalita (%sx) - Pro ultra-vysoké DPI nebo malý tisk</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>Tisk</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>Kvalita tisku (%sx) - Vhodné pro vysoce kvalitní tisk (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>Přehnané</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>Přehnané rozlišení (%sx) - Zbytečně vysoké</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/da.locallang_be.xlf
+++ b/Resources/Private/Language/da.locallang_be.xlf
@@ -5,71 +5,71 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>Brugerdefineret CSS-klasse</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>Bredde</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>Højde</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>Rådgivende titel</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>Alternativ tekst</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>Klik for at forstørre</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>Aktiveret</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>Spring billedbehandling over</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>Billedegenskaber</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>Annuller</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>Gem</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>Indsæt billede</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>Ingen standard %s tilgængelig i filmetadata. Kan ikke overskrive tom værdi.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>Aktiverer klik-for-at-forstørre/lightbox funktionalitet. Standard popup-konfiguration leveres automatisk. Se dokumentation for brugerdefineret lightbox-biblioteksintegration.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>Springer billedbehandling over og bruger den originale fil. Nyttigt til nyhedsbreve, PDF'er, skærme med maksimal opløsning og SVG-grafik. Konfigurer globalt via TypoScript eller aktiver pr. billede.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>Billedkvalitet</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>Ingen skalering</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
@@ -89,11 +89,11 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>Lav</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>Lav kvalitet (%sx) - Billede kan virke sløret</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
@@ -101,7 +101,7 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>Standard kvalitet (%sx) - Skarp på grundlæggende skærme</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,7 +109,7 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>Retina kvalitet (%sx) - Optimal til moderne skærme</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
@@ -117,7 +117,7 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>Ultra kvalitet (%sx) - Til ultra-høj DPI eller lille print</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
@@ -125,15 +125,15 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>Print kvalitet (%sx) - Egnet til print i høj kvalitet (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>Overdreven</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>Overdreven opløsning (%sx) - Unødvendigt høj</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/fi.locallang_be.xlf
+++ b/Resources/Private/Language/fi.locallang_be.xlf
@@ -5,75 +5,75 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>Mukautettu CSS-luokka</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>Leveys</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>Korkeus</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>Neuvoa-antava otsikko</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>Vaihtoehtoinen teksti</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>Napsauta suurentaaksesi</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>Käytössä</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>Ohita kuvankäsittely</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>Kuvan ominaisuudet</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>Peruuta</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>Tallenna</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>Lisää kuva</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>Ei oletusarvoa %s saatavilla tiedoston metatiedoissa. Tyhjää arvoa ei voi ohittaa.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>Ottaa käyttöön napsauta-suurentaaksesi/lightbox-toiminnon. Ponnahdusikkunan oletuskonfiguraatio toimitetaan automaattisesti. Katso dokumentaatio mukautetun lightbox-kirjaston integroinnista.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>Ohittaa kuvankäsittelyn ja käyttää alkuperäistä tiedostoa. Hyödyllinen uutiskirjeille, PDF-tiedostoille, maksimitarkkuuden näytöille ja SVG-grafiikalle. Määritä globaalisti TypoScriptin kautta tai ota käyttöön kuvaa kohden.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>Kuvan laatu</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>Ei skaalausta</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
-				<target>Standard (1.0x)</target>
+				<target>Standardi (1.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina" xml:space="preserve">
 				<source>Retina (2.0x)</source>
@@ -85,23 +85,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>Tulostus (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>Matala</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>Matala laatu (%sx) - Kuva voi näyttää epäterävältä</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
-				<target>Standard</target>
+				<target>Standardi</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>Standardi laatu (%sx) - Terävä perusnäytöillä</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,7 +109,7 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>Retina-laatu (%sx) - Optimaalinen moderneille näytöille</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
@@ -117,23 +117,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>Ultra-laatu (%sx) - Erittäin korkealle DPI:lle tai pienelle tulosteelle</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>Tulostus</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>Tulostuslaatu (%sx) - Sopii korkealaatuiseen tulostukseen (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>Liiallinen</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>Liiallinen tarkkuus (%sx) - Tarpeettoman korkea</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/hi.locallang_be.xlf
+++ b/Resources/Private/Language/hi.locallang_be.xlf
@@ -5,135 +5,135 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>कस्टम CSS वर्ग</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>चौड़ाई</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>ऊंचाई</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>सलाहकार शीर्षक</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>वैकल्पिक पाठ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>बड़ा करने के लिए क्लिक करें</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>सक्षम</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>छवि प्रसंस्करण छोड़ें</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>छवि गुण</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>रद्द करें</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>सहेजें</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>छवि डालें</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>फ़ाइल मेटाडेटा में कोई डिफ़ॉल्ट %s उपलब्ध नहीं है। खाली मान को ओवरराइड नहीं कर सकते।</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>क्लिक-टू-एनलार्ज/लाइटबॉक्स कार्यक्षमता सक्षम करता है। डिफ़ॉल्ट पॉपअप कॉन्फ़िगरेशन स्वचालित रूप से प्रदान किया जाता है। कस्टम लाइटबॉक्स लाइब्रेरी एकीकरण के लिए दस्तावेज़ देखें।</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>छवि प्रसंस्करण को छोड़ता है और मूल फ़ाइल का उपयोग करता है। समाचार पत्र, पीडीएफ, अधिकतम रिज़ॉल्यूशन डिस्प्ले और एसवीजी ग्राफिक्स के लिए उपयोगी। TypoScript के माध्यम से वैश्विक रूप से कॉन्फ़िगर करें या प्रति-छवि सक्षम करें।</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>छवि गुणवत्ता</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>कोई स्केलिंग नहीं</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
-				<target>Standard (1.0x)</target>
+				<target>मानक (1.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina" xml:space="preserve">
 				<source>Retina (2.0x)</source>
-				<target>Retina (2.0x)</target>
+				<target>रेटिना (2.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra" xml:space="preserve">
 				<source>Ultra (3.0x)</source>
-				<target>Ultra (3.0x)</target>
+				<target>अल्ट्रा (3.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>प्रिंट (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>कम</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>कम गुणवत्ता (%sx) - छवि धुंधली दिखाई दे सकती है</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
-				<target>Standard</target>
+				<target>मानक</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>मानक गुणवत्ता (%sx) - बुनियादी डिस्प्ले पर तेज</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
-				<target>Retina</target>
+				<target>रेटिना</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>रेटिना गुणवत्ता (%sx) - आधुनिक डिस्प्ले के लिए इष्टतम</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
-				<target>Ultra</target>
+				<target>अल्ट्रा</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>अल्ट्रा गुणवत्ता (%sx) - अल्ट्रा-हाई डीपीआई या छोटे प्रिंट के लिए</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>प्रिंट</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>प्रिंट गुणवत्ता (%sx) - उच्च गुणवत्ता वाले मुद्रण के लिए उपयुक्त (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>अत्यधिक</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>अत्यधिक रिज़ॉल्यूशन (%sx) - अनावश्यक रूप से उच्च</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/id.locallang_be.xlf
+++ b/Resources/Private/Language/id.locallang_be.xlf
@@ -5,75 +5,75 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>Kelas CSS kustom</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>Lebar</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>Tinggi</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>Judul penasihat</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>Teks alternatif</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>Klik untuk memperbesar</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>Diaktifkan</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>Lewati pemrosesan gambar</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>Properti gambar</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>Batal</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>Simpan</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>Sisipkan gambar</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>Tidak ada %s default tersedia dalam metadata file. Tidak dapat menimpa nilai kosong.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>Mengaktifkan fungsi klik-untuk-memperbesar/lightbox. Konfigurasi popup default disediakan secara otomatis. Lihat dokumentasi untuk integrasi perpustakaan lightbox kustom.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>Melewati pemrosesan gambar dan menggunakan file asli. Berguna untuk newsletter, PDF, tampilan resolusi maksimum, dan grafik SVG. Konfigurasi secara global melalui TypoScript atau aktifkan per gambar.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>Kualitas gambar</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>Tanpa penskalaan</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
-				<target>Standard (1.0x)</target>
+				<target>Standar (1.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina" xml:space="preserve">
 				<source>Retina (2.0x)</source>
@@ -85,23 +85,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>Cetak (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>Rendah</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>Kualitas rendah (%sx) - Gambar mungkin tampak buram</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
-				<target>Standard</target>
+				<target>Standar</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>Kualitas standar (%sx) - Tajam pada tampilan dasar</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,7 +109,7 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>Kualitas Retina (%sx) - Optimal untuk tampilan modern</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
@@ -117,23 +117,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>Kualitas Ultra (%sx) - Untuk DPI ultra-tinggi atau cetakan kecil</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>Cetak</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>Kualitas cetak (%sx) - Cocok untuk pencetakan berkualitas tinggi (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>Berlebihan</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>Resolusi berlebihan (%sx) - Terlalu tinggi</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/ja.locallang_be.xlf
+++ b/Resources/Private/Language/ja.locallang_be.xlf
@@ -5,75 +5,75 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>カスタムCSSクラス</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>幅</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>高さ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>アドバイザリータイトル</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>代替テキスト</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>クリックして拡大</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>有効</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>画像処理をスキップ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>画像プロパティ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>キャンセル</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>保存</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>画像を挿入</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>ファイルメタデータにデフォルトの%sがありません。空の値を上書きできません。</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>クリック拡大/ライトボックス機能を有効にします。デフォルトのポップアップ設定は自動的に提供されます。カスタムライトボックスライブラリ統合については、ドキュメントを参照してください。</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>画像処理をスキップして元のファイルを使用します。ニュースレター、PDF、最大解像度ディスプレイ、およびSVGグラフィックスに役立ちます。TypoScriptでグローバルに設定するか、画像ごとに有効にします。</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>画像品質</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>スケーリングなし</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
-				<target>Standard (1.0x)</target>
+				<target>標準 (1.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina" xml:space="preserve">
 				<source>Retina (2.0x)</source>
@@ -81,27 +81,27 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra" xml:space="preserve">
 				<source>Ultra (3.0x)</source>
-				<target>Ultra (3.0x)</target>
+				<target>ウルトラ (3.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>印刷 (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>低</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>低品質 (%sx) - 画像がぼやけて見える場合があります</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
-				<target>Standard</target>
+				<target>標準</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>標準品質 (%sx) - 基本ディスプレイで鮮明</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,31 +109,31 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>Retina品質 (%sx) - 最新ディスプレイに最適</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
-				<target>Ultra</target>
+				<target>ウルトラ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>ウルトラ品質 (%sx) - 超高DPIまたは小さな印刷用</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>印刷</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>印刷品質 (%sx) - 高品質印刷に適しています (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>過剰</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>過剰な解像度 (%sx) - 不必要に高い</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/ko.locallang_be.xlf
+++ b/Resources/Private/Language/ko.locallang_be.xlf
@@ -5,75 +5,75 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>사용자 정의 CSS 클래스</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>너비</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>높이</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>권고 제목</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>대체 텍스트</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>클릭하여 확대</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>활성화됨</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>이미지 처리 건너뛰기</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>이미지 속성</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>취소</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>저장</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>이미지 삽입</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>파일 메타데이터에 기본 %s를 사용할 수 없습니다. 빈 값을 재정의할 수 없습니다.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>클릭하여 확대/라이트박스 기능을 활성화합니다. 기본 팝업 구성이 자동으로 제공됩니다. 사용자 정의 라이트박스 라이브러리 통합은 문서를 참조하십시오.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>이미지 처리를 건너뛰고 원본 파일을 사용합니다. 뉴스레터, PDF, 최대 해상도 디스플레이 및 SVG 그래픽에 유용합니다. TypoScript를 통해 전역으로 구성하거나 이미지별로 활성화합니다.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>이미지 품질</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>배율 없음</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
-				<target>Standard (1.0x)</target>
+				<target>표준 (1.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina" xml:space="preserve">
 				<source>Retina (2.0x)</source>
@@ -81,27 +81,27 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra" xml:space="preserve">
 				<source>Ultra (3.0x)</source>
-				<target>Ultra (3.0x)</target>
+				<target>울트라 (3.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>인쇄 (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>낮음</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>낮은 품질 (%sx) - 이미지가 흐릿하게 보일 수 있습니다</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
-				<target>Standard</target>
+				<target>표준</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>표준 품질 (%sx) - 기본 디스플레이에서 선명함</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,31 +109,31 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>Retina 품질 (%sx) - 최신 디스플레이에 최적</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
-				<target>Ultra</target>
+				<target>울트라</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>울트라 품질 (%sx) - 초고DPI 또는 소형 인쇄용</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>인쇄</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>인쇄 품질 (%sx) - 고품질 인쇄에 적합 (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>과도함</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>과도한 해상도 (%sx) - 불필요하게 높음</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/no.locallang_be.xlf
+++ b/Resources/Private/Language/no.locallang_be.xlf
@@ -5,71 +5,71 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>Tilpasset CSS-klasse</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>Bredde</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>Høyde</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>Rådgivende tittel</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>Alternativ tekst</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>Klikk for å forstørre</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>Aktivert</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>Hopp over bildebehandling</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>Bildeegenskaper</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>Avbryt</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>Lagre</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>Sett inn bilde</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>Ingen standard %s tilgjengelig i filmetadata. Kan ikke overstyre tom verdi.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>Aktiverer klikk-for-å-forstørre/lightbox-funksjonalitet. Standard popup-konfigurasjon leveres automatisk. Se dokumentasjon for tilpasset lightbox-bibliotekintegrasjon.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>Hopper over bildebehandling og bruker originalfilen. Nyttig for nyhetsbrev, PDF-er, skjermer med maksimal oppløsning og SVG-grafikk. Konfigurer globalt via TypoScript eller aktiver per bilde.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>Bildekvalitet</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>Ingen skalering</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
@@ -85,15 +85,15 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>Trykk (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>Lav</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>Lav kvalitet (%sx) - Bildet kan virke uskarp</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
@@ -101,7 +101,7 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>Standard kvalitet (%sx) - Skarp på grunnleggende skjermer</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,7 +109,7 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>Retina-kvalitet (%sx) - Optimal for moderne skjermer</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
@@ -117,23 +117,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>Ultra-kvalitet (%sx) - For ultrahøy DPI eller lite trykk</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>Trykk</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>Trykkkvalitet (%sx) - Egnet for høykvalitetstrykk (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>Overdreven</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>Overdreven oppløsning (%sx) - Unødvendig høy</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/pl.locallang_be.xlf
+++ b/Resources/Private/Language/pl.locallang_be.xlf
@@ -5,75 +5,75 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>Niestandardowa klasa CSS</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>Szerokość</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>Wysokość</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>Tytuł doradczy</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>Tekst alternatywny</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>Kliknij aby powiększyć</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>Włączone</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>Pomiń przetwarzanie obrazu</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>Właściwości obrazu</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>Anuluj</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>Zapisz</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>Wstaw obraz</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>Brak domyślnego %s w metadanych pliku. Nie można nadpisać pustej wartości.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>Włącza funkcję powiększania po kliknięciu/lightbox. Domyślna konfiguracja popup jest dostarczona automatycznie. Zobacz dokumentację dla niestandardowej integracji biblioteki lightbox.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>Pomija przetwarzanie obrazu i używa oryginalnego pliku. Przydatne dla newsletterów, PDF-ów, wyświetlaczy o maksymalnej rozdzielczości i grafiki SVG. Skonfiguruj globalnie przez TypoScript lub włącz dla pojedynczego obrazu.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>Jakość obrazu</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>Bez skalowania</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
-				<target>Standard (1.0x)</target>
+				<target>Standardowa (1.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina" xml:space="preserve">
 				<source>Retina (2.0x)</source>
@@ -85,23 +85,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>Druk (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>Niska</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>Niska jakość (%sx) - Obraz może być niewyraźny</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
-				<target>Standard</target>
+				<target>Standardowa</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>Standardowa jakość (%sx) - Ostry na podstawowych wyświetlaczach</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,7 +109,7 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>Jakość Retina (%sx) - Optymalna dla nowoczesnych wyświetlaczy</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
@@ -117,23 +117,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>Jakość Ultra (%sx) - Dla ultra-wysokiego DPI lub małego druku</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>Druk</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>Jakość druku (%sx) - Odpowiednia dla druku wysokiej jakości (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>Nadmierna</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>Nadmierna rozdzielczość (%sx) - Niepotrzebnie wysoka</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/pt.locallang_be.xlf
+++ b/Resources/Private/Language/pt.locallang_be.xlf
@@ -5,75 +5,75 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>Classe CSS personalizada</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>Largura</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>Altura</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>Título consultivo</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>Texto alternativo</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>Clique para ampliar</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>Ativado</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>Ignorar processamento de imagem</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>Propriedades da imagem</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>Cancelar</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>Salvar</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>Inserir imagem</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>Nenhum %s padrão disponível nos metadados do arquivo. Não é possível substituir valor vazio.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>Ativa a funcionalidade de clique para ampliar/lightbox. A configuração padrão do popup é fornecida automaticamente. Consulte a documentação para integração de biblioteca lightbox personalizada.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>Ignora o processamento de imagem e usa o arquivo original. Útil para newsletters, PDFs, displays de resolução máxima e gráficos SVG. Configure globalmente via TypoScript ou ative por imagem.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>Qualidade da imagem</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>Sem escala</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
-				<target>Standard (1.0x)</target>
+				<target>Padrão (1.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina" xml:space="preserve">
 				<source>Retina (2.0x)</source>
@@ -85,23 +85,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>Impressão (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>Baixa</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>Baixa qualidade (%sx) - A imagem pode aparecer desfocada</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
-				<target>Standard</target>
+				<target>Padrão</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>Qualidade padrão (%sx) - Nítida em displays básicos</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,7 +109,7 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>Qualidade Retina (%sx) - Ideal para displays modernos</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
@@ -117,23 +117,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>Qualidade Ultra (%sx) - Para DPI ultra-alto ou impressão pequena</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>Impressão</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>Qualidade de impressão (%sx) - Adequada para impressão de alta qualidade (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>Excessiva</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>Resolução excessiva (%sx) - Desnecessariamente alta</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/ru.locallang_be.xlf
+++ b/Resources/Private/Language/ru.locallang_be.xlf
@@ -5,75 +5,75 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>Пользовательский CSS класс</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>Ширина</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>Высота</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>Консультативный заголовок</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>Альтернативный текст</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>Нажмите, чтобы увеличить</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>Включено</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>Пропустить обработку изображения</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>Свойства изображения</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>Отмена</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>Сохранить</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>Вставить изображение</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>Нет значения по умолчанию %s в метаданных файла. Невозможно переопределить пустое значение.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>Включает функцию увеличения по клику/lightbox. Конфигурация всплывающего окна по умолчанию предоставляется автоматически. См. документацию для интеграции пользовательской библиотеки lightbox.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>Пропускает обработку изображения и использует исходный файл. Полезно для рассылок, PDF, дисплеев с максимальным разрешением и графики SVG. Настройте глобально через TypoScript или включите для каждого изображения.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>Качество изображения</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>Без масштабирования</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
-				<target>Standard (1.0x)</target>
+				<target>Стандартное (1.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina" xml:space="preserve">
 				<source>Retina (2.0x)</source>
@@ -81,27 +81,27 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra" xml:space="preserve">
 				<source>Ultra (3.0x)</source>
-				<target>Ultra (3.0x)</target>
+				<target>Ультра (3.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>Печать (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>Низкое</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>Низкое качество (%sx) - Изображение может быть размытым</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
-				<target>Standard</target>
+				<target>Стандартное</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>Стандартное качество (%sx) - Четкое на базовых дисплеях</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,31 +109,31 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>Качество Retina (%sx) - Оптимально для современных дисплеев</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
-				<target>Ultra</target>
+				<target>Ультра</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>Ультра качество (%sx) - Для сверхвысокого DPI или мелкой печати</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>Печать</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>Качество печати (%sx) - Подходит для высококачественной печати (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>Избыточное</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>Избыточное разрешение (%sx) - Излишне высокое</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/sv.locallang_be.xlf
+++ b/Resources/Private/Language/sv.locallang_be.xlf
@@ -5,71 +5,71 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>Anpassad CSS-klass</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>Bredd</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>Höjd</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>Rådgivande titel</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>Alternativ text</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>Klicka för att förstora</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>Aktiverad</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>Hoppa över bildbehandling</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>Bildegenskaper</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>Avbryt</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>Spara</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>Infoga bild</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>Ingen standard %s tillgänglig i filmetadata. Kan inte åsidosätta tomt värde.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>Aktiverar klicka-för-att-förstora/lightbox-funktionalitet. Standard popup-konfiguration tillhandahålls automatiskt. Se dokumentation för anpassad lightbox-biblioteksintegration.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>Hoppar över bildbehandling och använder originalfilen. Användbart för nyhetsbrev, PDF-filer, skärmar med maximal upplösning och SVG-grafik. Konfigurera globalt via TypoScript eller aktivera per bild.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>Bildkvalitet</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>Ingen skalning</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
@@ -85,15 +85,15 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>Tryck (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>Låg</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>Låg kvalitet (%sx) - Bild kan framstå som suddig</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
@@ -101,7 +101,7 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>Standard kvalitet (%sx) - Skarp på grundläggande skärmar</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,7 +109,7 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>Retina-kvalitet (%sx) - Optimal för moderna skärmar</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
@@ -117,23 +117,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>Ultra-kvalitet (%sx) - För ultrahög DPI eller litet tryck</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>Tryck</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>Tryckkvalitet (%sx) - Lämplig för högkvalitativt tryck (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>Överdriven</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>Överdriven upplösning (%sx) - Onödigt hög</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/sw.locallang_be.xlf
+++ b/Resources/Private/Language/sw.locallang_be.xlf
@@ -5,75 +5,75 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>Darasa la CSS maalum</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>Upana</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>Urefu</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>Kichwa cha ushauri</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>Maandishi mbadala</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>Bofya ili kuongeza</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>Imewezeshwa</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>Ruka usindikaji wa picha</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>Sifa za picha</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>Ghairi</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>Hifadhi</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>Ingiza picha</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>Hakuna %s chaguo-msingi katika metadata ya faili. Haiwezi kubadilisha thamani tupu.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>Huwezesha kitendakazi cha kubofya-ili-kuongeza/sanduku la taa. Usanidi wa chaguo-msingi wa dirisha unatolewa moja kwa moja. Tazama nyaraka za kuunganisha maktaba ya sanduku la taa maalum.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>Huruka usindikaji wa picha na hutumia faili asili. Inafaa kwa majarida, PDF, maonyesho ya azimio la juu zaidi, na michoro ya SVG. Sanidi kimataifa kupitia TypoScript au wezesha kwa kila picha.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>Ubora wa picha</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>Hakuna kupima</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
-				<target>Standard (1.0x)</target>
+				<target>Kawaida (1.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina" xml:space="preserve">
 				<source>Retina (2.0x)</source>
@@ -85,23 +85,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>Chapa (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>Chini</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>Ubora wa chini (%sx) - Picha inaweza kuonekana isiyo dhahiri</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
-				<target>Standard</target>
+				<target>Kawaida</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>Ubora wa kawaida (%sx) - Kali kwenye maonyesho ya kimsingi</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,7 +109,7 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>Ubora wa Retina (%sx) - Bora kwa maonyesho ya kisasa</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
@@ -117,23 +117,23 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>Ubora wa Ultra (%sx) - Kwa DPI ya juu sana au chapa ndogo</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>Chapa</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>Ubora wa kuchapisha (%sx) - Inafaa kwa uchapishaji wa ubora wa juu (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>Kupita kiasi</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>Azimio la kupita kiasi (%sx) - Juu bila sababu</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/th.locallang_be.xlf
+++ b/Resources/Private/Language/th.locallang_be.xlf
@@ -5,75 +5,75 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>คลาส CSS แบบกำหนดเอง</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>ความกว้าง</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>ความสูง</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>ชื่อคำแนะนำ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>ข้อความทางเลือก</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>คลิกเพื่อขยาย</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>เปิดใช้งาน</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>ข้ามการประมวลผลรูปภาพ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>คุณสมบัติรูปภาพ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>ยกเลิก</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>บันทึก</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>แทรกรูปภาพ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>ไม่มี %s เริ่มต้นในข้อมูลเมตาของไฟล์ ไม่สามารถแทนที่ค่าว่างได้</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>เปิดใช้งานฟังก์ชันคลิกเพื่อขยาย/ไลท์บ็อกซ์ การกำหนดค่าป๊อปอัปเริ่มต้นจะจัดให้โดยอัตโนมัติ ดูเอกสารสำหรับการรวมไลบรารีไลท์บ็อกซ์แบบกำหนดเอง</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>ข้ามการประมวลผลรูปภาพและใช้ไฟล์ต้นฉบับ มีประโยชน์สำหรับจดหมายข่าว PDF จอแสดงผลความละเอียดสูงสุด และกราฟิก SVG กำหนดค่าทั่วโลกผ่าน TypoScript หรือเปิดใช้งานแบบแยกรูปภาพ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>คุณภาพรูปภาพ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>ไม่มีการปรับขนาด</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
-				<target>Standard (1.0x)</target>
+				<target>มาตรฐาน (1.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina" xml:space="preserve">
 				<source>Retina (2.0x)</source>
@@ -81,27 +81,27 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra" xml:space="preserve">
 				<source>Ultra (3.0x)</source>
-				<target>Ultra (3.0x)</target>
+				<target>อัลตร้า (3.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>พิมพ์ (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>ต่ำ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>คุณภาพต่ำ (%sx) - รูปภาพอาจดูเบลอ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
-				<target>Standard</target>
+				<target>มาตรฐาน</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>คุณภาพมาตรฐาน (%sx) - คมชัดบนจอแสดงผลพื้นฐาน</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,31 +109,31 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>คุณภาพ Retina (%sx) - เหมาะสำหรับจอแสดงผลสมัยใหม่</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
-				<target>Ultra</target>
+				<target>อัลตร้า</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>คุณภาพอัลตร้า (%sx) - สำหรับ DPI สูงมากหรือพิมพ์ขนาดเล็ก</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>พิมพ์</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>คุณภาพการพิมพ์ (%sx) - เหมาะสำหรับการพิมพ์คุณภาพสูง (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>มากเกินไป</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>ความละเอียดมากเกินไป (%sx) - สูงเกินความจำเป็น</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/vi.locallang_be.xlf
+++ b/Resources/Private/Language/vi.locallang_be.xlf
@@ -5,75 +5,75 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>Lớp CSS tùy chỉnh</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>Chiều rộng</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>Chiều cao</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>Tiêu đề tư vấn</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>Văn bản thay thế</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>Nhấp để phóng to</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>Đã bật</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>Bỏ qua xử lý hình ảnh</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>Thuộc tính hình ảnh</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>Hủy</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>Lưu</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>Chèn hình ảnh</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>Không có %s mặc định trong metadata tệp. Không thể ghi đè giá trị trống.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>Kích hoạt chức năng nhấp-để-phóng-to/lightbox. Cấu hình popup mặc định được cung cấp tự động. Xem tài liệu để tích hợp thư viện lightbox tùy chỉnh.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>Bỏ qua xử lý hình ảnh và sử dụng tệp gốc. Hữu ích cho bản tin, PDF, màn hình độ phân giải tối đa và đồ họa SVG. Cấu hình toàn cục qua TypoScript hoặc bật cho từng hình ảnh.</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>Chất lượng hình ảnh</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>Không chia tỷ lệ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
-				<target>Standard (1.0x)</target>
+				<target>Tiêu chuẩn (1.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina" xml:space="preserve">
 				<source>Retina (2.0x)</source>
@@ -81,27 +81,27 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra" xml:space="preserve">
 				<source>Ultra (3.0x)</source>
-				<target>Ultra (3.0x)</target>
+				<target>Siêu (3.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>In (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>Thấp</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>Chất lượng thấp (%sx) - Hình ảnh có thể bị mờ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
-				<target>Standard</target>
+				<target>Tiêu chuẩn</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>Chất lượng tiêu chuẩn (%sx) - Sắc nét trên màn hình cơ bản</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,31 +109,31 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>Chất lượng Retina (%sx) - Tối ưu cho màn hình hiện đại</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
-				<target>Ultra</target>
+				<target>Siêu</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>Chất lượng siêu (%sx) - Cho DPI cực cao hoặc in nhỏ</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>In</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>Chất lượng in (%sx) - Phù hợp cho in chất lượng cao (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>Quá mức</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>Độ phân giải quá mức (%sx) - Cao không cần thiết</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/zh.locallang_be.xlf
+++ b/Resources/Private/Language/zh.locallang_be.xlf
@@ -5,75 +5,75 @@
         <body>
             <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve">
 				<source>Custom CSS class</source>
-				<target>Custom CSS class</target>
+				<target>自定义CSS类</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.width" xml:space="preserve">
 				<source>Width</source>
-				<target>Width</target>
+				<target>宽度</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.height" xml:space="preserve">
 				<source>Height</source>
-				<target>Height</target>
+				<target>高度</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.title" xml:space="preserve">
 				<source>Advisory Title</source>
-				<target>Advisory Title</target>
+				<target>咨询标题</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.alt" xml:space="preserve">
 				<source>Alternative Text</source>
-				<target>Alternative Text</target>
+				<target>替代文本</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.clicktoenlarge" xml:space="preserve">
 				<source>Click to Enlarge</source>
-				<target>Click to Enlarge</target>
+				<target>点击放大</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.enabled" xml:space="preserve">
 				<source>Enabled</source>
-				<target>Enabled</target>
+				<target>已启用</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.skipimageprocessing" xml:space="preserve">
 				<source>Skip Image Processing</source>
-				<target>Skip Image Processing</target>
+				<target>跳过图像处理</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.imageproperties" xml:space="preserve">
 				<source>Image Properties</source>
-				<target>Image Properties</target>
+				<target>图像属性</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.cancel" xml:space="preserve">
 				<source>Cancel</source>
-				<target>Cancel</target>
+				<target>取消</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.save" xml:space="preserve">
 				<source>Save</source>
-				<target>Save</target>
+				<target>保存</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.insertimage" xml:space="preserve">
 				<source>Insert image</source>
-				<target>Insert image</target>
+				<target>插入图像</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.nodefaultmetadata" xml:space="preserve">
 				<source>No default %s available in file metadata. Cannot override empty value.</source>
-				<target>No default %s available in file metadata. Cannot override empty value.</target>
+				<target>文件元数据中没有默认的%s。无法覆盖空值。</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.zoomhelp" xml:space="preserve">
 				<source>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</source>
-				<target>Enables click-to-enlarge/lightbox functionality. Default popup configuration is provided automatically. See documentation for custom lightbox library integration.</target>
+				<target>启用点击放大/灯箱功能。默认弹出窗口配置自动提供。请参阅文档以了解自定义灯箱库集成。</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.noscalehelp" xml:space="preserve">
 				<source>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</source>
-				<target>Skips image processing and uses the original file. Useful for newsletters, PDFs, maximum resolution displays, and SVG graphics. Configure globally via TypoScript or enable per-image.</target>
+				<target>跳过图像处理并使用原始文件。对新闻通讯、PDF、最大分辨率显示和SVG图形有用。通过TypoScript全局配置或按图像启用。</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality" xml:space="preserve">
 				<source>Image Quality</source>
-				<target>Image Quality</target>
+				<target>图像质量</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.none" xml:space="preserve">
 				<source>No Scaling</source>
-				<target>No Scaling</target>
+				<target>不缩放</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard" xml:space="preserve">
 				<source>Standard (1.0x)</source>
-				<target>Standard (1.0x)</target>
+				<target>标准 (1.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina" xml:space="preserve">
 				<source>Retina (2.0x)</source>
@@ -81,27 +81,27 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra" xml:space="preserve">
 				<source>Ultra (3.0x)</source>
-				<target>Ultra (3.0x)</target>
+				<target>超清 (3.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve">
 				<source>Print (6.0x)</source>
-				<target>Print (6.0x)</target>
+				<target>打印 (6.0x)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve">
 				<source>Low</source>
-				<target>Low</target>
+				<target>低</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve">
 				<source>Low quality (%sx) - Image may appear blurry</source>
-				<target>Low quality (%sx) - Image may appear blurry</target>
+				<target>低质量 (%sx) - 图像可能模糊</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.label" xml:space="preserve">
 				<source>Standard</source>
-				<target>Standard</target>
+				<target>标准</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.standard.tooltip" xml:space="preserve">
 				<source>Standard quality (%sx) - Sharp on basic displays</source>
-				<target>Standard quality (%sx) - Sharp on basic displays</target>
+				<target>标准质量 (%sx) - 在基本显示器上清晰</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.label" xml:space="preserve">
 				<source>Retina</source>
@@ -109,31 +109,31 @@
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.retina.tooltip" xml:space="preserve">
 				<source>Retina quality (%sx) - Optimal for modern displays</source>
-				<target>Retina quality (%sx) - Optimal for modern displays</target>
+				<target>Retina质量 (%sx) - 适合现代显示器</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve">
 				<source>Ultra</source>
-				<target>Ultra</target>
+				<target>超清</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
-				<target>Ultra quality (%sx) - For ultra-high DPI or small print</target>
+				<target>超清质量 (%sx) - 适用于超高DPI或小型打印</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.label" xml:space="preserve">
 				<source>Print</source>
-				<target>Print</target>
+				<target>打印</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.print.tooltip" xml:space="preserve">
 				<source>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</source>
-				<target>Print quality (%sx) - Suitable for high-quality printing (300 DPI)</target>
+				<target>打印质量 (%sx) - 适合高质量打印 (300 DPI)</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.label" xml:space="preserve">
 				<source>Excessive</source>
-				<target>Excessive</target>
+				<target>过度</target>
 			</trans-unit>
             <trans-unit id="labels.ckeditor.quality.excessive.tooltip" xml:space="preserve">
 				<source>Excessive resolution (%sx) - Unnecessarily high</source>
-				<target>Excessive resolution (%sx) - Unnecessarily high</target>
+				<target>过度分辨率 (%sx) - 不必要地高</target>
 			</trans-unit>
         </body>
     </file>


### PR DESCRIPTION
## Summary

Replace English placeholders with proper native translations for 18 language files added in PR #400.

## Changes

**European Languages (8):**
- 🇵🇱 Polish (pl) - Polski
- 🇩🇰 Danish (da) - Dansk
- 🇨🇿 Czech (cs) - Čeština
- 🇸🇪 Swedish (sv) - Svenska
- 🇷🇺 Russian (ru) - Русский
- 🇵🇹 Portuguese (pt) - Português
- 🇳🇴 Norwegian (no) - Norsk
- 🇫🇮 Finnish (fi) - Suomi

**East Asian Languages (4):**
- 🇨🇳 Chinese (zh) - 中文
- 🇯🇵 Japanese (ja) - 日本語
- 🇰🇷 Korean (ko) - 한국어
- 🇹🇭 Thai (th) - ไทย

**Southeast Asian Languages (2):**
- 🇮🇩 Indonesian (id) - Bahasa Indonesia
- 🇻🇳 Vietnamese (vi) - Tiếng Việt

**South Asian & Middle Eastern (2):**
- 🇮🇳 Hindi (hi) - हिन्दी
- 🇸🇦 Arabic (ar) - العربية

**African Languages (2):**
- 🇹🇿 Swahili (sw) - Kiswahili
- 🇿🇦 Afrikaans (af) - Afrikaans

## Translation Details

- **Total keys per file**: 34 (base + quality selector)
- **Total translations**: 612 strings (34 keys × 18 languages)
- **Changes**: English placeholders → native language translations

## Quality

- All translations follow proper grammar and conventions for each language
- Technical terms (Retina, DPI, TypoScript) preserved where appropriate
- Files maintain TYPO3 XLIFF 1.0 format with proper source/target structure
- Ready for professional review via Crowdin workflow

## Related

- Builds on PR #400 which added the skeleton files
- Part of global internationalization expansion (6 → 24 languages)

## Test Plan

1. ✅ Verify all 18 files have native translations (not English placeholders)
2. ✅ Check XLIFF format validity
3. ✅ Confirm language codes match target-language attributes
4. ✅ Test in TYPO3 backend with language switcher