### PR TITLE
fix(ddev): add proper FAL entries for E2E test content

### DIFF
--- a/.ddev/commands/web/install-v13
+++ b/.ddev/commands/web/install-v13
@@ -54,25 +54,9 @@ vendor/bin/typo3 styleguide:generate
 # The styleguide creates demo content, but E2E tests need content on the root page
 # Add a text content element with an image in the bodytext
 # NOTE: MySQL credentials are hardcoded for DDEV local development only
-mysql -h db -u root -p"root" $VERSION << EOSQL
-INSERT INTO tt_content (pid, CType, header, bodytext, hidden, deleted, tstamp, crdate, colPos, sorting)
-VALUES (
-    1,
-    'text',
-    'Welcome to RTE CKEditor Image Demo',
-    '<p>This is a test page with an image:</p><p><img src="fileadmin/user_upload/example.jpg" alt="Example image" width="$TEST_IMAGE_WIDTH" height="$TEST_IMAGE_HEIGHT" /></p><p>Click the image to see the click-to-enlarge functionality.</p>',
-    0,
-    0,
-    UNIX_TIMESTAMP(),
-    UNIX_TIMESTAMP(),
-    0,
-    256
-);
-EOSQL
 
-# Create a dummy image file for the test
+# First, create the test image file (needed before FAL registration)
 mkdir -p public/fileadmin/user_upload
-# Create a test image using ImageMagick (pre-installed in DDEV web container)
 if command -v convert &> /dev/null; then
     convert -size ${TEST_IMAGE_WIDTH}x${TEST_IMAGE_HEIGHT} \
         xc:blue \
@@ -83,11 +67,85 @@ if command -v convert &> /dev/null; then
         public/fileadmin/user_upload/example.jpg
 else
     echo "Warning: ImageMagick not found, creating minimal placeholder image"
-    # Fallback: Create a minimal 1x1 blue pixel JPEG using base64
-    # This ensures the file exists so E2E tests can at least find the image reference
     echo '/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD9/KKKKAP/2Q==' | base64 -d > public/fileadmin/user_upload/example.jpg
-    echo "Warning: E2E tests will use a minimal 1x1 placeholder image"
 fi
+
+# Get actual file info for FAL entry
+TEST_FILE_PATH="public/fileadmin/user_upload/example.jpg"
+TEST_FILE_SIZE=$(stat -c%s "$TEST_FILE_PATH" 2>/dev/null || stat -f%z "$TEST_FILE_PATH")
+TEST_FILE_SHA1=$(sha1sum "$TEST_FILE_PATH" 2>/dev/null | cut -d' ' -f1 || shasum "$TEST_FILE_PATH" | cut -d' ' -f1)
+
+# Create FAL entry in sys_file for proper click-to-enlarge support
+# The click-to-enlarge feature requires:
+# 1. A valid sys_file entry (with metadata for width/height)
+# 2. data-htmlarea-file-uid attribute pointing to the sys_file UID
+# 3. data-htmlarea-zoom="true" attribute
+mysql -h db -u root -p"root" $VERSION << EOSQL
+-- Insert sys_file entry for the test image
+INSERT INTO sys_file (
+    pid, storage, type, identifier, identifier_hash, folder_hash,
+    extension, mime_type, name, sha1, size,
+    creation_date, modification_date, tstamp, last_indexed
+)
+VALUES (
+    0,
+    1,
+    2,
+    '/user_upload/example.jpg',
+    SHA1('/user_upload/example.jpg'),
+    SHA1('/user_upload'),
+    'jpg',
+    'image/jpeg',
+    'example.jpg',
+    '$TEST_FILE_SHA1',
+    $TEST_FILE_SIZE,
+    UNIX_TIMESTAMP(),
+    UNIX_TIMESTAMP(),
+    UNIX_TIMESTAMP(),
+    UNIX_TIMESTAMP()
+);
+
+-- Get the sys_file UID we just created
+SET @file_uid = LAST_INSERT_ID();
+
+-- Insert sys_file_metadata with width/height (required for image processing)
+INSERT INTO sys_file_metadata (
+    pid, tstamp, crdate, file, width, height
+)
+VALUES (
+    0,
+    UNIX_TIMESTAMP(),
+    UNIX_TIMESTAMP(),
+    @file_uid,
+    $TEST_IMAGE_WIDTH,
+    $TEST_IMAGE_HEIGHT
+);
+
+-- Update sys_file to link to metadata
+UPDATE sys_file SET metadata = LAST_INSERT_ID() WHERE uid = @file_uid;
+
+-- Insert tt_content with proper RTE image attributes for click-to-enlarge
+INSERT INTO tt_content (pid, CType, header, bodytext, hidden, deleted, tstamp, crdate, colPos, sorting)
+VALUES (
+    1,
+    'text',
+    'Welcome to RTE CKEditor Image Demo',
+    CONCAT(
+        '<p>This is a test page with an image:</p>',
+        '<p><img src="fileadmin/user_upload/example.jpg" alt="Example image" ',
+        'width="$TEST_IMAGE_WIDTH" height="$TEST_IMAGE_HEIGHT" ',
+        'data-htmlarea-file-uid="', @file_uid, '" ',
+        'data-htmlarea-zoom="true" /></p>',
+        '<p>Click the image to see the click-to-enlarge functionality.</p>'
+    ),
+    0,
+    0,
+    UNIX_TIMESTAMP(),
+    UNIX_TIMESTAMP(),
+    0,
+    256
+);
+EOSQL
 
 # Add site sets to site configuration (TYPO3 v13 approach)
 # Bootstrap Package is added for frontend rendering demo


### PR DESCRIPTION
## Summary
- Fix install-v13 script to create proper FAL (File Abstraction Layer) entries for E2E test content
- Adds sys_file and sys_file_metadata entries with correct width/height attributes
- RTE content now includes proper data-htmlarea-file-uid and data-htmlarea-zoom attributes

This ensures E2E tests can properly validate click-to-enlarge functionality by having complete FAL entries that mirror real user-created content.

## Test plan
- [ ] Run `ddev delete -O -y && ddev start && ddev install-v13`
- [ ] Visit https://v13.rte-ckeditor-image.ddev.site/ and verify image has click-to-enlarge popup
- [ ] Run E2E tests: `composer ci:test:e2e`