### PR TITLE
fix(frontend): prevent double figure wrapping for captioned images (#546)

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -13,7 +13,7 @@ parameters:
 			path: ../Classes/Controller/ImageRenderingAdapter.php
 
 		-
-			message: '#^Parameter \#1 \$attributes of method Netresearch\\RteCKEditorImage\\Service\\ImageResolverService\:\:resolve\(\) expects array\<string, string\>, array given\.$#'
+			message: '#^Parameter \#1 \$attributes of method Netresearch\\RteCKEditorImage\\Service\\ImageResolverService\:\:resolve\(\) expects array\<string, string\>, array\<mixed, mixed\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: ../Classes/Controller/ImageRenderingAdapter.php

--- a/Tests/Functional/Controller/FigureCaptionRenderingTest.php
+++ b/Tests/Functional/Controller/FigureCaptionRenderingTest.php
@@ -1,0 +1,227 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/rte-ckeditor-image.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\RteCKEditorImage\Tests\Functional\Controller;
+
+use Netresearch\RteCKEditorImage\Controller\ImageRenderingAdapter;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Functional tests for figure/caption rendering.
+ *
+ * Tests to reproduce and verify fix for issue #546:
+ * - Double figure/figcaption wrapping in frontend output
+ *
+ * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @license https://www.gnu.org/licenses/agpl-3.0.de.html
+ *
+ * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/546
+ */
+final class FigureCaptionRenderingTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/rte_ckeditor_image',
+    ];
+
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-rte-ckeditor',
+    ];
+
+    /** @phpstan-ignore property.uninitialized (initialized in setUp) */
+    private ServerRequestInterface $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Import test data
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/sys_file_storage.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/sys_file.csv');
+
+        // Create a minimal site configuration
+        $site = new Site('test', 1, [
+            'base'      => 'http://localhost/',
+            'languages' => [
+                [
+                    'languageId' => 0,
+                    'title'      => 'English',
+                    'locale'     => 'en_US.UTF-8',
+                    'base'       => '/',
+                ],
+            ],
+        ]);
+
+        // Create request with site
+        $this->request = (new ServerRequest())
+            ->withAttribute('site', $site)
+            ->withAttribute('language', $site->getDefaultLanguage());
+    }
+
+    /**
+     * Test that renderFigure does not create nested figure elements.
+     *
+     * Reproduces issue #546: Frontend shows double figure/figcaption wrapping
+     *
+     * Input (from CKEditor):
+     * <figure class="image">
+     *   <img data-htmlarea-file-uid="1" ...>
+     *   <figcaption>My Caption</figcaption>
+     * </figure>
+     *
+     * Expected output: Single figure with single figcaption
+     * Bug output: Nested figures with duplicate figcaptions
+     */
+    #[Test]
+    public function renderFigureDoesNotCreateNestedFigures(): void
+    {
+        $adapter = $this->get(ImageRenderingAdapter::class);
+
+        /** @var ContentObjectRenderer $contentObjectRenderer */
+        $contentObjectRenderer = $this->get(ContentObjectRenderer::class);
+
+        // Simulate CKEditor output with figure and caption
+        $inputHtml = '<figure class="image">'
+            . '<img src="/fileadmin/test.jpg" data-htmlarea-file-uid="1" width="250" height="250" alt="Test">'
+            . '<figcaption>My Caption</figcaption>'
+            . '</figure>';
+
+        // Set the current value as TypoScript would
+        $contentObjectRenderer->setCurrentVal($inputHtml);
+        $adapter->setContentObjectRenderer($contentObjectRenderer);
+
+        // Call renderFigure as TypoScript preUserFunc would
+        /** @var string $result */
+        $result = $adapter->renderFigure(null, [], $this->request);
+
+        // Assert: No nested figures
+        $figureCount = substr_count($result, '<figure');
+        self::assertSame(
+            1,
+            $figureCount,
+            'Expected exactly 1 figure element, got ' . $figureCount . '. Result: ' . $result,
+        );
+
+        // Assert: No nested figcaptions
+        $figcaptionCount = substr_count($result, '<figcaption');
+        self::assertSame(
+            1,
+            $figcaptionCount,
+            'Expected exactly 1 figcaption element, got ' . $figcaptionCount . '. Result: ' . $result,
+        );
+
+        // Assert: Caption text appears only once
+        $captionTextCount = substr_count($result, 'My Caption');
+        self::assertSame(
+            1,
+            $captionTextCount,
+            'Expected caption text to appear exactly once, got ' . $captionTextCount . '. Result: ' . $result,
+        );
+    }
+
+    /**
+     * Test that the output is idempotent - rendering the output again should not change structure.
+     *
+     * This is test case 27 from @prdt3e's specification.
+     */
+    #[Test]
+    public function renderingIsIdempotent(): void
+    {
+        $adapter = $this->get(ImageRenderingAdapter::class);
+
+        /** @var ContentObjectRenderer $contentObjectRenderer */
+        $contentObjectRenderer = $this->get(ContentObjectRenderer::class);
+
+        // First render
+        $inputHtml = '<figure class="image">'
+            . '<img src="/fileadmin/test.jpg" data-htmlarea-file-uid="1" width="250" height="250" alt="Test">'
+            . '<figcaption>Caption</figcaption>'
+            . '</figure>';
+
+        $contentObjectRenderer->setCurrentVal($inputHtml);
+        $adapter->setContentObjectRenderer($contentObjectRenderer);
+
+        /** @var string $firstRender */
+        $firstRender = $adapter->renderFigure(null, [], $this->request);
+
+        // Second render - using the output from the first render
+        $contentObjectRenderer->setCurrentVal($firstRender);
+
+        /** @var string $secondRender */
+        $secondRender = $adapter->renderFigure(null, [], $this->request);
+
+        // Structure should remain the same (still 1 figure, 1 figcaption)
+        $figureCount = substr_count($secondRender, '<figure');
+        self::assertSame(
+            1,
+            $figureCount,
+            'Idempotency check: Expected 1 figure after second render, got ' . $figureCount . '. Result: ' . $secondRender,
+        );
+    }
+
+    /**
+     * Test that figure without file UID returns original content unchanged.
+     */
+    #[Test]
+    public function renderFigureReturnsOriginalForExternalImages(): void
+    {
+        $adapter = $this->get(ImageRenderingAdapter::class);
+
+        /** @var ContentObjectRenderer $contentObjectRenderer */
+        $contentObjectRenderer = $this->get(ContentObjectRenderer::class);
+
+        // External image without file UID
+        $inputHtml = '<figure class="image">'
+            . '<img src="https://example.com/external.jpg" width="250" height="250" alt="External">'
+            . '<figcaption>External Caption</figcaption>'
+            . '</figure>';
+
+        $contentObjectRenderer->setCurrentVal($inputHtml);
+        $adapter->setContentObjectRenderer($contentObjectRenderer);
+
+        $result = $adapter->renderFigure(null, [], $this->request);
+
+        // Should return original unchanged
+        self::assertSame($inputHtml, $result);
+    }
+
+    /**
+     * Test that figure without figcaption but with data-caption works correctly.
+     */
+    #[Test]
+    public function renderFigureHandlesDataCaptionAttribute(): void
+    {
+        $adapter = $this->get(ImageRenderingAdapter::class);
+
+        /** @var ContentObjectRenderer $contentObjectRenderer */
+        $contentObjectRenderer = $this->get(ContentObjectRenderer::class);
+
+        // Figure with data-caption but no figcaption element
+        $inputHtml = '<figure class="image">'
+            . '<img src="/fileadmin/test.jpg" data-htmlarea-file-uid="1" width="250" height="250" alt="Test" data-caption="Data Caption">'
+            . '</figure>';
+
+        $contentObjectRenderer->setCurrentVal($inputHtml);
+        $adapter->setContentObjectRenderer($contentObjectRenderer);
+
+        /** @var string $result */
+        $result = $adapter->renderFigure(null, [], $this->request);
+
+        // Should have exactly one figure
+        $figureCount = substr_count($result, '<figure');
+        self::assertSame(1, $figureCount, 'Expected 1 figure. Result: ' . $result);
+    }
+}

--- a/Tests/Functional/Controller/ImageTagRenderingTest.php
+++ b/Tests/Functional/Controller/ImageTagRenderingTest.php
@@ -1,0 +1,238 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/rte-ckeditor-image.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\RteCKEditorImage\Tests\Functional\Controller;
+
+use Netresearch\RteCKEditorImage\Controller\ImageRenderingAdapter;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Functional tests for standalone img tag rendering.
+ *
+ * Tests to verify that the tags.img handler (renderImageAttributes) does NOT
+ * create figure wrappers for captioned images, preventing nested figure
+ * structures when both tags.img and tags.figure handlers process content.
+ *
+ * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @license https://www.gnu.org/licenses/agpl-3.0.de.html
+ *
+ * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/546
+ */
+final class ImageTagRenderingTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/rte_ckeditor_image',
+    ];
+
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-rte-ckeditor',
+    ];
+
+    /** @phpstan-ignore property.uninitialized (initialized in setUp) */
+    private ServerRequestInterface $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Import test data
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/sys_file_storage.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/sys_file.csv');
+
+        // Create a minimal site configuration
+        $site = new Site('test', 1, [
+            'base'      => 'http://localhost/',
+            'languages' => [
+                [
+                    'languageId' => 0,
+                    'title'      => 'English',
+                    'locale'     => 'en_US.UTF-8',
+                    'base'       => '/',
+                ],
+            ],
+        ]);
+
+        // Create request with site
+        $this->request = (new ServerRequest())
+            ->withAttribute('site', $site)
+            ->withAttribute('language', $site->getDefaultLanguage());
+    }
+
+    /**
+     * Test that renderImageAttributes does NOT create figure wrappers for captioned images.
+     *
+     * This is the root cause of bug #546: When an img tag has data-caption attribute,
+     * the tags.img handler (renderImageAttributes) was creating a figure wrapper.
+     * When this image is inside a figure (as CKEditor outputs captioned images),
+     * both handlers create figure wrappers, resulting in nested figures.
+     *
+     * FIX: renderImageAttributes should NEVER create figure wrappers. Only
+     * renderFigure (tags.figure handler) should create figure wrappers.
+     *
+     * Current CKEditor output for captioned images:
+     * <figure class="image">
+     *   <img src="..." data-htmlarea-file-uid="1" data-caption="Caption">
+     *   <figcaption>Caption</figcaption>
+     * </figure>
+     */
+    #[Test]
+    public function renderImageAttributesDoesNotCreateFigureWrapperForCaptionedImage(): void
+    {
+        $adapter = $this->get(ImageRenderingAdapter::class);
+
+        /** @var ContentObjectRenderer $cObj */
+        $cObj = $this->get(ContentObjectRenderer::class);
+        $cObj->setRequest($this->request);
+        $adapter->setContentObjectRenderer($cObj);
+
+        // Simulate tags.img handler receiving an img with data-caption
+        // This is what parseFunc passes to the handler for standalone img tags
+        $cObj->parameters = [
+            'src'                    => '/fileadmin/test.jpg',
+            'data-htmlarea-file-uid' => '1',
+            'width'                  => '250',
+            'height'                 => '250',
+            'alt'                    => 'Test',
+            'data-caption'           => 'My Caption',
+        ];
+
+        /** @var string $result */
+        $result = $adapter->renderImageAttributes(null, [], $this->request);
+
+        // CRITICAL ASSERTION: The output should NOT contain figure wrapper
+        // If it does, we'll get nested figures when this img is inside a figure
+        $figureCount = substr_count($result, '<figure');
+
+        self::assertSame(
+            0,
+            $figureCount,
+            'renderImageAttributes should NOT create figure wrappers for captioned images. '
+            . 'Found ' . $figureCount . ' figure element(s). Result: ' . $result,
+        );
+
+        // The output should be just an img tag (possibly with wrapper span for styling)
+        self::assertStringContainsString('<img', $result, 'Output should contain img element');
+
+        // Should NOT contain figcaption (that's renderFigure's job)
+        self::assertStringNotContainsString(
+            '<figcaption',
+            $result,
+            'renderImageAttributes should NOT create figcaption. That is renderFigure\'s responsibility.',
+        );
+    }
+
+    /**
+     * Test that renderImageAttributes handles img WITHOUT caption correctly.
+     *
+     * Images without data-caption should be processed normally without figure wrapper.
+     */
+    #[Test]
+    public function renderImageAttributesHandlesImageWithoutCaption(): void
+    {
+        $adapter = $this->get(ImageRenderingAdapter::class);
+
+        /** @var ContentObjectRenderer $cObj */
+        $cObj = $this->get(ContentObjectRenderer::class);
+        $cObj->setRequest($this->request);
+        $adapter->setContentObjectRenderer($cObj);
+
+        // Simulate tags.img handler receiving an img WITHOUT data-caption
+        $cObj->parameters = [
+            'src'                    => '/fileadmin/test.jpg',
+            'data-htmlarea-file-uid' => '1',
+            'width'                  => '250',
+            'height'                 => '250',
+            'alt'                    => 'Test',
+        ];
+
+        /** @var string $result */
+        $result = $adapter->renderImageAttributes(null, [], $this->request);
+
+        // Should output just an img tag, no figure wrapper
+        $figureCount = substr_count($result, '<figure');
+        self::assertSame(
+            0,
+            $figureCount,
+            'Uncaptioned images should not have figure wrappers. Result: ' . $result,
+        );
+
+        self::assertStringContainsString('<img', $result, 'Output should contain img element');
+    }
+
+    /**
+     * Test simulation of parseFunc processing order causing nested figures.
+     *
+     * This test demonstrates the bug: when parseFunc processes content with
+     * a captioned image inside a figure, both handlers create figure wrappers.
+     */
+    #[Test]
+    public function combinedHandlersDoNotCreateNestedFigures(): void
+    {
+        $adapter = $this->get(ImageRenderingAdapter::class);
+
+        /** @var ContentObjectRenderer $cObj */
+        $cObj = $this->get(ContentObjectRenderer::class);
+        $cObj->setRequest($this->request);
+        $adapter->setContentObjectRenderer($cObj);
+
+        // Step 1: Simulate what tags.img handler produces
+        $cObj->parameters = [
+            'src'                    => '/fileadmin/test.jpg',
+            'data-htmlarea-file-uid' => '1',
+            'width'                  => '250',
+            'height'                 => '250',
+            'alt'                    => 'Test',
+            'data-caption'           => 'Caption Text',
+        ];
+
+        /** @var string $imgResult */
+        $imgResult = $adapter->renderImageAttributes(null, [], $this->request);
+
+        // Step 2: Build what the figure would look like after img processing
+        // This simulates what parseFunc produces after tags.img runs
+        $figureWithProcessedImg = '<figure class="image">'
+            . $imgResult
+            . '<figcaption>Caption Text</figcaption>'
+            . '</figure>';
+
+        // Step 3: Now simulate tags.figure handler processing this
+        $cObj->setCurrentVal($figureWithProcessedImg);
+
+        /** @var string $figureResult */
+        $figureResult = $adapter->renderFigure(null, [], $this->request);
+
+        // CRITICAL: After both handlers run, we should have exactly 1 figure
+        $figureCount = substr_count($figureResult, '<figure');
+
+        self::assertSame(
+            1,
+            $figureCount,
+            'Combined handlers should produce exactly 1 figure, not nested figures. '
+            . 'Got ' . $figureCount . ' figures. Result: ' . $figureResult,
+        );
+
+        // Should have exactly 1 figcaption
+        $figcaptionCount = substr_count($figureResult, '<figcaption');
+
+        self::assertSame(
+            1,
+            $figcaptionCount,
+            'Combined handlers should produce exactly 1 figcaption, not duplicates. '
+            . 'Got ' . $figcaptionCount . ' figcaptions. Result: ' . $figureResult,
+        );
+    }
+}

--- a/Tests/Functional/TypoScript/ParseFuncIntegrationTest.php
+++ b/Tests/Functional/TypoScript/ParseFuncIntegrationTest.php
@@ -1,0 +1,201 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/rte-ckeditor-image.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\RteCKEditorImage\Tests\Functional\TypoScript;
+
+use Netresearch\RteCKEditorImage\Controller\ImageRenderingAdapter;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Integration tests for parseFunc_RTE TypoScript processing.
+ *
+ * Tests the TypoScript preUserFunc behavior to verify that figure elements
+ * are processed without creating nested structures.
+ *
+ * These tests verify the renderFigure method is idempotent - calling it
+ * multiple times on the same content should not create nested structures.
+ * This simulates what would happen if parseFunc_RTE processed content
+ * that already went through the image rendering pipeline.
+ *
+ * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @license https://www.gnu.org/licenses/agpl-3.0.de.html
+ *
+ * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/546
+ */
+final class ParseFuncIntegrationTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/rte_ckeditor_image',
+    ];
+
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-rte-ckeditor',
+        'typo3/cms-frontend',
+    ];
+
+    /** @phpstan-ignore property.uninitialized (initialized in setUp) */
+    private Site $site;
+
+    /** @phpstan-ignore property.uninitialized (initialized in setUp) */
+    private ServerRequest $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Import test data
+        $this->importCSVDataSet(__DIR__ . '/../Controller/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Controller/Fixtures/sys_file_storage.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Controller/Fixtures/sys_file.csv');
+
+        // Create site and request
+        $this->site = new Site('test', 1, [
+            'base'      => 'http://localhost/',
+            'languages' => [
+                [
+                    'languageId' => 0,
+                    'title'      => 'English',
+                    'locale'     => 'en_US.UTF-8',
+                    'base'       => '/',
+                ],
+            ],
+        ]);
+
+        $this->request = (new ServerRequest())
+            ->withAttribute('site', $this->site)
+            ->withAttribute('language', $this->site->getDefaultLanguage());
+    }
+
+    /**
+     * Test that renderFigure output does not create nested figures when processed again.
+     *
+     * This tests idempotency: passing renderFigure output through renderFigure again
+     * should not create additional nesting. This simulates scenarios where content
+     * might be processed multiple times.
+     *
+     * Reproduces issue #546: Double figure wrapping in frontend output
+     */
+    #[Test]
+    public function renderFigureOutputIsIdempotent(): void
+    {
+        $adapter = $this->get(ImageRenderingAdapter::class);
+
+        /** @var ContentObjectRenderer $cObj */
+        $cObj = $this->get(ContentObjectRenderer::class);
+        $cObj->setRequest($this->request);
+        $adapter->setContentObjectRenderer($cObj);
+
+        // First render - CKEditor input
+        $ckeditorOutput = '<figure class="image">'
+            . '<img src="/fileadmin/test.jpg" data-htmlarea-file-uid="1" width="250" height="250" alt="Test">'
+            . '<figcaption>My Caption</figcaption>'
+            . '</figure>';
+
+        $cObj->setCurrentVal($ckeditorOutput);
+
+        /** @var string $firstRender */
+        $firstRender = $adapter->renderFigure(null, [], $this->request);
+
+        // Second render - simulate parseFunc processing the output again
+        $cObj->setCurrentVal($firstRender);
+
+        /** @var string $secondRender */
+        $secondRender = $adapter->renderFigure(null, [], $this->request);
+
+        // Count figures in first render
+        $firstFigureCount = substr_count($firstRender, '<figure');
+        self::assertSame(
+            1,
+            $firstFigureCount,
+            'First render should have exactly 1 figure. Got ' . $firstFigureCount . '. Result: ' . $firstRender,
+        );
+
+        // Count figures in second render - should still be 1, not 2
+        $secondFigureCount = substr_count($secondRender, '<figure');
+        self::assertSame(
+            1,
+            $secondFigureCount,
+            'Second render should still have exactly 1 figure (idempotent). '
+            . 'Got ' . $secondFigureCount . '. Result: ' . $secondRender,
+        );
+
+        // Count figcaptions - should be exactly 1 in both
+        $firstCaptionCount  = substr_count($firstRender, '<figcaption');
+        $secondCaptionCount = substr_count($secondRender, '<figcaption');
+
+        self::assertSame(1, $firstCaptionCount, 'First render should have 1 figcaption');
+        self::assertSame(1, $secondCaptionCount, 'Second render should have 1 figcaption');
+    }
+
+    /**
+     * Test that already-rendered figure HTML is detected and not re-wrapped.
+     *
+     * When renderFigure receives HTML that was already processed (no data-htmlarea-file-uid),
+     * it should return the content unchanged to prevent nesting.
+     */
+    #[Test]
+    public function alreadyProcessedFigureIsNotReWrapped(): void
+    {
+        $adapter = $this->get(ImageRenderingAdapter::class);
+
+        /** @var ContentObjectRenderer $cObj */
+        $cObj = $this->get(ContentObjectRenderer::class);
+        $cObj->setRequest($this->request);
+        $adapter->setContentObjectRenderer($cObj);
+
+        // Simulate already-rendered figure (no data-htmlarea-file-uid)
+        $renderedFigure = '<figure class="image">'
+            . '<img src="/fileadmin/_processed_/test.jpg" width="250" height="250" alt="Test" decoding="async">'
+            . '<figcaption>My Caption</figcaption>'
+            . '</figure>';
+
+        $cObj->setCurrentVal($renderedFigure);
+        $result = $adapter->renderFigure(null, [], $this->request);
+
+        // Should return original unchanged (no file UID = no processing)
+        self::assertSame($renderedFigure, $result, 'Already processed figure should not be modified');
+
+        // Verify no nesting occurred
+        $figureCount = substr_count($result, '<figure');
+        self::assertSame(1, $figureCount, 'Should have exactly 1 figure');
+    }
+
+    /**
+     * Test figure rendering with external images does not create nesting.
+     *
+     * External images (no file UID) should pass through unchanged.
+     */
+    #[Test]
+    public function externalImageFigurePassesThroughUnchanged(): void
+    {
+        $adapter = $this->get(ImageRenderingAdapter::class);
+
+        /** @var ContentObjectRenderer $cObj */
+        $cObj = $this->get(ContentObjectRenderer::class);
+        $cObj->setRequest($this->request);
+        $adapter->setContentObjectRenderer($cObj);
+
+        $externalFigure = '<figure class="image">'
+            . '<img src="https://example.com/image.jpg" width="250" height="250" alt="External">'
+            . '<figcaption>External Caption</figcaption>'
+            . '</figure>';
+
+        $cObj->setCurrentVal($externalFigure);
+        $result = $adapter->renderFigure(null, [], $this->request);
+
+        // Should return original unchanged
+        self::assertSame($externalFigure, $result);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Bug 3 from #546: Double figure/figcaption wrapping in frontend output.

**Root cause**: When CKEditor outputs captioned images, it creates:
```html
<figure><img data-caption="X"><figcaption>X</figcaption></figure>
```

The `tags.img` handler (`renderImageAttributes`) was passing `data-caption` to the resolver, which created a figure wrapper. When parseFunc then processed the figure element via `tags.figure`, it created another wrapper, resulting in nested figure elements.

**Fix**: Strip `data-caption` from attributes in `renderImageAttributes` before resolving. Caption handling is `renderFigure`'s responsibility, not `renderImageAttributes`.

## Changes

- `ImageRenderingAdapter::renderImageAttributes()` - Added `unset($attributes['data-caption'])` with explanatory comment
- Updated PHPStan baseline for changed error pattern
- Added functional tests for:
  - Figure/caption rendering without nesting
  - Standalone img tag handling  
  - parseFunc processing idempotency

## Test plan

- [x] PHPStan passes
- [x] Unit tests pass
- [x] Functional tests pass (10 new tests)
- [ ] E2E tests pass (CI will verify)

Fixes part of #546