### PR TITLE
fix: alignment class without caption should not trigger figure wrapper

### DIFF
--- a/Classes/Service/ImageRenderingService.php
+++ b/Classes/Service/ImageRenderingService.php
@@ -134,13 +134,11 @@ class ImageRenderingService
         $hasLink    = $imageData->link instanceof LinkDto;
         $isPopup    = $imageData->link instanceof LinkDto && $imageData->link->isPopup;
 
-        // Check for actual alignment classes (image-left, image-center, image-right)
-        // The generic "image" class alone should NOT trigger figure wrapper
-        $hasAlignmentClass = $imageData->figureClass !== null
-            && preg_match('/\bimage-(left|center|right)\b/', $imageData->figureClass) === 1;
-
-        // Figure wrapper is needed if there's a caption OR an alignment class
-        $needsFigureWrapper = $hasCaption || $hasAlignmentClass;
+        // Figure wrapper is only needed when there's a caption.
+        // Alignment classes (image-left, image-center, image-right) without caption
+        // should render as standalone <img> with the alignment class on the element.
+        // See: https://github.com/netresearch/t3x-rte_ckeditor_image/issues/595
+        $needsFigureWrapper = $hasCaption;
 
         return match (true) {
             $isPopup && $needsFigureWrapper => self::TEMPLATE_POPUP_WITH_CAPTION,

--- a/Classes/Service/ImageResolverService.php
+++ b/Classes/Service/ImageResolverService.php
@@ -185,6 +185,15 @@ class ImageResolverService
             // CRITICAL: Caption XSS prevention
             $caption = $this->sanitizeCaption($attributes['data-caption'] ?? '');
 
+            // When there's no caption, alignment class goes on the <img> element
+            // since no <figure> wrapper will be generated (see #595)
+            if ($caption === '' && $figureClass !== null && $figureClass !== '') {
+                $existingClass = $htmlAttributes['class'] ?? '';
+                $existingClass = is_string($existingClass) ? $existingClass : '';
+
+                $htmlAttributes['class'] = trim(($existingClass !== '' ? $existingClass . ' ' : '') . $figureClass);
+            }
+
             // Build link DTO if link attributes provided OR if popup attributes are present
             $link = null;
 

--- a/Tests/Functional/Controller/RteMixedContentRenderingTest.php
+++ b/Tests/Functional/Controller/RteMixedContentRenderingTest.php
@@ -245,6 +245,145 @@ final class RteMixedContentRenderingTest extends FunctionalTestCase
     }
 
     // ========================================================================
+    // Issue #595: Alignment class without caption should NOT trigger figure
+    // ========================================================================
+
+    /**
+     * Test: Image with alignment class but no caption renders as standalone img.
+     *
+     * CKEditor 5 outputs: <figure class="image image-left"><img ...></figure>
+     * When there's no caption, the renderer should output just <img> with the
+     * alignment class on the element, not a <figure> wrapper.
+     *
+     * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/595
+     */
+    #[Test]
+    public function alignedImageWithoutCaptionOutputsStandaloneImg(): void
+    {
+        ['adapter' => $adapter, 'cObj' => $cObj] = $this->getAdapterWithCObj();
+
+        $inputHtml = '<figure class="image image-left">'
+            . '<img src="/fileadmin/test.jpg" data-htmlarea-file-uid="1" width="250" height="250" alt="Left aligned">'
+            . '</figure>';
+
+        $cObj->setCurrentVal($inputHtml);
+
+        /** @var string $result */
+        $result = $adapter->renderFigure(null, [], $this->request);
+
+        // Without caption, should NOT have figure wrapper
+        self::assertStringNotContainsString('<figure', $result, 'Aligned image without caption should not have figure wrapper');
+        self::assertStringNotContainsString('<figcaption', $result, 'Should not have figcaption');
+        // Should have the alignment class on the img element
+        self::assertStringContainsString('image-left', $result, 'Alignment class should be on the img element');
+        self::assertStringContainsString('<img', $result, 'Should contain img element');
+    }
+
+    /**
+     * Test: Image with image-center class but no caption renders as standalone img.
+     *
+     * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/595
+     */
+    #[Test]
+    public function centeredImageWithoutCaptionOutputsStandaloneImg(): void
+    {
+        ['adapter' => $adapter, 'cObj' => $cObj] = $this->getAdapterWithCObj();
+
+        $inputHtml = '<figure class="image image-center">'
+            . '<img src="/fileadmin/test.jpg" data-htmlarea-file-uid="1" width="250" height="250" alt="Centered">'
+            . '</figure>';
+
+        $cObj->setCurrentVal($inputHtml);
+
+        /** @var string $result */
+        $result = $adapter->renderFigure(null, [], $this->request);
+
+        self::assertStringNotContainsString('<figure', $result, 'Centered image without caption should not have figure wrapper');
+        self::assertStringContainsString('image-center', $result, 'Center alignment class should be on the img element');
+    }
+
+    /**
+     * Test: Image with image-right class but no caption renders as standalone img.
+     *
+     * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/595
+     */
+    #[Test]
+    public function rightAlignedImageWithoutCaptionOutputsStandaloneImg(): void
+    {
+        ['adapter' => $adapter, 'cObj' => $cObj] = $this->getAdapterWithCObj();
+
+        $inputHtml = '<figure class="image image-right">'
+            . '<img src="/fileadmin/test.jpg" data-htmlarea-file-uid="1" width="250" height="250" alt="Right aligned">'
+            . '</figure>';
+
+        $cObj->setCurrentVal($inputHtml);
+
+        /** @var string $result */
+        $result = $adapter->renderFigure(null, [], $this->request);
+
+        self::assertStringNotContainsString('<figure', $result, 'Right-aligned image without caption should not have figure wrapper');
+        self::assertStringContainsString('image-right', $result, 'Right alignment class should be on the img element');
+    }
+
+    /**
+     * Test: Image with alignment class AND caption correctly uses figure wrapper.
+     *
+     * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/595
+     */
+    #[Test]
+    public function alignedImageWithCaptionUsesFigureWrapper(): void
+    {
+        ['adapter' => $adapter, 'cObj' => $cObj] = $this->getAdapterWithCObj();
+
+        $inputHtml = '<figure class="image image-left">'
+            . '<img src="/fileadmin/test.jpg" data-htmlarea-file-uid="1" width="250" height="250" alt="Left aligned">'
+            . '<figcaption>Caption for aligned image</figcaption>'
+            . '</figure>';
+
+        $cObj->setCurrentVal($inputHtml);
+
+        /** @var string $result */
+        $result = $adapter->renderFigure(null, [], $this->request);
+
+        // With caption, SHOULD have figure wrapper
+        self::assertSame(1, substr_count($result, '<figure'), 'Aligned image with caption should have figure wrapper');
+        self::assertStringContainsString('<figcaption', $result, 'Should have figcaption');
+        self::assertStringContainsString('Caption for aligned image', $result, 'Caption text should be present');
+        // Alignment class should be on the figure element
+        self::assertStringContainsString('image-left', $result, 'Alignment class should be present');
+    }
+
+    /**
+     * Test: Linked image with alignment class but no caption uses Link template.
+     *
+     * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/595
+     */
+    #[Test]
+    public function linkedAlignedImageWithoutCaptionUsesLinkTemplate(): void
+    {
+        ['adapter' => $adapter, 'cObj' => $cObj] = $this->getAdapterWithCObj();
+
+        $inputHtml = '<figure class="image image-center">'
+            . '<a href="https://example.com">'
+            . '<img src="/fileadmin/test.jpg" data-htmlarea-file-uid="1" width="250" height="250" alt="Linked center">'
+            . '</a>'
+            . '</figure>';
+
+        $cObj->setCurrentVal($inputHtml);
+
+        /** @var string $result */
+        $result = $adapter->renderFigure(null, [], $this->request);
+
+        // Without caption, should NOT have figure wrapper
+        self::assertStringNotContainsString('<figure', $result, 'Linked aligned image without caption should not have figure wrapper');
+        // Should have link
+        self::assertStringContainsString('<a', $result, 'Should contain link');
+        self::assertStringContainsString('href="https://example.com"', $result, 'Link href should be preserved');
+        // Alignment class should be on the img element
+        self::assertStringContainsString('image-center', $result, 'Center alignment class should be present');
+    }
+
+    // ========================================================================
     // Inline image handling inside paragraphs
     // ========================================================================
 

--- a/Tests/Unit/Service/ImageRenderingServiceTest.php
+++ b/Tests/Unit/Service/ImageRenderingServiceTest.php
@@ -389,6 +389,94 @@ class ImageRenderingServiceTest extends TestCase
         );
     }
 
+    // ========================================================================
+    // Issue #595: Alignment class without caption should NOT trigger figure
+    // ========================================================================
+
+    /**
+     * Image with figureClass but no caption should use Standalone template.
+     *
+     * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/595
+     */
+    public function testSelectTemplateWithAlignmentClassButNoCaptionUsesStandalone(): void
+    {
+        $dto = new ImageRenderingDto(
+            src: '/image.jpg',
+            width: 800,
+            height: 600,
+            alt: 'Alt',
+            title: 'Title',
+            htmlAttributes: ['class' => 'image image-left'],
+            caption: null,
+            link: null,
+            isMagicImage: true,
+            figureClass: 'image image-left',
+        );
+
+        $template = $this->callProtectedMethod($this->service, 'selectTemplate', [$dto]);
+
+        self::assertSame('Image/Standalone', $template);
+    }
+
+    /**
+     * Linked image with figureClass but no caption should use Link template (not LinkWithCaption).
+     *
+     * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/595
+     */
+    public function testSelectTemplateWithAlignmentClassLinkedNoCaptionUsesLink(): void
+    {
+        $linkDto = new LinkDto(
+            url: 'https://example.com',
+            target: '_blank',
+            class: null,
+            params: null,
+            isPopup: false,
+            jsConfig: null,
+        );
+
+        $dto = new ImageRenderingDto(
+            src: '/image.jpg',
+            width: 800,
+            height: 600,
+            alt: 'Alt',
+            title: 'Title',
+            htmlAttributes: ['class' => 'image image-center'],
+            caption: null,
+            link: $linkDto,
+            isMagicImage: true,
+            figureClass: 'image image-center',
+        );
+
+        $template = $this->callProtectedMethod($this->service, 'selectTemplate', [$dto]);
+
+        self::assertSame('Image/Link', $template);
+    }
+
+    /**
+     * Image with BOTH alignment class AND caption should use WithCaption template.
+     *
+     * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/595
+     */
+    public function testSelectTemplateWithAlignmentClassAndCaptionUsesWithCaption(): void
+    {
+        $dto = new ImageRenderingDto(
+            src: '/image.jpg',
+            width: 800,
+            height: 600,
+            alt: 'Alt',
+            title: 'Title',
+            htmlAttributes: [],
+            caption: 'A caption',
+            link: null,
+            isMagicImage: true,
+            figureClass: 'image image-right',
+        );
+
+        $template = $this->callProtectedMethod($this->service, 'selectTemplate', [$dto]);
+
+        self::assertSame('Image/WithCaption', $template);
+    }
+
     /**
      * Test that render() trims whitespace from Fluid template output.
      *


### PR DESCRIPTION
## Summary

Fixes #595

- When images have alignment classes (`image-left`, `image-center`, `image-right`) but **no caption**, they were incorrectly wrapped in `<figure>` elements
- Now they render as standalone `<img>` with the alignment class on the element
- Images with both alignment class AND caption correctly continue to use `<figure>` wrapper

### Changes
- **`ImageRenderingService::selectTemplate()`**: Remove alignment class from figure wrapper decision — only caption triggers `<figure>`
- **`ImageResolverService::resolve()`**: When no caption, merge `figureClass` into `htmlAttributes['class']` so alignment appears on `<img>`
- **Unit tests**: 3 new tests for template selection with alignment classes
- **Functional tests**: 5 new tests covering all alignment variants (left, center, right, with caption, linked)

## Test plan

- [ ] Unit tests pass (`composer ci:test:php:unit`)
- [ ] Functional tests pass (`composer ci:test:php:functional`)
- [ ] PHPStan passes (`composer ci:test:php:phpstan`)
- [ ] CGL passes (`composer ci:test:php:cgl`)
- [ ] Verify `<figure class="image image-left"><img ...></figure>` (no caption) renders as `<img class="image image-left" ...>`
- [ ] Verify `<figure class="image image-left"><img ...><figcaption>...</figcaption></figure>` (with caption) still renders with `<figure>` wrapper