### PR TITLE
fix(js): remove dead code referencing undefined $checkboxNoResize

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -312,13 +312,6 @@ function getImageDialog(editor, img, attributes) {
 
     $customRow.append($customRowCol1, $customRowCol2);
 
-    // Check for existing noresize attribute
-    if (attributes['data-htmlarea-noresize']) {
-        $checkboxNoResize.prop('checked', true);
-        $inputWidth.prop('disabled', true);
-        $inputHeight.prop('disabled', true);
-    }
-
     // Support new `zoom` and legacy `clickenlarge` attributes
     if (attributes['data-htmlarea-zoom'] || attributes['data-htmlarea-clickenlarge']) {
         $zoom.prop('checked', true);


### PR DESCRIPTION
## Summary

Removes orphaned dead code that referenced an undefined `$checkboxNoResize` variable.

## Problem

The code block handling `data-htmlarea-noresize` attribute (lines 315-320) referenced `$checkboxNoResize` which was **never defined**, causing a potential `ReferenceError` if triggered.

## Investigation

| Question | Finding |
|----------|---------|
| When introduced? | Commit `e2fe9ff` (Dec 29, 2020) |
| Original feature | [#88](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/88) - Add custom class field |
| Was `$checkboxNoResize` ever defined? | ❌ No |
| Does UI exist to set attribute? | ❌ No |
| GitHub issues about this? | ❌ None in 4+ years |
| Code path reachable? | ❌ No |

## Root Cause

The contributor added attribute handling code but never created the corresponding UI checkbox element. This was incomplete feature code from day one.

## Changes

- Removed 7 lines of dead code from `typo3image.js`

## Test Plan

- [x] Pre-commit hooks pass (PHP lint, CS-Fixer, PHPStan)
- [x] No functional change (code was unreachable)