### PR TITLE
docs: enable 'Give feedback' button on docs.typo3.org

### DIFF
--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -16,7 +16,7 @@
                project-contact="https://github.com/netresearch/t3x-rte_ckeditor_image/discussions"
                project-repository="https://github.com/netresearch/t3x-rte_ckeditor_image"
                project-issues="https://github.com/netresearch/t3x-rte_ckeditor_image/issues"
-               project-discussions="https://github.com/netresearch/t3x-rte_ckeditor_image/discussions"
+               report-issue="https://github.com/netresearch/t3x-rte_ckeditor_image/issues"
                typo3-core-preferred="13.4"/>
 
     <!-- Project Metadata -->


### PR DESCRIPTION
## Summary
- Replace non-standard `project-discussions` attribute with valid `report-issue` attribute
- Enables the "Give feedback" button in the rendered documentation on docs.typo3.org

## Test plan
- Verify documentation renders correctly after merge
- Check that "Give feedback" button appears and links to GitHub issues