### PR TITLE
docs: add TYPO3 core removal explanation and decision guidance

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -56,6 +56,14 @@ Image support in CKEditor for the TYPO3 ecosystem.
         ..  card-footer:: :ref:`Read more <quick-start>`
             :button-style: btn btn-primary stretched-link
 
+    ..  card:: ⚠️ Core Removal Notice
+
+        **Important:** TYPO3 intentionally removed RTE image handling in v10.
+        Understand the design decision before using this extension.
+
+        ..  card-footer:: :ref:`Read more <core-removal>`
+            :button-style: btn btn-warning stretched-link
+
     ..  card:: ⚙️ Configuration
 
         Learn how to configure custom image styles, processing options,
@@ -110,6 +118,7 @@ This extension is licensed under `AGPL-3.0-or-later <https://www.gnu.org/license
    :caption: Getting Started
 
    Introduction/Index
+   Introduction/CoreRemoval
    Contributing/Index
 
 .. toctree::

--- a/Documentation/Introduction/CoreRemoval.rst
+++ b/Documentation/Introduction/CoreRemoval.rst
@@ -1,0 +1,344 @@
+.. include:: /Includes.rst.txt
+
+.. _core-removal:
+
+====================================
+TYPO3 Core Removal & Design Decision
+====================================
+
+.. important::
+
+   **Before installing this extension, please read this page carefully.**
+
+   This extension re-implements functionality that TYPO3 core **intentionally removed**
+   in version 10.0. Understanding the reasoning behind this removal will help you make
+   an informed decision about whether this extension is right for your project.
+
+
+.. _core-removal-what:
+
+What TYPO3 Removed
+==================
+
+In TYPO3 v10.0 (`Breaking #88500 <https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Breaking-88500-RTEImageHandlingFunctionalityDropped.html>`__),
+the core team removed the RTE image handling functionality:
+
+Removed Components
+------------------
+
+- **RTE processing mode** ("ts_images")
+- **SoftReference Index** for inline images
+- **Magic Image processing** (automatic scaling, cropping via TSConfig)
+- **Image storage handling** (``RTE_imageStorageDir``)
+- **CLI cleanup command** (``cleanup:rteimages``)
+- **Public API methods** (``ImportExport->getRTEoriginalFilename()``, ``RteHtmlParser->TS_images_rte()``)
+
+Later Deprecation
+-----------------
+
+In TYPO3 v12.4 (`Deprecation #99237 <https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.4/Deprecation-99237-MagicImageService.html>`__),
+the **MagicImageService** class was deprecated with no direct migration path.
+
+
+.. _core-removal-why:
+
+Why TYPO3 Removed This
+=======================
+
+The TYPO3 core team removed this functionality for several architectural reasons:
+
+1. **Obsolete Technology**
+
+   CKEditor replaced RTEHtmlArea in TYPO3 v8, making the native RTE image handling
+   unused and obsolete.
+
+2. **Incomplete Implementation**
+
+   The changelog explicitly states the functionality was **"very incomplete"** compared
+   to modern alternatives.
+
+3. **Architectural Philosophy**
+
+   TYPO3 promotes **structured content** over inline mixed content. Storing images
+   as relations (FAL references) provides better:
+
+   - Content reuse across multiple elements
+   - Metadata management (alt text, copyright, descriptions)
+   - Image variant generation (responsive images, WebP conversion)
+   - Migration and content import/export
+   - Multi-language handling
+   - Permission and access control
+   - Asset management and organization
+
+
+.. _core-removal-typo3-recommendation:
+
+TYPO3's Official Recommendation
+================================
+
+The breaking change documentation recommends:
+
+**Primary Approach: Structured Content**
+-----------------------------------------
+
+Move images from inline RTE fields to **proper relational fields**:
+
+.. code-block:: php
+
+   // TCA Configuration Example
+   'columns' => [
+       'bodytext' => [
+           'config' => [
+               'type' => 'text',
+               'enableRichtext' => true,
+           ],
+       ],
+       'images' => [
+           'config' => [
+               'type' => 'file',
+               'allowed' => 'common-image-types',
+               'maxitems' => 10,
+           ],
+       ],
+   ],
+
+**Benefits of Structured Content:**
+
+- ✅ Better content reuse
+- ✅ Proper metadata management
+- ✅ Responsive image generation
+- ✅ Clean separation of concerns
+- ✅ Modern TYPO3 architecture
+- ✅ Better editor experience
+
+**Fallback Approach: Extensions**
+----------------------------------
+
+For projects that need inline image functionality, TYPO3 recommends extensions
+like ``rte_ckeditor_image`` or creating custom extension implementations.
+
+
+.. _core-removal-why-this-extension:
+
+Why This Extension Exists
+==========================
+
+Despite TYPO3's architectural direction, this extension exists because:
+
+Real-World Requirements
+-----------------------
+
+1. **Legacy Content Migration**
+
+   Many TYPO3 installations have years of content with inline images. Migrating
+   to structured content requires significant time and resources.
+
+2. **Editorial Workflows**
+
+   Some editorial teams are trained on inline image workflows and prefer
+   WYSIWYG image placement directly in text.
+
+3. **Content Nature**
+
+   Certain content types (news articles, blog posts, documentation) naturally
+   contain inline images that are contextually bound to surrounding text.
+
+4. **Migration Bridge**
+
+   Provides a transition path while planning migration to structured content.
+
+What This Extension Provides
+-----------------------------
+
+- **Backward compatibility** with RTEHtmlArea image workflows
+- **Magic Image processing** (automatic scaling via TSConfig)
+- **TYPO3 FAL integration** (native file browser)
+- **Modern CKEditor 5** implementation
+- **Image attributes** (width, height, alt, title, quality)
+- **Custom styles** via CKEditor style system
+- **Event-driven architecture** for extensibility
+
+
+.. _core-removal-decision-guide:
+
+Decision Guide: Should You Use This Extension?
+===============================================
+
+Use This Extension When
+-----------------------
+
+✅ **You have legacy content** with extensive inline images that cannot be migrated immediately
+
+✅ **Editorial workflow requires** inline image placement with WYSIWYG editing
+
+✅ **Content is tightly coupled** to surrounding text (inline diagrams, screenshots, examples)
+
+✅ **Migration timeline** is long and you need a working solution now
+
+✅ **Small to medium projects** where structured content overhead isn't justified
+
+Follow TYPO3 Guidelines Instead When
+-------------------------------------
+
+❌ **Starting a new project** - Build with structured content from the beginning
+
+❌ **Images are reusable** - Same images appear across multiple content elements
+
+❌ **Need advanced features** - Responsive images, WebP conversion, image variants
+
+❌ **Multi-language sites** - Image metadata needs proper translation workflows
+
+❌ **Large editorial teams** - Structured content provides better governance
+
+❌ **Long-term maintainability** - Align with TYPO3's architectural direction
+
+
+.. _core-removal-hybrid-approach:
+
+Hybrid Approach
+===============
+
+You can use **both approaches** in the same TYPO3 installation:
+
+- **Structured content** for main images, galleries, and reusable assets
+- **Inline images** (this extension) for contextual images in rich text
+
+Example TCA configuration:
+
+.. code-block:: php
+
+   'columns' => [
+       'header_image' => [
+           // Structured: Main article image
+           'config' => [
+               'type' => 'file',
+               'allowed' => 'common-image-types',
+               'maxitems' => 1,
+           ],
+       ],
+       'bodytext' => [
+           // Inline: Contextual images within text
+           'config' => [
+               'type' => 'text',
+               'enableRichtext' => true,
+               // rte_ckeditor_image provides inline functionality
+           ],
+       ],
+       'gallery' => [
+           // Structured: Image gallery
+           'config' => [
+               'type' => 'file',
+               'allowed' => 'common-image-types',
+               'maxitems' => 20,
+           ],
+       ],
+   ],
+
+
+.. _core-removal-migration-path:
+
+Future Migration Path
+=====================
+
+If you use this extension now but plan to migrate to structured content later:
+
+Planning Migration
+------------------
+
+1. **Audit content** - Identify all RTE fields with inline images
+2. **Create TCA fields** - Add proper FAL reference fields
+3. **Write migration script** - Extract inline images to relations
+4. **Update templates** - Adjust Fluid templates for structured content
+5. **Train editors** - Update editorial workflows and documentation
+
+Migration Tools
+---------------
+
+TYPO3 provides tools for content migration:
+
+- **Data Handler API** for programmatic content updates
+- **TypoScript** processors for rendering
+- **CLI commands** for batch processing
+
+This extension can coexist during the migration period.
+
+
+.. _core-removal-best-practices:
+
+Best Practices If Using This Extension
+=======================================
+
+1. **Document the Decision**
+
+   Add notes to your project documentation explaining why inline images
+   are used and what the long-term plan is.
+
+2. **Set Editor Guidelines**
+
+   Define when editors should use inline images vs. structured image fields.
+
+3. **Configure Processing**
+
+   Use magic image configuration (TSConfig) to control automatic scaling:
+
+   .. code-block:: typoscript
+
+      RTE.default.buttons.image.options.magic {
+          maxWidth = 1920
+          maxHeight = 9999
+      }
+
+4. **Monitor TYPO3 Updates**
+
+   Stay informed about TYPO3's direction regarding RTE and CKEditor.
+
+5. **Plan Migration**
+
+   If project lifespan is long, plan eventual migration to structured content.
+
+
+.. _core-removal-conclusion:
+
+Conclusion
+==========
+
+This extension serves as a **pragmatic bridge** between TYPO3's architectural
+direction (structured content) and real-world editorial needs (inline images).
+
+**Key Takeaways:**
+
+- TYPO3 intentionally removed RTE image handling for good architectural reasons
+- Structured content is the recommended modern approach
+- This extension provides backward compatibility when needed
+- Consider your project's specific requirements, timeline, and resources
+- A hybrid approach (both structured and inline) is valid
+- Plan for eventual migration if project lifespan is long
+
+**Questions to ask:**
+
+1. Do we have time/budget to migrate existing content?
+2. Does our editorial team need inline image placement?
+3. Are our images contextually bound to text or reusable assets?
+4. What is our project's expected lifespan?
+5. Can we align with TYPO3's architectural direction?
+
+The "right" choice depends on your specific context. There is no universal answer.
+
+
+.. _core-removal-resources:
+
+Additional Resources
+====================
+
+**TYPO3 Core Documentation:**
+
+- `Breaking #88500 - RTE Image Handling Removed <https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Breaking-88500-RTEImageHandlingFunctionalityDropped.html>`__
+- `Deprecation #99237 - MagicImageService <https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.4/Deprecation-99237-MagicImageService.html>`__
+- `File Abstraction Layer (FAL) <https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Fal/Index.html>`__
+- `Content Elements <https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/ContentElements/Index.html>`__
+
+**This Extension:**
+
+- :ref:`Quick Start <quick-start>`
+- :ref:`Configuration <integration-configuration>`
+- :ref:`Troubleshooting <troubleshooting-index>`

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -108,3 +108,10 @@ If you need to customize the RTE configuration or create your own preset, see th
 :ref:`RTE Setup Guide <integration-configuration-rte-setup>` for detailed instructions.
 
 The extension provides a default preset that you can extend or override as needed.
+
+
+.. important::
+
+   **Before using this extension**, please read :ref:`TYPO3 Core Removal & Design Decision <core-removal>`
+   to understand why TYPO3 intentionally removed this functionality and whether this extension
+   is the right choice for your project.


### PR DESCRIPTION
## Summary

Adds comprehensive documentation explaining why TYPO3 core **intentionally removed** RTE image handling functionality (Breaking #88500, Deprecation #99237) and provides guidance for users to make informed decisions about using this extension.

## Why This Matters

Users need to understand that:
1. TYPO3 **deliberately removed** this functionality for architectural reasons
2. TYPO3 recommends **structured content** (FAL relations) over inline RTE images
3. This extension **re-implements removed functionality** to bridge real-world needs
4. There are **trade-offs** to consider when choosing this extension vs. TYPO3 guidelines

## What's Included

### New Documentation Page: `CoreRemoval.rst` (344 lines)

**Sections:**
- ✅ What TYPO3 removed (Breaking #88500, Deprecation #99237)
- ✅ Why it was removed (RTEHtmlArea → CKEditor, architectural reasons)
- ✅ TYPO3's official recommendation (use FAL relations, structured content)
- ✅ Why this extension exists (legacy content, editorial workflows, migration bridge)
- ✅ Decision guide (when to use vs. follow TYPO3 guidelines)
- ✅ Hybrid approach (structured + inline images)
- ✅ Migration path planning
- ✅ Best practices if using this extension

### UI Changes

**Index.rst:**
- Added **⚠️ Core Removal Notice** card (with btn-warning style)
- Prominently displayed between Quick Start and Configuration

**Introduction/Index.rst:**
- Added important notice at end of Quick Start section
- Links to full CoreRemoval.rst page

**Toctree:**
- Added `Introduction/CoreRemoval` to "Getting Started" section

## Background Context

**TYPO3 v10.0 (Breaking #88500):**
- Removed: RTE processing mode, SoftReference Index, magic images, CLI cleanup
- Reason: RTEHtmlArea replaced by CKEditor in v8, functionality was "very incomplete"
- Recommendation: Move images to proper relations or use extensions like this one

**TYPO3 v12.4 (Deprecation #99237):**
- Deprecated: MagicImageService class
- Reason: "functionality is no longer needed for CKEditor"
- Migration: No direct path, copy code to custom extension if needed

**This Extension:**
Re-implements intentionally removed functionality to bridge:
- Real-world needs: Legacy content, editorial workflows, contextual inline images
- TYPO3 direction: Structured content, FAL relations, modern architecture

## Decision Framework

**Use This Extension When:**
- ✅ Legacy content with extensive inline images
- ✅ Editorial workflow requires inline WYSIWYG placement
- ✅ Content tightly coupled to text (diagrams, screenshots)
- ✅ Migration timeline is long, need working solution now

**Follow TYPO3 Guidelines When:**
- ❌ Starting new projects (build with structured content)
- ❌ Images are reusable across multiple elements
- ❌ Need advanced features (responsive images, WebP)
- ❌ Long-term maintainability is priority

## Benefits

**For Users:**
- 🎯 Informed decision-making (understand trade-offs)
- 📚 Clear guidance on when to use vs. follow TYPO3
- 🔄 Hybrid approach option (both structured + inline)
- 🗺️ Migration path planning for future

**For Project:**
- 🏷️ Transparent about re-implementing removed functionality
- 📖 Reduces confusion about TYPO3's stance
- ⚖️ Balanced perspective (extension benefits vs. TYPO3 direction)
- 🤝 Respects both real-world needs and TYPO3 architecture

## Validation

✅ Documentation renders successfully (34 documents)
✅ No RST syntax errors
✅ Cross-references working
✅ 344 lines of comprehensive guidance
✅ Warning card prominently displayed

## Related

- Breaking #88500: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Breaking-88500-RTEImageHandlingFunctionalityDropped.html
- Deprecation #99237: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.4/Deprecation-99237-MagicImageService.html
- PR #411: Translation contribution guide (recently merged)