### PR TITLE
fix(controller): folder navigation and file permission check (#290)

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -49,12 +49,6 @@ parameters:
 			path: ../Classes/Controller/ImageRenderingAdapter.php
 
 		-
-			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: ../Classes/Controller/SelectImageController.php
-
-		-
 			message: '#^Cannot access offset ''GFX'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
@@ -109,12 +103,6 @@ parameters:
 			path: ../Classes/Controller/SelectImageController.php
 
 		-
-			message: '#^Cannot access offset ''uid'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: ../Classes/Controller/SelectImageController.php
-
-		-
 			message: '#^Cannot access offset non\-falsy\-string on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
@@ -127,21 +115,9 @@ parameters:
 			path: ../Classes/Controller/SelectImageController.php
 
 		-
-			message: '#^Cannot call method getFileStorageRecords\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: ../Classes/Controller/SelectImageController.php
-
-		-
-			message: '#^Cannot call method isAdmin\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: ../Classes/Controller/SelectImageController.php
-
-		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
-			count: 8
+			count: 6
 			path: ../Classes/Controller/SelectImageController.php
 
 		-


### PR DESCRIPTION
## Summary

Fixes two bugs reported by @akiessling in issue #290 follow-up:

1. **expandFolder always overwritten**: Admin users couldn't browse folders because `expandFolder` was always set to the default upload folder. Now only sets default when NOT already provided.

2. **`getFileStorageRecords()` undefined method**: This method doesn't exist in TYPO3's `BackendUserAuthentication`. Replaced with `File::checkActionPermission('read')` which correctly uses TYPO3's built-in permission system.

## Root Cause Analysis

The old permission check had two issues:
- Used non-existent method `getFileStorageRecords()` 
- Logic was semantically wrong: compared file **storage** UIDs against file **mount** UIDs (these are different entities in TYPO3)

## Solution

Uses `File::checkActionPermission('read')` which internally:
- Checks admin status (admins always have access)
- Validates file mount boundaries via `isWithinFileMountBoundaries()`
- Respects user group permissions

## Changes

| File | Change |
|------|--------|
| `SelectImageController.php:109-125` | Only set `expandFolder` if NOT already provided |
| `SelectImageController.php:395-416` | Use `File::checkActionPermission('read')` |
| `SelectImageControllerTest.php` | Updated and added tests for new permission logic |
| `phpstan-baseline.neon` | Removed obsolete suppressed errors |

## Test plan

- [x] Unit tests pass (123 tests, 366 assertions)
- [x] CI passes (lint, phpstan, functional, e2e)
- [ ] Admin users can browse folders in image selector
- [ ] Non-admin users can access files within their file mounts

---

Thanks to @akiessling for reporting these bugs!