### PR TITLE
fix(ci): add CODECOV_TOKEN for Codecov uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
                 if: ${{ always() && steps.coverage.conclusion == 'success' && matrix.run_coverage }}
                 uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
                 with:
+                    token: ${{ secrets.CODECOV_TOKEN }}
                     files: .Build/logs/clover.xml
                     fail_ci_if_error: false
 


### PR DESCRIPTION
## Summary
- Add explicit `token` parameter to codecov-action

The codecov-action requires an explicit token parameter to authenticate uploads. Without it, uploads may appear to succeed but data doesn't appear in the Codecov dashboard.

## Test plan
- [ ] Verify Codecov upload works after merging and running CI