### PR TITLE
feat(ci): add release labeler workflow

### DIFF
--- a/.github/workflows/release-labeler.yml
+++ b/.github/workflows/release-labeler.yml
@@ -56,14 +56,15 @@ jobs:
           LABEL_NAME: ${{ steps.release.outputs.label }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
-          # Create label if it doesn't exist (green color: 0e8a16)
+          # Create or update label (green color: 0e8a16)
           gh label create "${LABEL_NAME}" \
             --repo ${{ github.repository }} \
             --color 0e8a16 \
             --description "Released in ${RELEASE_TAG}" \
-            2>/dev/null || echo "Label already exists"
+            --force
 
       - name: Find and label merged PRs
+        id: label_prs
         env:
           GH_TOKEN: ${{ github.token }}
           LABEL_NAME: ${{ steps.release.outputs.label }}
@@ -71,15 +72,19 @@ jobs:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
           PREV_TAG: ${{ steps.prev_release.outputs.tag }}
         run: |
+          LABELED_PRS=""
+
           # Get merge commits between tags
           if [[ -n "${PREV_TAG}" ]]; then
             echo "Finding PRs merged between ${PREV_TAG} and ${RELEASE_TAG}"
-            # Get commits between tags
-            COMMITS=$(gh api repos/${{ github.repository }}/compare/${PREV_TAG}...${RELEASE_TAG} \
-              --jq '.commits[].sha' 2>/dev/null || echo "")
+            # Get commits between tags with explicit error handling
+            if ! COMMITS=$(gh api repos/${{ github.repository }}/compare/${PREV_TAG}...${RELEASE_TAG} \
+              --jq '.commits[].sha' 2>&1); then
+              echo "::warning::Failed to fetch commits between ${PREV_TAG} and ${RELEASE_TAG}: ${COMMITS}"
+              COMMITS=""
+            fi
           else
-            echo "No previous release found, labeling PRs from last 30 days"
-            # Fallback: get recent merged PRs
+            echo "No previous release found"
             COMMITS=""
           fi
 
@@ -91,6 +96,7 @@ jobs:
                 --jq '.[0].number // empty' 2>/dev/null || echo "")
               if [[ -n "${PR_NUM}" ]]; then
                 echo "Found PR #${PR_NUM} for commit ${sha:0:7}"
+                LABELED_PRS="${LABELED_PRS} ${PR_NUM}"
                 # Add label
                 gh pr edit ${PR_NUM} --repo ${{ github.repository }} \
                   --add-label "${LABEL_NAME}" 2>/dev/null || true
@@ -104,14 +110,21 @@ jobs:
               fi
             done
           else
-            # Fallback: find PRs merged to default branch recently
-            echo "Using fallback: searching recently merged PRs"
-            gh pr list --repo ${{ github.repository }} --state merged --limit 50 \
-              --json number,mergedAt --jq '.[].number' | while read PR_NUM; do
+            # Fallback for first release: find PRs merged to default branch
+            # Only label PRs that don't already have a released: label
+            echo "Using fallback: searching recently merged PRs without release labels"
+            PR_LIST=$(gh pr list --repo ${{ github.repository }} --state merged --limit 50 \
+              --json number,labels --jq '.[] | select(.labels | map(.name) | any(startswith("released:")) | not) | .number')
+            for PR_NUM in ${PR_LIST}; do
+              echo "Labeling PR #${PR_NUM} (first release)"
+              LABELED_PRS="${LABELED_PRS} ${PR_NUM}"
               gh pr edit ${PR_NUM} --repo ${{ github.repository }} \
                 --add-label "${LABEL_NAME}" 2>/dev/null || true
             done
           fi
+
+          # Output labeled PRs for next step (avoid race condition with label query)
+          echo "labeled_prs=${LABELED_PRS}" >> $GITHUB_OUTPUT
 
       - name: Find and label closed issues
         env:
@@ -119,13 +132,10 @@ jobs:
           LABEL_NAME: ${{ steps.release.outputs.label }}
           RELEASE_URL: ${{ steps.release.outputs.url }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          LABELED_PRS: ${{ steps.label_prs.outputs.labeled_prs }}
         run: |
-          # Find issues that reference the release label PRs
-          # Get PRs with the release label
-          PR_NUMBERS=$(gh pr list --repo ${{ github.repository }} --state merged \
-            --label "${LABEL_NAME}" --json number --jq '.[].number')
-
-          for PR_NUM in ${PR_NUMBERS}; do
+          # Use PR numbers from previous step (avoids race condition with label propagation)
+          for PR_NUM in ${LABELED_PRS}; do
             # Get issues linked/closed by this PR
             LINKED_ISSUES=$(gh pr view ${PR_NUM} --repo ${{ github.repository }} \
               --json closingIssuesReferences --jq '.closingIssuesReferences[].number' 2>/dev/null || echo "")
@@ -153,10 +163,13 @@ jobs:
             --label "${LABEL_NAME}" --json number --jq 'length')
           ISSUE_COUNT=$(gh issue list --repo ${{ github.repository }} --state closed \
             --label "${LABEL_NAME}" --json number --jq 'length')
+          # Properly URL-encode the query parameter
+          QUERY="label:${LABEL_NAME}"
+          ENCODED_QUERY=$(printf '%s' "${QUERY}" | jq -sRr @uri)
           echo "## Release Labeling Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Label:** \`${LABEL_NAME}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **PRs labeled:** ${PR_COUNT}" >> $GITHUB_STEP_SUMMARY
           echo "- **Issues labeled:** ${ISSUE_COUNT}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "[View all labeled items](https://github.com/${{ github.repository }}/issues?q=label%3A${LABEL_NAME})" >> $GITHUB_STEP_SUMMARY
+          echo "[View all labeled items](https://github.com/${{ github.repository }}/issues?q=${ENCODED_QUERY})" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Add automatic release labeling for PRs and issues

## What it does

When a release is published, this workflow:
1. Creates label `released:vX.Y.Z` (green)
2. Finds all PRs merged since previous release
3. Labels those PRs
4. Finds issues closed by those PRs
5. Labels those issues  
6. Adds comments linking to the release

## Benefits

- Users see "Fixed in v13.2.0" on their reported issues
- Easy to query what shipped in a release
- Automatic audit trail

## Usage

After merge, all future releases will auto-label. Query with:
```
https://github.com/netresearch/t3x-rte_ckeditor_image/issues?q=label:released:v13.2.0
```

## Test plan

- [ ] Merge this PR
- [ ] Create a test release
- [ ] Verify PRs and issues get labeled