### PR TITLE
feat(ci): add workflow_dispatch trigger for TER publish

### DIFF
--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -3,6 +3,12 @@ name: Publish new extension version to TER
 on:
     release:
         types: [published]
+    workflow_dispatch:
+        inputs:
+            version:
+                description: 'Version to publish (e.g., 13.1.0)'
+                required: true
+                type: string
 
 permissions:
     contents: read
@@ -10,7 +16,7 @@ permissions:
 jobs:
     publish:
         name: Publish new version to TER
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
 
         permissions:
@@ -24,17 +30,36 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-            - name: Check tag
+            - name: Validate and extract version
+              id: get-version
               env:
-                  GIT_REF: ${{ github.ref }}
+                  INPUT_VERSION: ${{ inputs.version }}
               run: |
-                  if ! [[ "${GIT_REF}" =~ ^refs/tags/v[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
-                      exit 1
+                  if [[ -n "${INPUT_VERSION}" ]]; then
+                      # Manual dispatch - validate and normalize input version
+                      if ! [[ "${INPUT_VERSION}" =~ ^v?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+                          echo "Invalid input version format: ${INPUT_VERSION}"
+                          echo "Expected format: 13.1.0 or v13.1.0"
+                          exit 1
+                      fi
+                      # Strip optional leading 'v' for internal use
+                      normalized_version="${INPUT_VERSION#v}"
+                      echo "version=${normalized_version}" >> $GITHUB_ENV
+                  else
+                      # Release event - extract from tag
+                      if ! [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+                          echo "Invalid tag format: ${GITHUB_REF}"
+                          exit 1
+                      fi
+                      echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
                   fi
 
-            - name: Get version
-              id: get-version
-              run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+            - name: Checkout tag
+              if: inputs.version != ''
+              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+              with:
+                  ref: v${{ env.version }}
+                  fetch-tags: true
 
             - name: Get comment
               id: get-comment


### PR DESCRIPTION
## Add Manual Trigger for TER Publish

Adds `workflow_dispatch` trigger to allow manual re-publishing to TER.

### Usage

```bash
gh workflow run publish-to-ter.yml -f version=13.1.0
```

### Why

The v13.1.0 TER publish failed due to workflow issues (fixed in #487). This allows re-triggering the publish without recreating the release.

### Changes

- Add `workflow_dispatch` with version input
- Handle both release events and manual triggers
- Checkout specific tag when manually triggered