### PR TITLE
fix: remove 'a' from encapsTagList to prevent duplicate links

### DIFF
--- a/Configuration/TypoScript/ImageRendering/setup.typoscript
+++ b/Configuration/TypoScript/ImageRendering/setup.typoscript
@@ -112,12 +112,13 @@ lib.parseFunc_RTE {
 # artifacts between <img> and <figcaption> elements.
 # See: https://github.com/netresearch/t3x-rte_ckeditor_image/pull/482
 #
-# Note: 'a' is included for linked images (<a><img></a>) rendered
-# by this extension's templates. Standard inline anchors within
-# paragraph text are unaffected since they're already wrapped
-# in their parent paragraph content.
+# Note: 'a' was removed from this list in TYPO3 v13 due to duplicate
+# link generation when images are wrapped in links. The encapsLines
+# handler in v13 processes anchor tags differently, causing nested
+# links like <a><a><img></a></a>.
+# See: https://github.com/netresearch/t3x-rte_ckeditor_image/issues/565
 #******************************************************
-lib.parseFunc_RTE.nonTypoTagStdWrap.encapsLines.encapsTagList := addToList(img,figure,figcaption,a)
+lib.parseFunc_RTE.nonTypoTagStdWrap.encapsLines.encapsTagList := addToList(img,figure,figcaption)
 
 #******************************************************
 # Figure element configuration


### PR DESCRIPTION
## Summary

- Remove `a` from `encapsLines.encapsTagList` to fix duplicate link generation in TYPO3 v13
- This is a **critical data corruption bug** that affects content with linked images

## Problem

In TYPO3 v13, including `a` in `encapsTagList` causes the `encapsLines` handler to process anchor tags as block-level elements. This results in duplicate/nested links when images are wrapped in links:

**Original HTML:**
```html
<a href="https://example.com"><img src="..." /></a>
```

**After saving in v13:**
```html
<a href="https://example.com"><a class="" href="https://example.com"><img src="..." /></a></a>
```

This causes:
1. Data corruption in the database
2. Invalid nested HTML
3. Extra empty links in frontend output
4. Progressive corruption on repeated saves

## Root Cause

The `a` tag was added to `encapsTagList` in PR #482 to prevent `<p>&nbsp;</p>` artifacts around linked images. However, TYPO3 v13's `encapsLines` handler processes tags in this list differently, causing the anchor tag to be duplicated.

## Solution

Remove `a` from `encapsTagList`:
```typoscript
# Before
lib.parseFunc_RTE.nonTypoTagStdWrap.encapsLines.encapsTagList := addToList(img,figure,figcaption,a)

# After
lib.parseFunc_RTE.nonTypoTagStdWrap.encapsLines.encapsTagList := addToList(img,figure,figcaption)
```

## Test plan

- [ ] Create content with image wrapped in link: `<a href="..."><img/></a>`
- [ ] Save the content
- [ ] Verify no duplicate links are created
- [ ] Check source mode in CKEditor shows single link
- [ ] Verify frontend renders correctly without extra empty links

## Risk Assessment

**Low risk** - This change only affects parseFunc's handling of anchor tags in the encapsLines processor. The `tags.a` handler still processes linked images correctly.

Closes #565