### PR TITLE
test: add missing 4th argument to resolve() mock expectations

### DIFF
--- a/Tests/Unit/Controller/ImageRenderingAdapterTest.php
+++ b/Tests/Unit/Controller/ImageRenderingAdapterTest.php
@@ -512,6 +512,7 @@ final class ImageRenderingAdapterTest extends TestCase
                 }),
                 [],
                 $this->request,
+                null, // No link attributes (empty link array from parser)
             )
             ->willReturn($dto);
 
@@ -572,6 +573,7 @@ final class ImageRenderingAdapterTest extends TestCase
                 }),
                 [],
                 $this->request,
+                null, // No link attributes (empty link array from parser)
             )
             ->willReturn($dto);
 


### PR DESCRIPTION
## Summary

Address Copilot review feedback from PR #556.

Two existing tests were missing the 4th argument (`linkAttributes`) in their mock expectations for `ImageResolverService::resolve()` after the API change in #556.

## Changes

- `renderFigureRendersViaServiceWhenResolutionSucceeds` - added `null` as 4th argument
- `renderFigureFigcaptionOverridesDataCaption` - added `null` as 4th argument

## Test Plan

- [x] All tests pass