### PR TITLE
docs: add signed releases requirement to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,24 @@ See **[claudedocs/INDEX.md](claudedocs/INDEX.md)** for AI context navigation.
 - **Commits:** Use conventional format: `type(scope): message`
 - **Security:** No secrets in VCS (use .env, LocalConfiguration.php)
 - **Quality Gate:** All code must pass `composer ci:test` before commit
+- **Releases:** ALWAYS create signed tags - NEVER use `gh release create` alone
+
+## 🏷️ Creating Signed Releases
+
+**CRITICAL:** Tags/releases created via `gh release create` are UNSIGNED. Always use this process:
+
+```bash
+# 1. Create signed tag locally
+git tag -s vX.Y.Z -m "vX.Y.Z"
+
+# 2. Push signed tag to remote
+git push origin vX.Y.Z
+
+# 3. Create release on existing tag (tag already exists, so it stays signed)
+gh release create vX.Y.Z --title "vX.Y.Z" --notes "Release notes..."
+```
+
+**NEVER:** Run `gh release create` without first creating and pushing a signed tag.
 
 ## ⚡ Pre-Commit Checklist
 


### PR DESCRIPTION
## Summary
- Adds mandatory signed releases requirement to Global Rules
- Documents the correct process for creating signed tags/releases
- Prevents future unsigned releases

## Process
```bash
git tag -s vX.Y.Z -m "vX.Y.Z"   # Create signed tag locally
git push origin vX.Y.Z          # Push signed tag
gh release create vX.Y.Z ...    # Create release on existing tag
```