### PR TITLE
chore: Remove accidentally committed log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ Tests/E2E/node_modules/
 Tests/E2E/playwright-report/
 Tests/E2E/test-results/
 Build/test-results/
+render-output.log

--- a/render-output.log
+++ b/render-output.log
@@ -1,8 +1,0 @@
-
-The command 'docker' could not be found in this WSL 2 distro.
-We recommend to activate the WSL integration in Docker Desktop settings.
-
-For details about using Docker Desktop with WSL 2, visit:
-
-https://docs.docker.com/go/wsl2/
-


### PR DESCRIPTION
Removes `render-output.log` (Docker/DDEV debug output) and adds it to `.gitignore` to prevent future accidents.