### PR TITLE
ci: add SLSA provenance workflow and badge

### DIFF
--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -1,0 +1,121 @@
+name: SLSA Provenance
+
+on:
+  release:
+    types: [published]
+
+permissions: read-all
+
+jobs:
+  provenance:
+    name: Generate SLSA Provenance
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    outputs:
+      subjects: ${{ steps.subjects.outputs.subjects }}
+      has_subjects: ${{ steps.subjects.outputs.has_subjects }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p release-assets
+          gh release download "${{ github.event.release.tag_name }}" -D release-assets || true
+          ls -la release-assets/ || echo "No release assets found"
+
+      - name: Generate provenance subjects
+        id: subjects
+        run: |
+          cd release-assets
+          if ls * 1> /dev/null 2>&1; then
+            sha256sum * > ../provenance-subjects.txt
+            cat ../provenance-subjects.txt
+            SUBJECTS=$(cat ../provenance-subjects.txt | awk '{print "{\"name\":\""$2"\",\"digest\":{\"sha256\":\""$1"\"}}"}' | jq -s -c '.')
+            SUBJECTS_BASE64=$(echo "$SUBJECTS" | base64 -w0)
+            echo "subjects=$SUBJECTS_BASE64" >> "$GITHUB_OUTPUT"
+            echo "has_subjects=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No assets to hash, using source commit"
+            echo "has_subjects=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate source provenance attestation
+        run: |
+          cat > source-provenance.json << 'EOF'
+          {
+            "_type": "https://in-toto.io/Statement/v0.1",
+            "predicateType": "https://slsa.dev/provenance/v0.2",
+            "subject": [
+              {
+                "name": "github.com/netresearch/t3x-rte_ckeditor_image",
+                "digest": {
+                  "sha1": "${{ github.sha }}"
+                }
+              }
+            ],
+            "predicate": {
+              "builder": {
+                "id": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              },
+              "buildType": "https://github.com/slsa-framework/slsa-github-generator/generic@v1",
+              "invocation": {
+                "configSource": {
+                  "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
+                  "digest": {
+                    "sha1": "${{ github.sha }}"
+                  },
+                  "entryPoint": ".github/workflows/slsa-provenance.yml"
+                }
+              },
+              "metadata": {
+                "buildInvocationID": "${{ github.run_id }}",
+                "completeness": {
+                  "parameters": true,
+                  "environment": true,
+                  "materials": true
+                },
+                "reproducible": false
+              },
+              "materials": [
+                {
+                  "uri": "git+https://github.com/${{ github.repository }}@${{ github.ref }}",
+                  "digest": {
+                    "sha1": "${{ github.sha }}"
+                  }
+                }
+              ]
+            }
+          }
+          EOF
+
+      - name: Upload source provenance
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" source-provenance.json --clobber || true
+
+  slsa-provenance:
+    name: SLSA Level 3 Provenance
+    needs: provenance
+    if: needs.provenance.outputs.has_subjects == 'true'
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: ${{ needs.provenance.outputs.subjects }}
+      upload-assets: true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![PHPStan](https://img.shields.io/badge/PHPStan-level%2010-brightgreen.svg)](https://phpstan.org/)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![codecov](https://codecov.io/gh/netresearch/t3x-rte_ckeditor_image/graph/badge.svg)](https://codecov.io/gh/netresearch/t3x-rte_ckeditor_image)
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 
 ![Total downloads](https://typo3-badges.dev/badge/rte_ckeditor_image/downloads/shields.svg)
 ![TYPO3 extension](https://typo3-badges.dev/badge/rte_ckeditor_image/extension/shields.svg)


### PR DESCRIPTION
## Summary

- Add SLSA Level 3 provenance workflow for release attestation
- Add SLSA 3 badge to README

This adds SLSA Level 3 supply chain security for releases.