### PR TITLE
feat(security): sanitize SVG data URIs to prevent XSS attacks

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -37,6 +37,7 @@ services:
     arguments:
       $resourceFactory: '@TYPO3\CMS\Core\Resource\ResourceFactory'
       $processedFilesHandler: '@Netresearch\RteCKEditorImage\Utils\ProcessedFilesHandler'
+      $svgSanitizer: '@TYPO3\CMS\Core\Resource\Security\SvgSanitizer'
       $logManager: '@TYPO3\CMS\Core\Log\LogManager'
 
   Netresearch\RteCKEditorImage\Service\ImageRenderingService:

--- a/Tests/Unit/Service/ImageResolverServiceTest.php
+++ b/Tests/Unit/Service/ImageResolverServiceTest.php
@@ -20,6 +20,7 @@ use ReflectionMethod;
 use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Resource\Security\SvgSanitizer;
 
 /**
  * Test case for ImageResolverService.
@@ -37,6 +38,9 @@ final class ImageResolverServiceTest extends TestCase
     /** @var ProcessedFilesHandler&\PHPUnit\Framework\MockObject\MockObject */
     private ProcessedFilesHandler $processedFilesHandlerMock;
 
+    /** @var SvgSanitizer&\PHPUnit\Framework\MockObject\MockObject */
+    private SvgSanitizer $svgSanitizerMock;
+
     /** @var LogManager&\PHPUnit\Framework\MockObject\MockObject */
     private LogManager $logManagerMock;
 
@@ -46,15 +50,21 @@ final class ImageResolverServiceTest extends TestCase
 
         $this->resourceFactoryMock       = $this->createMock(ResourceFactory::class);
         $this->processedFilesHandlerMock = $this->createMock(ProcessedFilesHandler::class);
+        $this->svgSanitizerMock          = $this->createMock(SvgSanitizer::class);
         $this->logManagerMock            = $this->createMock(LogManager::class);
 
         // Mock logger to prevent null reference
         $loggerMock = $this->createMock(\Psr\Log\LoggerInterface::class);
         $this->logManagerMock->method('getLogger')->willReturn($loggerMock);
 
+        // Default: SvgSanitizer returns content unchanged (pass-through)
+        $this->svgSanitizerMock->method('sanitizeContent')
+            ->willReturnCallback(static fn (string $content): string => $content);
+
         $this->service = new ImageResolverService(
             $this->resourceFactoryMock,
             $this->processedFilesHandlerMock,
+            $this->svgSanitizerMock,
             $this->logManagerMock,
         );
     }
@@ -238,5 +248,265 @@ final class ImageResolverServiceTest extends TestCase
         $result = $this->callPrivateMethod($this->service, 'getAttributeValue', ['alt', $attributes, $fileMock]);
 
         self::assertNull($result);
+    }
+
+    // ========================================================================
+    // SVG Data URI Sanitization Tests
+    // ========================================================================
+
+    /**
+     * Helper to create a service instance with custom SvgSanitizer mock behavior.
+     *
+     * @param callable(string): string $sanitizerCallback Callback for sanitizeContent
+     */
+    private function createServiceWithSanitizer(callable $sanitizerCallback): ImageResolverService
+    {
+        $svgSanitizerMock = $this->createMock(SvgSanitizer::class);
+        $svgSanitizerMock->method('sanitizeContent')
+            ->willReturnCallback($sanitizerCallback);
+
+        return new ImageResolverService(
+            $this->resourceFactoryMock,
+            $this->processedFilesHandlerMock,
+            $svgSanitizerMock,
+            $this->logManagerMock,
+        );
+    }
+
+    #[Test]
+    public function sanitizeSvgDataUriPassesThroughNonSvgDataUri(): void
+    {
+        // PNG data URI should pass through unchanged
+        $pngDataUri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+        $result = $this->callPrivateMethod($this->service, 'sanitizeSvgDataUri', [$pngDataUri]);
+
+        self::assertSame($pngDataUri, $result);
+    }
+
+    #[Test]
+    public function sanitizeSvgDataUriPassesThroughRegularHttpsUrl(): void
+    {
+        $httpsUrl = 'https://example.com/image.svg';
+
+        $result = $this->callPrivateMethod($this->service, 'sanitizeSvgDataUri', [$httpsUrl]);
+
+        self::assertSame($httpsUrl, $result);
+    }
+
+    #[Test]
+    public function sanitizeSvgDataUriHandlesCaseInsensitiveMimeType(): void
+    {
+        // Mixed case should still be recognized as SVG
+        $mixedCaseUri = 'DATA:IMAGE/SVG+XML;base64,' . base64_encode('<svg></svg>');
+
+        $result = $this->callPrivateMethod($this->service, 'sanitizeSvgDataUri', [$mixedCaseUri]);
+        self::assertIsString($result);
+
+        // Should be processed (result will be lowercase prefix with sanitized content)
+        self::assertStringStartsWith('data:image/svg+xml;base64,', $result);
+    }
+
+    #[Test]
+    public function sanitizeSvgDataUriSanitizesBase64EncodedSvgWithScript(): void
+    {
+        $maliciousSvg = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>';
+        $cleanSvg     = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+
+        // Configure sanitizer to strip <script> tags
+        $service = $this->createServiceWithSanitizer(
+            static fn (string $content): string => str_contains($content, '<script>')
+                ? $cleanSvg
+                : $content,
+        );
+
+        $maliciousUri = 'data:image/svg+xml;base64,' . base64_encode($maliciousSvg);
+
+        $result = $this->callPrivateMethod($service, 'sanitizeSvgDataUri', [$maliciousUri]);
+        self::assertIsString($result);
+
+        // Decode result and verify script was removed
+        $resultParts   = explode(';base64,', $result, 2);
+        $decodedResult = base64_decode($resultParts[1], true);
+
+        self::assertSame($cleanSvg, $decodedResult);
+    }
+
+    #[Test]
+    public function sanitizeSvgDataUriSanitizesRawEncodedSvgWithEventHandler(): void
+    {
+        $maliciousSvg = '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"></svg>';
+        $cleanSvg     = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+
+        // Configure sanitizer to strip event handlers
+        $service = $this->createServiceWithSanitizer(
+            static fn (string $content): string => str_contains($content, 'onload')
+                ? $cleanSvg
+                : $content,
+        );
+
+        $maliciousUri = 'data:image/svg+xml,' . rawurlencode($maliciousSvg);
+
+        $result = $this->callPrivateMethod($service, 'sanitizeSvgDataUri', [$maliciousUri]);
+        self::assertIsString($result);
+
+        // Decode result and verify event handler was removed
+        $commaPos = strpos($result, ',');
+        self::assertIsInt($commaPos);
+        $decodedResult = rawurldecode(substr($result, $commaPos + 1));
+
+        self::assertSame($cleanSvg, $decodedResult);
+    }
+
+    #[Test]
+    public function sanitizeSvgDataUriHandlesInvalidBase64Gracefully(): void
+    {
+        // Invalid base64 content (not valid base64 string)
+        $invalidUri = 'data:image/svg+xml;base64,!!not_valid_base64!!';
+
+        $result = $this->callPrivateMethod($this->service, 'sanitizeSvgDataUri', [$invalidUri]);
+
+        // Should return original when base64 decode fails
+        self::assertSame($invalidUri, $result);
+    }
+
+    #[Test]
+    public function sanitizeSvgDataUriHandlesMalformedBase64UriGracefully(): void
+    {
+        // Malformed: missing actual base64 content after marker
+        $malformedUri = 'data:image/svg+xml;base64,';
+
+        $result = $this->callPrivateMethod($this->service, 'sanitizeSvgDataUri', [$malformedUri]);
+        self::assertIsString($result);
+
+        // Empty base64 decodes to empty string, which is valid
+        // Result should be processed (empty SVG content)
+        self::assertStringStartsWith('data:image/svg+xml;base64,', $result);
+    }
+
+    #[Test]
+    public function sanitizeSvgDataUriHandlesMalformedRawUriGracefully(): void
+    {
+        // Malformed: no comma separator
+        $malformedUri = 'data:image/svg+xml%3Csvg%3E%3C/svg%3E';
+
+        $result = $this->callPrivateMethod($this->service, 'sanitizeSvgDataUri', [$malformedUri]);
+
+        // Should return original when format is invalid
+        self::assertSame($malformedUri, $result);
+    }
+
+    #[Test]
+    public function sanitizeSvgDataUriPreservesCleanSvgUnchanged(): void
+    {
+        $cleanSvg = '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect fill="red"/></svg>';
+
+        $originalUri = 'data:image/svg+xml;base64,' . base64_encode($cleanSvg);
+
+        $result = $this->callPrivateMethod($this->service, 'sanitizeSvgDataUri', [$originalUri]);
+        self::assertIsString($result);
+
+        // Decode and verify content is unchanged
+        $resultParts   = explode(';base64,', $result, 2);
+        $decodedResult = base64_decode($resultParts[1], true);
+
+        self::assertSame($cleanSvg, $decodedResult);
+    }
+
+    /**
+     * Data provider for SVG XSS payload tests.
+     *
+     * @return array<string, array{maliciousContent: string, description: string}>
+     */
+    public static function svgXssPayloadDataProvider(): array
+    {
+        return [
+            'script tag' => [
+                'maliciousContent' => '<script>alert(1)</script>',
+                'description'      => 'Inline script execution',
+            ],
+            'onload event handler' => [
+                'maliciousContent' => '<svg onload="alert(1)">',
+                'description'      => 'Event handler XSS',
+            ],
+            'onerror event handler' => [
+                'maliciousContent' => '<image onerror="alert(1)">',
+                'description'      => 'Image error handler XSS',
+            ],
+            'onclick event handler' => [
+                'maliciousContent' => '<rect onclick="alert(1)">',
+                'description'      => 'Click handler XSS',
+            ],
+            'javascript href' => [
+                'maliciousContent' => '<a href="javascript:alert(1)">',
+                'description'      => 'JavaScript protocol in href',
+            ],
+            'foreignObject with script' => [
+                'maliciousContent' => '<foreignObject><script>alert(1)</script></foreignObject>',
+                'description'      => 'ForeignObject script injection',
+            ],
+            'set element with onbegin' => [
+                'maliciousContent' => '<set onbegin="alert(1)">',
+                'description'      => 'Animation event handler',
+            ],
+        ];
+    }
+
+    /**
+     * Verify that various XSS payloads are passed to the sanitizer.
+     *
+     * This test verifies that the sanitizeSvgDataUri method correctly extracts
+     * and passes SVG content to the sanitizer. The actual XSS prevention is
+     * handled by TYPO3's SvgSanitizer.
+     */
+    #[Test]
+    #[DataProvider('svgXssPayloadDataProvider')]
+    public function sanitizeSvgDataUriPassesContentToSanitizer(string $maliciousContent, string $description): void
+    {
+        $maliciousSvg   = '<svg xmlns="http://www.w3.org/2000/svg">' . $maliciousContent . '</svg>';
+        $sanitizedSvg   = '<svg xmlns="http://www.w3.org/2000/svg"><!-- sanitized --></svg>';
+        $sanitizerCalls = [];
+
+        // Track what gets passed to the sanitizer
+        $service = $this->createServiceWithSanitizer(
+            static function (string $content) use (&$sanitizerCalls, $sanitizedSvg): string {
+                $sanitizerCalls[] = $content;
+
+                return $sanitizedSvg;
+            },
+        );
+
+        $maliciousUri = 'data:image/svg+xml;base64,' . base64_encode($maliciousSvg);
+
+        $result = $this->callPrivateMethod($service, 'sanitizeSvgDataUri', [$maliciousUri]);
+        self::assertIsString($result);
+
+        // Verify sanitizer was called with the malicious content
+        self::assertCount(1, $sanitizerCalls, 'Sanitizer should be called exactly once');
+        self::assertSame($maliciousSvg, $sanitizerCalls[0], 'Sanitizer should receive the decoded SVG content');
+
+        // Verify result contains sanitized content
+        $resultParts   = explode(';base64,', $result, 2);
+        $decodedResult = base64_decode($resultParts[1], true);
+        self::assertSame($sanitizedSvg, $decodedResult, sprintf('Content should be sanitized (%s)', $description));
+    }
+
+    #[Test]
+    public function sanitizeSvgDataUriHandlesRawFormatWithCharset(): void
+    {
+        $svgContent = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+
+        // Data URI with charset parameter
+        $dataUri = 'data:image/svg+xml;charset=utf-8,' . rawurlencode($svgContent);
+
+        $result = $this->callPrivateMethod($this->service, 'sanitizeSvgDataUri', [$dataUri]);
+        self::assertIsString($result);
+
+        // Should handle the charset parameter correctly
+        $commaPos = strpos($result, ',');
+        self::assertIsInt($commaPos);
+        $decodedResult = rawurldecode(substr($result, $commaPos + 1));
+
+        self::assertSame($svgContent, $decodedResult);
     }
 }


### PR DESCRIPTION
## Summary

- Add SVG data URI sanitization in `ImageResolverService` using TYPO3's built-in `SvgSanitizer`
- Prevents XSS attacks via embedded JavaScript in `data:image/svg+xml` URIs
- Handles both base64-encoded and percent-encoded SVG formats
- Add 17 unit tests covering malicious payloads and edge cases

## Problem

SVG data URIs bypass TYPO3 FAL upload validation (they're inline, not uploaded files). They can contain:
- `<script>` tags
- Event handlers (`onload`, `onerror`, `onclick`, etc.)
- `javascript:` hrefs
- XXE vectors

## Solution

Sanitize SVG data URIs at render time in `createDtoFromExternalImage()` using TYPO3 Core's `SvgSanitizer`, which provides:
- Whitelist-based tag/attribute filtering
- XXE protection
- DoS prevention via `<use>` element nesting limits
- Remote reference removal

## Files Changed

| File | Changes |
|------|---------|
| `Configuration/Services.yaml` | Add `SvgSanitizer` injection |
| `Classes/Service/ImageResolverService.php` | Add `sanitizeSvgDataUri()` method |
| `Tests/Unit/Service/ImageResolverServiceTest.php` | Add 17 test cases |
| `Documentation/Architecture/ADR-003-*.rst` | Update security documentation |

## Test plan

- [x] Unit tests pass (149 tests, 0 failures)
- [x] PHPStan level max passes
- [x] PHP-CS-Fixer passes
- [ ] CI pipeline passes

Closes #474