### PR TITLE
fix(config): remove TCA richtextConfiguration override

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -427,12 +427,6 @@ parameters:
 			path: ../Configuration/TCA/Overrides/tt_content.php
 
 		-
-			message: '#^Cannot access offset ''richtextConfiguration'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: ../Configuration/TCA/Overrides/tt_content.php
-
-		-
 			message: '#^Cannot access offset ''softref'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove TCA `richtextConfiguration` override that blocked TSconfig preset overrides (#464)
+
 ## [14.0.0] - TBD
 
 ### Added

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -35,9 +35,6 @@ call_user_func(
             $cleanSoftReferences,
         );
 
-        // Override RTE configuration for bodytext field to use our preset with image support
-        $GLOBALS['TCA']['tt_content']['columns']['bodytext']['config']['richtextConfiguration'] = 'rteWithImages';
-
         // Register preview renderer
         $GLOBALS['TCA']['tt_content']['types']['text']['previewRenderer']
             = RteImagePreviewRenderer::class;


### PR DESCRIPTION
## Summary

Removes the TCA-level `richtextConfiguration` override that was blocking users from customizing the RTE preset via TSconfig.

### Problem

The extension was setting the RTE configuration in two places:
1. **TCA** (`tt_content.php:39`): `richtextConfiguration = 'rteWithImages'`
2. **TSconfig** (`page.tsconfig:2`): `RTE.default.preset = rteWithImages`

Since TCA `richtextConfiguration` takes precedence over `RTE.default.preset` in TSconfig, users could not override the preset using the standard TYPO3 approach.

### Solution

- Remove the TCA `richtextConfiguration` line (redundant since TSconfig already handles this)
- Keep TSconfig `RTE.default.preset = rteWithImages` (zero-config still works)
- Clean up related PHPStan baseline entry

### After this change

Users can now properly override the preset using:
```typoscript
# Global override
RTE.default.preset = myPreset

# Field-specific override  
RTE.config.tt_content.bodytext.preset = myPreset
```

### Impact

- ✅ Zero-config installation unchanged
- ✅ Standard TYPO3 override patterns now work
- ✅ No breaking changes

Resolves #464