### PR TITLE
docs(agents): add ddev functional test commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,18 @@ See **[claudedocs/INDEX.md](claudedocs/INDEX.md)** for AI context navigation.
 ## ⚡ Pre-Commit Checklist
 
 ```bash
-composer ci:test              # All checks (lint + phpstan + rector + cgl)
-composer ci:cgl               # Auto-fix code style if needed
+# Quality checks (lint + phpstan + rector + cgl)
+composer ci:test
+
+# Run FULL test suite (ALWAYS run before committing!)
+composer ci:test:php:unit  # Unit tests
+ddev exec "cd /var/www/rte_ckeditor_image && typo3DatabaseHost=db typo3DatabaseUsername=root typo3DatabasePassword=root typo3DatabaseName=func_test .Build/bin/phpunit -c Build/phpunit/FunctionalTests.xml"  # Functional tests
+
+# Auto-fix code style
+composer ci:cgl
 ```
+
+**IMPORTANT:** ddev/containers are ALWAYS available in this project. Never skip functional tests!
 
 ## 📂 Scoped Guides (Nearest Wins)
 

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -66,26 +66,37 @@ class RteImageSoftReferenceParserTest extends FunctionalTestCase
 ## 🔧 Build & Tests
 
 ### Running Tests
-```bash
-# Currently no test runner configured in Makefile
-# When available, use:
-make test                           # Run all tests
-make test-functional               # Functional tests only
-make test-unit                     # Unit tests only
 
-# Direct PHPUnit execution
-vendor/bin/phpunit Tests/Functional/
-vendor/bin/phpunit Tests/Unit/
+**CRITICAL: Always run the full test suite before committing changes!**
+
+```bash
+# Unit tests (no database required)
+composer ci:test:php:unit
+
+# Functional tests (REQUIRES ddev with database)
+# ALWAYS use ddev for functional tests - never skip them!
+ddev start  # Ensure ddev is running first
+ddev exec "cd /var/www/rte_ckeditor_image && typo3DatabaseHost=db typo3DatabaseUsername=root typo3DatabasePassword=root typo3DatabaseName=func_test .Build/bin/phpunit -c Build/phpunit/FunctionalTests.xml"
+
+# Run all tests (unit + functional)
+composer ci:test:php:unit && ddev exec "cd /var/www/rte_ckeditor_image && typo3DatabaseHost=db typo3DatabaseUsername=root typo3DatabasePassword=root typo3DatabaseName=func_test .Build/bin/phpunit -c Build/phpunit/FunctionalTests.xml"
 
 # With coverage (requires xdebug)
-vendor/bin/phpunit --coverage-html coverage/ Tests/
+composer ci:coverage:unit
+ddev exec "cd /var/www/rte_ckeditor_image && typo3DatabaseHost=db typo3DatabaseUsername=root typo3DatabasePassword=root typo3DatabaseName=func_test .Build/bin/phpunit -c Build/phpunit/FunctionalTests.xml --coverage-html=.Build/coverage-functional"
 ```
 
 ### Test Configuration
-Test configuration location (when available):
-- `phpunit.xml.dist` - PHPUnit configuration
-- `Build/phpunit-functional.xml` - Functional tests config
-- `Build/phpunit-unit.xml` - Unit tests config
+- `Build/phpunit/UnitTests.xml` - Unit tests config
+- `Build/phpunit/FunctionalTests.xml` - Functional tests config
+- `phpunit.xml` - Legacy config (relative paths for TYPO3 vendor setup)
+
+### Database Requirements for Functional Tests
+Functional tests require database credentials via environment variables:
+- `typo3DatabaseHost=db` (ddev database hostname)
+- `typo3DatabaseUsername=root`
+- `typo3DatabasePassword=root`
+- `typo3DatabaseName=func_test` (uses dedicated test database)
 
 ## 📝 Code Style
 


### PR DESCRIPTION
## Summary
- Document proper way to run functional tests using ddev
- Add database environment variables for TYPO3 testing framework
- Mark functional tests as critical pre-commit requirement

## Changes
- `AGENTS.md`: Add ddev exec command for functional tests
- `Tests/AGENTS.md`: Complete test running documentation with ddev

This ensures AI agents and developers always run the full test suite.