### PR TITLE
fix(i18n): correct translation errors in 5 language files

### DIFF
--- a/Resources/Private/Language/hi.locallang_be.xlf
+++ b/Resources/Private/Language/hi.locallang_be.xlf
@@ -32,7 +32,7 @@
 			<target state="final">छवि गुण</target></trans-unit>
       <trans-unit id="labels.ckeditor.cancel" xml:space="preserve" approved="yes">
 				<source>Cancel</source>
-			<target state="final">कुल सक्रिय किए गए प्रदाताओं को प्रयोंक्ता %s के लिए सफलतापूर्वक निष्क्रिय किया गया</target></trans-unit>
+			<target state="final">रद्द करें</target></trans-unit>
       <trans-unit id="labels.ckeditor.save" xml:space="preserve" approved="yes">
 				<source>Save</source>
 			<target state="final">सहेजें</target></trans-unit>

--- a/Resources/Private/Language/pl.locallang_be.xlf
+++ b/Resources/Private/Language/pl.locallang_be.xlf
@@ -71,7 +71,7 @@
 			<target state="final">Druk (6.0x)</target></trans-unit>
       <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve" approved="yes">
 				<source>Low</source>
-			<target state="final">Niski:</target></trans-unit>
+			<target state="final">Niski</target></trans-unit>
       <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve" approved="yes">
 				<source>Low quality (%sx) - Image may appear blurry</source>
 			<target state="final">Niska jakość (%sx) - Obraz może być niewyraźny</target></trans-unit>

--- a/Resources/Private/Language/ro.locallang_be.xlf
+++ b/Resources/Private/Language/ro.locallang_be.xlf
@@ -5,7 +5,7 @@
     <body>
       <trans-unit id="labels.ckeditor.cssclass" xml:space="preserve" approved="yes">
 				<source>Custom CSS class</source>
-			<target state="final">Custom CSS class</target></trans-unit>
+			<target state="final">Clasă CSS personalizată</target></trans-unit>
       <trans-unit id="labels.ckeditor.width" xml:space="preserve" approved="yes">
 				<source>Width</source>
 			<target state="final">Lățime</target></trans-unit>

--- a/Resources/Private/Language/sw.locallang_be.xlf
+++ b/Resources/Private/Language/sw.locallang_be.xlf
@@ -65,7 +65,7 @@
       <trans-unit id="labels.ckeditor.quality.ultra" xml:space="preserve" approved="yes">
 				<source>Ultra (3.0x)</source>
 				
-			<target state="final">Namba moja (3.0x)</target><note>Multilingual term - keep as-is unless your language has a more natural equivalent</note></trans-unit>
+			<target state="final">Ultra (3.0x)</target><note>Multilingual term - keep as-is unless your language has a more natural equivalent</note></trans-unit>
       <trans-unit id="labels.ckeditor.quality.print" xml:space="preserve" approved="yes">
 				<source>Print (6.0x)</source>
 			<target state="final">Chapa (6.0x)</target></trans-unit>
@@ -92,7 +92,7 @@
       <trans-unit id="labels.ckeditor.quality.ultra.label" xml:space="preserve" approved="yes">
 				<source>Ultra</source>
 				
-			<target state="final">Namba moja</target><note>Multilingual term - keep as-is unless your language has a more natural equivalent</note></trans-unit>
+			<target state="final">Ultra</target><note>Multilingual term - keep as-is unless your language has a more natural equivalent</note></trans-unit>
       <trans-unit id="labels.ckeditor.quality.ultra.tooltip" xml:space="preserve" approved="yes">
 				<source>Ultra quality (%sx) - For ultra-high DPI or small print</source>
 			<target state="final">Ubora wa Ultra (%sx) - Kwa DPI ya juu sana au chapa ndogo</target></trans-unit>

--- a/Resources/Private/Language/tr.locallang_be.xlf
+++ b/Resources/Private/Language/tr.locallang_be.xlf
@@ -71,7 +71,7 @@
 			<target state="final">Baskı (6.0x)</target></trans-unit>
       <trans-unit id="labels.ckeditor.quality.low.label" xml:space="preserve" approved="yes">
 				<source>Low</source>
-			<target state="final">Düşük:</target></trans-unit>
+			<target state="final">Düşük</target></trans-unit>
       <trans-unit id="labels.ckeditor.quality.low.tooltip" xml:space="preserve" approved="yes">
 				<source>Low quality (%sx) - Image may appear blurry</source>
 			<target state="final">Düşük kalite (%sx) - Görüntü bulanık görünebilir</target></trans-unit>


### PR DESCRIPTION
## Summary
- **Hindi (hi)**: Fixed Cancel translation - was garbage text from wrong context, now correctly `रद्द करें`
- **Romanian (ro)**: Translated "Custom CSS class" - was untranslated, now `Clasă CSS personalizată`
- **Polish (pl)**: Removed trailing colon from "Low" label (`Niski:` → `Niski`)
- **Turkish (tr)**: Removed trailing colon from "Low" label (`Düşük:` → `Düşük`)
- **Swahili (sw)**: Fixed Ultra translation - was "Namba moja" (Number one), now kept as technical term `Ultra`

## Test plan
- [ ] Verify XLIFF files are valid XML (validated locally with xmllint)
- [ ] Check translations render correctly in TYPO3 backend for affected languages