### PR TITLE
fix: resolve YAML syntax error in publish-to-ter workflow

### DIFF
--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -92,9 +92,7 @@ jobs:
 
                   # Append release link if available
                   if [[ -n "${RELEASE_URL}" ]]; then
-                      COMMENT="${COMMENT}
-
-Details: ${RELEASE_URL}"
+                      COMMENT=$(printf '%s\n\nDetails: %s' "${COMMENT}" "${RELEASE_URL}")
                   fi
 
                   # Use heredoc for multiline support in GitHub Actions


### PR DESCRIPTION
## Summary

Fixes invalid YAML syntax in `.github/workflows/publish-to-ter.yml` that caused GitHub Actions to reject the workflow file.

**Problem:** Embedded newlines in bash string assignment (lines 95-97) confused YAML parsers:
```yaml
COMMENT="${COMMENT}

Details: ${RELEASE_URL}"
```

**Solution:** Use `printf` to construct the multiline string:
```yaml
COMMENT=$(printf '%s\n\nDetails: %s' "${COMMENT}" "${RELEASE_URL}")
```

## Test plan

- [ ] Workflow file passes YAML validation
- [ ] CI passes