### PR TITLE
Security: Fix workflow permissions (Scorecard alert)

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -5,14 +5,18 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
     # Only run for bot accounts
     if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'
+
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - name: Approve PR
         env:


### PR DESCRIPTION
## Summary

Fixes OpenSSF Scorecard security alert #10 (TokenPermissionsID) by implementing principle of least privilege for GitHub Actions workflow permissions.

## Changes

- **auto-merge-deps.yml**: Moved permissions from workflow level to job level
  - Set restrictive `contents: read` at workflow level (default for all jobs)
  - Moved `contents: write` and `pull-requests: write` to job level (only where needed)

## Security Impact

This change follows GitHub Actions security best practices:

1. **Principle of Least Privilege**: Workflows start with minimal permissions
2. **Job-Level Permissions**: Only specific jobs get elevated permissions
3. **Scorecard Compliance**: Resolves TokenPermissionsID alert

## Related

- Scorecard Alert: #10 (TokenPermissionsID)
- Security Best Practice: [GitHub Token Permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

## Testing

- Workflow syntax validated
- All existing actions already pinned to SHA
- No functional changes to workflow behavior