### PR TITLE
chore(config): remove dead rtehtmlarea_images_db transformation mode

### DIFF
--- a/Configuration/Sets/RteCKEditorImage/page.tsconfig
+++ b/Configuration/Sets/RteCKEditorImage/page.tsconfig
@@ -9,7 +9,6 @@ RTE.default.preset = rteWithImages
 
 # Configure image processing
 RTE.default.proc.overruleMode := addToList(default)
-RTE.default.proc.overruleMode := addToList(rtehtmlarea_images_db)
 
 RTE.default.buttons.image.options.magic {
     maxWidth = 1920

--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -3,7 +3,6 @@ RTE.default.preset = rteWithImages
 
 # Configure image processing
 RTE.default.proc.overruleMode := addToList(default)
-RTE.default.proc.overruleMode := addToList(rtehtmlarea_images_db)
 
 RTE.default.buttons.image.options.magic {
     maxWidth = 1920

--- a/Documentation/Integration/TSConfig.rst
+++ b/Documentation/Integration/TSConfig.rst
@@ -67,7 +67,6 @@ Processing Modes
 .. code-block:: typoscript
 
    RTE.default.proc.overruleMode := addToList(default)
-   RTE.default.proc.overruleMode := addToList(rtehtmlarea_images_db)
 
 .. _integration-configuration-upload-folder:
 


### PR DESCRIPTION
## Summary

- Remove dead `rtehtmlarea_images_db` RTE transformation mode from TSConfig files
- Update documentation to reflect the removal

## Background

The `rtehtmlarea_images_db` configuration was originally added in TYPO3 v10/v11 (commit `ba50233`) when the extension used a transformation hook:

```php
// Old hook (v10/v11) - REMOVED in v12
$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_parsehtml_proc.php']['transformation']['rtehtmlarea_images_db']
```

In TYPO3 v12 (commit `1cfe7a7`), the hook mechanism was changed to a DataHandler hook:

```php
// Current hook (v12+) - runs on ALL saves
$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][]
```

The TSConfig line was never cleaned up and has been silently ignored since v12 because:
- TYPO3 v13 core only recognizes: `default`, `css_transform`, `ts_links`, `detectbrokenlinks`
- Our extension no longer registers a transformation hook listener

## Changes

| File | Change |
|------|--------|
| `Configuration/page.tsconfig` | Remove dead line |
| `Configuration/Sets/RteCKEditorImage/page.tsconfig` | Remove dead line |
| `Documentation/Integration/TSConfig.rst` | Update docs |

## Test plan

- [x] PHP lint passes
- [x] PHP-CS-Fixer passes
- [x] PHPStan passes
- [ ] CI pipeline passes
- [ ] Image insertion still works in RTE (DataHandler hook unaffected)