### PR TITLE
fix: resolve t3:// link references in linked images

### DIFF
--- a/Tests/Functional/Controller/Fixtures/pages.csv
+++ b/Tests/Functional/Controller/Fixtures/pages.csv
@@ -1,4 +1,3 @@
 "pages"
 ,"uid","pid","title","slug","doktype"
 ,1,0,"Root Page","/",1
-,123,1,"Test Target Page","/test-target-page",1


### PR DESCRIPTION
## Explain the details

When images have links using TYPO3's internal `t3://` syntax (e.g., `t3://page?uid=123`), the rendered frontend output contained the raw `t3://` URL instead of the resolved path.

**Root cause**: This extension clears `tags.a >` in `lib.parseFunc_RTE` and replaces it with `externalBlocks.a` handled by `ImageRenderingAdapter->renderLink()`. The standard `tags.a` handler would normally resolve `t3://` links via `typolink`. Since we bypassed it, `t3://` links were never resolved.

**Two affected code paths**:
1. `renderLink()` — inline images in links → `wrapInLink()` was outputting raw href
2. `renderFigure()` — figure-wrapped linked images → `buildLinkDto()` was storing raw href

**Fix**: Added `resolveTypo3LinkUrl()` private method that uses `ContentObjectRenderer::typoLink_URL()` to resolve `t3://` links explicitly. Called in both `renderLink()` and `renderFigure()` paths before the href is used. Non-t3:// URLs pass through unchanged.

## Test plan

- [x] Unit tests pass (548 tests, 1251 assertions)
- [x] PHPStan passes (0 errors)
- [x] PHP-CS-Fixer passes (0 fixable issues)
- [x] PHP lint passes (73 files)
- [ ] CI functional tests verify:
  - `linkUrlsWithT3SyntaxAreResolvedInFigure` — t3:// URL resolved in renderFigure path
  - `linkUrlsWithT3SyntaxAreResolvedInLink` — t3:// URL resolved in renderLink path
  - `nonT3UrlsPassThroughUnchangedInLink` — https:// URLs not affected

## Code formatting

PSR-12 compliant; verified by PHP-CS-Fixer pre-commit hook.

## Closing issues

Closes #594