### PR TITLE
chore(demo): add #595 alignment caption vs no-caption demo content

### DIFF
--- a/.ddev/commands/web/install-v13
+++ b/.ddev/commands/web/install-v13
@@ -420,12 +420,11 @@ CONCAT(
 <p>Block images support <code>image-left</code>, <code>image-center</code>, and <code>image-right</code> alignment classes:</p>
 <div class="row">
 <div class="col-lg-6 mb-3">
-<div class="border rounded p-3">
+<div class="border rounded p-3 clearfix">
 <figure class="image image-left mb-0">
 <img src="fileadmin/user_upload/medium.jpg" alt="left aligned" width="150" height="113" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded">
 </figure>
 <p class="small">Text flows around the left-aligned image. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt.</p>
-<div style="clear:both"></div>
 </div>
 </div>
 <div class="col-lg-6 mb-3">
@@ -460,13 +459,12 @@ CONCAT(
 
 <div class="row mb-4">
 <div class="col-lg-4 mb-3">
-<div class="border rounded p-3">
+<div class="border rounded p-3 clearfix">
 <h6 class="text-muted">Left-aligned, no caption</h6>
 <figure class="image image-left mb-0">
 <img src="fileadmin/user_upload/medium.jpg" alt="left no caption" width="150" height="113" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded">
 </figure>
 <p class="small">Text wraps around. Inspect: should be <code>&lt;img class="... image-left"&gt;</code> with no figure.</p>
-<div style="clear:both"></div>
 </div>
 </div>
 <div class="col-lg-4 mb-3">
@@ -479,13 +477,12 @@ CONCAT(
 </div>
 </div>
 <div class="col-lg-4 mb-3">
-<div class="border rounded p-3">
+<div class="border rounded p-3 clearfix">
 <h6 class="text-muted">Right-aligned, no caption</h6>
 <figure class="image image-right mb-0">
 <img src="fileadmin/user_upload/medium.jpg" alt="right no caption" width="150" height="113" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded">
 </figure>
 <p class="small">Text wraps around. Inspect: should be <code>&lt;img class="... image-right"&gt;</code> with no figure.</p>
-<div style="clear:both"></div>
 </div>
 </div>
 </div>
@@ -497,14 +494,13 @@ CONCAT(
 
 <div class="row mb-4">
 <div class="col-lg-4 mb-3">
-<div class="border rounded p-3">
+<div class="border rounded p-3 clearfix">
 <h6 class="text-muted">Left-aligned, with caption</h6>
 <figure class="image image-left mb-0">
 <img src="fileadmin/user_upload/medium.jpg" alt="left with caption" width="150" height="113" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded">
 <figcaption class="small text-muted">Left-aligned caption</figcaption>
 </figure>
 <p class="small">Inspect: should be <code>&lt;figure class="... image-left"&gt;</code> with figcaption.</p>
-<div style="clear:both"></div>
 </div>
 </div>
 <div class="col-lg-4 mb-3">
@@ -518,14 +514,13 @@ CONCAT(
 </div>
 </div>
 <div class="col-lg-4 mb-3">
-<div class="border rounded p-3">
+<div class="border rounded p-3 clearfix">
 <h6 class="text-muted">Right-aligned, with caption</h6>
 <figure class="image image-right mb-0">
 <img src="fileadmin/user_upload/medium.jpg" alt="right with caption" width="150" height="113" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded">
 <figcaption class="small text-muted">Right-aligned caption</figcaption>
 </figure>
 <p class="small">Inspect: should be <code>&lt;figure class="... image-right"&gt;</code> with figcaption.</p>
-<div style="clear:both"></div>
 </div>
 </div>
 </div>
@@ -590,17 +585,19 @@ CONCAT(
 <div class="card-body">
 
 <h5 class="border-bottom pb-2 mb-3">Right-Aligned Image with Text Wrap</h5>
+<div class="clearfix">
 <figure class="image image-right mb-3">
 <img src="fileadmin/user_upload/medium.jpg" alt="right aligned" width="180" height="135" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded shadow-sm">
 <figcaption class="small text-muted">Right-aligned with caption</figcaption>
 </figure>
 <p>This paragraph demonstrates right-aligned images with text wrapping around them. The image floats to the right side of the container, and the text flows naturally on the left. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. This text continues to wrap around the right-aligned image until the float is cleared.</p>
-<div style="clear:both"></div>
+</div>
 
 <hr class="my-4">
 
 <h5 class="border-bottom pb-2 mb-3">Left-Aligned Image with Long Text</h5>
+<div class="clearfix">
 <figure class="image image-left mb-3">
 <img src="fileadmin/user_upload/medium.jpg" alt="left aligned large" width="200" height="150" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded shadow-sm">
 <figcaption class="small text-muted">Left-aligned with caption</figcaption>
@@ -608,7 +605,7 @@ CONCAT(
 <p>This is a longer paragraph that demonstrates how text wraps around a left-aligned image. The image floats to the left, creating a professional layout commonly seen in articles and documentation. When dealing with content management systems like TYPO3, proper image alignment is crucial for creating visually appealing pages that engage readers.</p>
 <p>The rte_ckeditor_image extension ensures that alignment classes set in CKEditor 5 are properly preserved during the rendering process. Without this functionality, the CSS classes would be stripped, and images would lose their intended positioning. This is particularly important for responsive designs where image placement affects the overall user experience.</p>
 <p>Additional paragraphs continue to flow around the floated image until the content extends beyond the image height or the float is explicitly cleared. This behavior is controlled by CSS rules defined in the image-alignment.css file.</p>
-<div style="clear:both"></div>
+</div>
 
 <hr class="my-4">
 
@@ -731,6 +728,7 @@ or read the <a href="https://docs.typo3.org" target="_blank"><img class="image i
 <hr class="my-4">
 
 <h5 class="border-bottom pb-2 mb-3">Linked Block Image with Caption and Alignment</h5>
+<div class="clearfix">
 <figure class="image image-left mb-3">
 <a href="https://netresearch.de" target="_blank">
 <img src="fileadmin/user_upload/medium.jpg" alt="Netresearch" width="180" height="135" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded">
@@ -739,7 +737,7 @@ or read the <a href="https://docs.typo3.org" target="_blank"><img class="image i
 </figure>
 <p>This demonstrates the complete combination: a block image that is left-aligned, wrapped in a link, AND has a caption. The text flows around it naturally. This is the most complex standard scenario and tests that all features work together without interference.</p>
 <p>The image links to an external URL, while the caption provides context. The alignment CSS ensures proper text flow, and the figure/figcaption structure maintains semantic HTML.</p>
-<div style="clear:both"></div>
+</div>
 
 <div class="alert alert-warning mt-4">
 <strong>Important Test Case:</strong> Linked images should NOT get additional popup/zoom links added - the existing link takes precedence. The <code>data-htmlarea-zoom</code> attribute is stripped for images that are already wrapped in links.
@@ -952,6 +950,7 @@ CONCAT(
 
 <h4>Chapter 1: Introduction to TYPO3 Content Management</h4>
 
+<div class="clearfix">
 <figure class="image image-right mb-3">
 <img src="fileadmin/user_upload/medium.jpg" alt="TYPO3 Dashboard" width="200" height="150" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded shadow-sm">
 <figcaption class="small">The TYPO3 Backend Interface</figcaption>
@@ -960,11 +959,11 @@ CONCAT(
 <p>TYPO3 is a powerful, enterprise-grade content management system that has been serving the web community for over two decades. Its flexibility and extensibility make it an ideal choice for organizations of all sizes, from small businesses to large enterprises with complex content requirements.</p>
 
 <p>The system provides robust tools for managing digital assets, including images <img class="image image-inline" src="fileadmin/user_upload/icon.jpg" alt="image icon" width="18" height="18" data-htmlarea-file-uid="', @file4_uid, '" data-htmlarea-file-table="sys_file">, documents <img class="image image-inline" src="fileadmin/user_upload/icon.jpg" alt="doc icon" width="18" height="18" data-htmlarea-file-uid="', @file4_uid, '" data-htmlarea-file-table="sys_file">, and multimedia content <img class="image image-inline" src="fileadmin/user_upload/icon.jpg" alt="media icon" width="18" height="18" data-htmlarea-file-uid="', @file4_uid, '" data-htmlarea-file-table="sys_file">. The File Abstraction Layer (FAL) ensures consistent handling of all file operations.</p>
-
-<div style="clear:both"></div>
+</div>
 
 <h4 class="mt-4">Chapter 2: Rich Text Editing with CKEditor 5</h4>
 
+<div class="clearfix">
 <figure class="image image-left mb-3">
 <img src="fileadmin/user_upload/medium.jpg" alt="CKEditor Interface" width="180" height="135" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" data-htmlarea-zoom="true" class="rounded shadow-sm">
 <figcaption class="small">CKEditor 5 in TYPO3 (click to enlarge)</figcaption>
@@ -982,8 +981,7 @@ CONCAT(
 <li>Click-to-enlarge (lightbox) functionality</li>
 <li>Link wrapping for images</li>
 </ul>
-
-<div style="clear:both"></div>
+</div>
 
 <h4 class="mt-4">Chapter 3: Best Practices for Image Content</h4>
 

--- a/.ddev/commands/web/install-v14
+++ b/.ddev/commands/web/install-v14
@@ -456,12 +456,11 @@ CONCAT(
 <p>Block images support <code>image-left</code>, <code>image-center</code>, and <code>image-right</code> alignment classes:</p>
 <div class="row">
 <div class="col-lg-6 mb-3">
-<div class="border rounded p-3">
+<div class="border rounded p-3 clearfix">
 <figure class="image image-left mb-0">
 <img src="fileadmin/user_upload/medium.jpg" alt="left aligned" width="150" height="113" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded">
 </figure>
 <p class="small">Text flows around the left-aligned image. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt.</p>
-<div style="clear:both"></div>
 </div>
 </div>
 <div class="col-lg-6 mb-3">
@@ -496,13 +495,12 @@ CONCAT(
 
 <div class="row mb-4">
 <div class="col-lg-4 mb-3">
-<div class="border rounded p-3">
+<div class="border rounded p-3 clearfix">
 <h6 class="text-muted">Left-aligned, no caption</h6>
 <figure class="image image-left mb-0">
 <img src="fileadmin/user_upload/medium.jpg" alt="left no caption" width="150" height="113" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded">
 </figure>
 <p class="small">Text wraps around. Inspect: should be <code>&lt;img class="... image-left"&gt;</code> with no figure.</p>
-<div style="clear:both"></div>
 </div>
 </div>
 <div class="col-lg-4 mb-3">
@@ -515,13 +513,12 @@ CONCAT(
 </div>
 </div>
 <div class="col-lg-4 mb-3">
-<div class="border rounded p-3">
+<div class="border rounded p-3 clearfix">
 <h6 class="text-muted">Right-aligned, no caption</h6>
 <figure class="image image-right mb-0">
 <img src="fileadmin/user_upload/medium.jpg" alt="right no caption" width="150" height="113" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded">
 </figure>
 <p class="small">Text wraps around. Inspect: should be <code>&lt;img class="... image-right"&gt;</code> with no figure.</p>
-<div style="clear:both"></div>
 </div>
 </div>
 </div>
@@ -533,14 +530,13 @@ CONCAT(
 
 <div class="row mb-4">
 <div class="col-lg-4 mb-3">
-<div class="border rounded p-3">
+<div class="border rounded p-3 clearfix">
 <h6 class="text-muted">Left-aligned, with caption</h6>
 <figure class="image image-left mb-0">
 <img src="fileadmin/user_upload/medium.jpg" alt="left with caption" width="150" height="113" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded">
 <figcaption class="small text-muted">Left-aligned caption</figcaption>
 </figure>
 <p class="small">Inspect: should be <code>&lt;figure class="... image-left"&gt;</code> with figcaption.</p>
-<div style="clear:both"></div>
 </div>
 </div>
 <div class="col-lg-4 mb-3">
@@ -554,14 +550,13 @@ CONCAT(
 </div>
 </div>
 <div class="col-lg-4 mb-3">
-<div class="border rounded p-3">
+<div class="border rounded p-3 clearfix">
 <h6 class="text-muted">Right-aligned, with caption</h6>
 <figure class="image image-right mb-0">
 <img src="fileadmin/user_upload/medium.jpg" alt="right with caption" width="150" height="113" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded">
 <figcaption class="small text-muted">Right-aligned caption</figcaption>
 </figure>
 <p class="small">Inspect: should be <code>&lt;figure class="... image-right"&gt;</code> with figcaption.</p>
-<div style="clear:both"></div>
 </div>
 </div>
 </div>
@@ -626,17 +621,19 @@ CONCAT(
 <div class="card-body">
 
 <h5 class="border-bottom pb-2 mb-3">Right-Aligned Image with Text Wrap</h5>
+<div class="clearfix">
 <figure class="image image-right mb-3">
 <img src="fileadmin/user_upload/medium.jpg" alt="right aligned" width="180" height="135" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded shadow-sm">
 <figcaption class="small text-muted">Right-aligned with caption</figcaption>
 </figure>
 <p>This paragraph demonstrates right-aligned images with text wrapping around them. The image floats to the right side of the container, and the text flows naturally on the left. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
 <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. This text continues to wrap around the right-aligned image until the float is cleared.</p>
-<div style="clear:both"></div>
+</div>
 
 <hr class="my-4">
 
 <h5 class="border-bottom pb-2 mb-3">Left-Aligned Image with Long Text</h5>
+<div class="clearfix">
 <figure class="image image-left mb-3">
 <img src="fileadmin/user_upload/medium.jpg" alt="left aligned large" width="200" height="150" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded shadow-sm">
 <figcaption class="small text-muted">Left-aligned with caption</figcaption>
@@ -644,7 +641,7 @@ CONCAT(
 <p>This is a longer paragraph that demonstrates how text wraps around a left-aligned image. The image floats to the left, creating a professional layout commonly seen in articles and documentation. When dealing with content management systems like TYPO3, proper image alignment is crucial for creating visually appealing pages that engage readers.</p>
 <p>The rte_ckeditor_image extension ensures that alignment classes set in CKEditor 5 are properly preserved during the rendering process. Without this functionality, the CSS classes would be stripped, and images would lose their intended positioning. This is particularly important for responsive designs where image placement affects the overall user experience.</p>
 <p>Additional paragraphs continue to flow around the floated image until the content extends beyond the image height or the float is explicitly cleared. This behavior is controlled by CSS rules defined in the image-alignment.css file.</p>
-<div style="clear:both"></div>
+</div>
 
 <hr class="my-4">
 
@@ -767,6 +764,7 @@ or read the <a href="https://docs.typo3.org" target="_blank"><img class="image i
 <hr class="my-4">
 
 <h5 class="border-bottom pb-2 mb-3">Linked Block Image with Caption and Alignment</h5>
+<div class="clearfix">
 <figure class="image image-left mb-3">
 <a href="https://netresearch.de" target="_blank">
 <img src="fileadmin/user_upload/medium.jpg" alt="Netresearch" width="180" height="135" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded">
@@ -775,7 +773,7 @@ or read the <a href="https://docs.typo3.org" target="_blank"><img class="image i
 </figure>
 <p>This demonstrates the complete combination: a block image that is left-aligned, wrapped in a link, AND has a caption. The text flows around it naturally. This is the most complex standard scenario and tests that all features work together without interference.</p>
 <p>The image links to an external URL, while the caption provides context. The alignment CSS ensures proper text flow, and the figure/figcaption structure maintains semantic HTML.</p>
-<div style="clear:both"></div>
+</div>
 
 <div class="alert alert-warning mt-4">
 <strong>Important Test Case:</strong> Linked images should NOT get additional popup/zoom links added - the existing link takes precedence. The <code>data-htmlarea-zoom</code> attribute is stripped for images that are already wrapped in links.
@@ -988,6 +986,7 @@ CONCAT(
 
 <h4>Chapter 1: Introduction to TYPO3 Content Management</h4>
 
+<div class="clearfix">
 <figure class="image image-right mb-3">
 <img src="fileadmin/user_upload/medium.jpg" alt="TYPO3 Dashboard" width="200" height="150" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" class="rounded shadow-sm">
 <figcaption class="small">The TYPO3 Backend Interface</figcaption>
@@ -996,11 +995,11 @@ CONCAT(
 <p>TYPO3 is a powerful, enterprise-grade content management system that has been serving the web community for over two decades. Its flexibility and extensibility make it an ideal choice for organizations of all sizes, from small businesses to large enterprises with complex content requirements.</p>
 
 <p>The system provides robust tools for managing digital assets, including images <img class="image image-inline" src="fileadmin/user_upload/icon.jpg" alt="image icon" width="18" height="18" data-htmlarea-file-uid="', @file4_uid, '" data-htmlarea-file-table="sys_file">, documents <img class="image image-inline" src="fileadmin/user_upload/icon.jpg" alt="doc icon" width="18" height="18" data-htmlarea-file-uid="', @file4_uid, '" data-htmlarea-file-table="sys_file">, and multimedia content <img class="image image-inline" src="fileadmin/user_upload/icon.jpg" alt="media icon" width="18" height="18" data-htmlarea-file-uid="', @file4_uid, '" data-htmlarea-file-table="sys_file">. The File Abstraction Layer (FAL) ensures consistent handling of all file operations.</p>
-
-<div style="clear:both"></div>
+</div>
 
 <h4 class="mt-4">Chapter 2: Rich Text Editing with CKEditor 5</h4>
 
+<div class="clearfix">
 <figure class="image image-left mb-3">
 <img src="fileadmin/user_upload/medium.jpg" alt="CKEditor Interface" width="180" height="135" data-htmlarea-file-uid="', @file3_uid, '" data-htmlarea-file-table="sys_file" data-htmlarea-zoom="true" class="rounded shadow-sm">
 <figcaption class="small">CKEditor 5 in TYPO3 (click to enlarge)</figcaption>
@@ -1018,8 +1017,7 @@ CONCAT(
 <li>Click-to-enlarge (lightbox) functionality</li>
 <li>Link wrapping for images</li>
 </ul>
-
-<div style="clear:both"></div>
+</div>
 
 <h4 class="mt-4">Chapter 3: Best Practices for Image Content</h4>
 


### PR DESCRIPTION
## Summary
- Adds Content Element 5b (sorting 510) to DDEV demo pages demonstrating the [#595](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/595) fix
- Shows aligned images **without captions** (render as standalone `<img>`) vs **with captions** (render in `<figure>` wrapper)
- Covers all three alignment directions: left, center, right
- Updates CE13 counter from 13 to 14 content scenarios
- Applied identically to both `install-v13` and `install-v14`

## Test plan
- [ ] `ddev start && ddev install-v13`
- [ ] Visit demo page, find "Alignment: Caption vs No Caption (Issue #595)" card
- [ ] Inspect HTML: aligned images without caption should be `<img>` (no `<figure>`)
- [ ] Inspect HTML: aligned images with caption should be `<figure>` with `<figcaption>`

Closes #595