### PR TITLE
fix(e2e): update Playwright Docker image to v1.57.0

### DIFF
--- a/.ddev/commands/host/test-e2e
+++ b/.ddev/commands/host/test-e2e
@@ -19,7 +19,7 @@ docker run --rm \
   -v "$(pwd)":/app \
   -w /app \
   -e BASE_URL=https://v13.rte-ckeditor-image.ddev.site \
-  mcr.microsoft.com/playwright:v1.52.0-noble \
+  mcr.microsoft.com/playwright:v1.57.0-noble \
   /bin/bash -c "npm install && npx playwright test"
 
 echo ""

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -464,7 +464,7 @@ IMAGE_MYSQL="docker.io/mysql:${DBMS_VERSION}"
 IMAGE_POSTGRES="docker.io/postgres:${DBMS_VERSION}-alpine"
 # E2E testing images (TYPO3 Core pattern)
 IMAGE_APACHE="ghcr.io/typo3/core-testing-apache24:1.7"
-IMAGE_PLAYWRIGHT="mcr.microsoft.com/playwright:v1.52.0-noble"
+IMAGE_PLAYWRIGHT="mcr.microsoft.com/playwright:v1.57.0-noble"
 
 # Set $1 to first mass argument, this is the optional test file or test directory to execute
 shift $((OPTIND - 1))

--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,7 @@
             "@ci:test:php:functional"
         ],
         "ci:test:e2e": [
-            "cd Tests/E2E && docker run --rm --network=ddev_default -v $(pwd):/app -w /app -e BASE_URL=https://v13.rte-ckeditor-image.ddev.site mcr.microsoft.com/playwright:v1.52.0-noble /bin/bash -c 'npm install && npx playwright test'"
+            "cd Tests/E2E && docker run --rm --network=ddev_default -v $(pwd):/app -w /app -e BASE_URL=https://v13.rte-ckeditor-image.ddev.site mcr.microsoft.com/playwright:v1.57.0-noble /bin/bash -c 'npm install && npx playwright test'"
         ]
     }
 }


### PR DESCRIPTION
## Summary
Update Playwright Docker image from v1.52.0 to v1.57.0 to match the updated Playwright package version.

## Files changed
- `composer.json` - ci:test:e2e script
- `Build/Scripts/runTests.sh` - IMAGE_PLAYWRIGHT variable
- `.ddev/commands/host/test-e2e` - docker run command

## Test plan
- [ ] CI E2E tests pass with new image version