### PR TITLE
Clarify two image styling approaches in documentation

### DIFF
--- a/Documentation/Examples/Image-Styles.rst
+++ b/Documentation/Examples/Image-Styles.rst
@@ -306,7 +306,7 @@ Choosing the right approach
      - None required
      - YAML configuration needed
    * - Styles available
-     - 5 alignment presets
+     - 5 style options (3 alignment + 2 display)
      - Custom (you define them)
    * - Location
      - Balloon above image


### PR DESCRIPTION
## Summary
Rewrites `Documentation/Examples/Image-Styles.rst` to clearly explain:

1. **Built-in balloon toolbar buttons** - work out of the box with `rteWithImages` preset
2. **Native CKEditor Style dropdown** - requires additional configuration

## Problem
The previous documentation only covered the native Style dropdown configuration, causing confusion for users who expected image styles to work automatically (Issue #501). Users didn't know:
- That built-in alignment buttons exist in the balloon toolbar
- That they need to click on an image to see the balloon toolbar
- That the native Style dropdown is a separate feature requiring configuration

## Changes
- Added overview section explaining both approaches
- Added table of built-in alignment styles (image-left, image-center, image-right, etc.)
- Added step-by-step usage instructions for both approaches
- Added requirements section for native Style dropdown
- Added troubleshooting section
- Added comparison table to help users choose the right approach

## Test Plan
- [x] RST syntax is valid
- [x] Documentation renders correctly

Closes #501