### PR TITLE
feat(ci): add create-release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,76 @@
+name: Create Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            version:
+                description: 'Version to release (e.g., 13.3.2)'
+                required: true
+                type: string
+            release_notes:
+                description: 'Release notes (markdown supported)'
+                required: false
+                type: string
+                default: ''
+
+permissions:
+    contents: write
+
+jobs:
+    create-release:
+        name: Create Release
+        runs-on: ubuntu-latest
+
+        env:
+            INPUT_VERSION: ${{ inputs.version }}
+            INPUT_RELEASE_NOTES: ${{ inputs.release_notes }}
+
+        steps:
+            - name: Validate version format
+              run: |
+                  if ! [[ "${INPUT_VERSION}" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+                      echo "::error::Invalid version format: ${INPUT_VERSION}. Expected: X.Y.Z (e.g., 13.3.2)"
+                      exit 1
+                  fi
+                  echo "VERSION=${INPUT_VERSION}" >> $GITHUB_ENV
+
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Configure git
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            - name: Update ext_emconf.php version
+              run: |
+                  sed -i "s/'version'[[:space:]]*=>[[:space:]]*'[^']*'/'version'        => '${VERSION}'/" ext_emconf.php
+                  echo "Updated ext_emconf.php to version ${VERSION}"
+                  grep "'version'" ext_emconf.php
+
+            - name: Commit version bump
+              run: |
+                  git add ext_emconf.php
+                  git commit -m "chore: bump version to ${VERSION}"
+                  git push origin main
+
+            - name: Create release
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  if [[ -n "${INPUT_RELEASE_NOTES}" ]]; then
+                      gh release create "v${VERSION}" \
+                          --title "v${VERSION}" \
+                          --notes "${INPUT_RELEASE_NOTES}"
+                  else
+                      gh release create "v${VERSION}" \
+                          --title "v${VERSION}" \
+                          --generate-notes
+                  fi
+
+            - name: Output release URL
+              run: |
+                  echo "::notice::Release created: https://github.com/${{ github.repository }}/releases/tag/v${VERSION}"


### PR DESCRIPTION
## Summary
- Adds automated release workflow that handles version bumping
- Updates ext_emconf.php version before creating release
- Prevents version mismatch issues with TER publishing

## Features
- Manual workflow dispatch with version input
- Version format validation (X.Y.Z)
- Automatic ext_emconf.php update
- Commits version bump before creating release
- Supports custom release notes or auto-generated notes

## Test plan
- [ ] Trigger workflow with test version
- [ ] Verify ext_emconf.php is updated correctly
- [ ] Verify release is created with correct tag