### PR TITLE
fix(ci): use correct commit SHA for scorecard-action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,7 +29,7 @@ jobs:
                   persist-credentials: false
 
             - name: Run analysis
-              uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+              uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
               with:
                   results_file: results.sarif
                   results_format: sarif


### PR DESCRIPTION
## Summary
The scorecard workflow was failing because the annotated tag object SHA was used instead of the actual commit SHA.

**Error**: `imposter commit: 99c09fe... does not belong to ossf/scorecard-action`

## Fix
- Changed from tag object SHA (`99c09fe...`) to actual commit SHA (`4eaacf0...`)

## Why This Matters
OpenSSF Scorecard verifies that the action SHA actually belongs to the official repository. Annotated tags have their own SHA which is different from the commit SHA they point to.