### PR TITLE
chore(demo): add CKEditor GHS config and widescreen layout

### DIFF
--- a/.ddev/assets/demoWithImages.yaml
+++ b/.ddev/assets/demoWithImages.yaml
@@ -1,0 +1,21 @@
+imports:
+  - { resource: "EXT:rte_ckeditor_image/Configuration/RTE/rteWithImages.yaml" }
+
+editor:
+  config:
+    htmlSupport:
+      allow:
+        - { name: "div", classes: true, styles: true, attributes: true }
+        - { name: "span", classes: true, styles: true, attributes: true }
+        - { name: "small", classes: true }
+        - { name: "i", classes: true }
+        - { name: "p", classes: true, styles: true }
+        - { name: "ul", classes: true }
+        - { name: "ol", classes: true }
+        - { name: "li", classes: true }
+        - { name: "h1", classes: true, styles: true }
+        - { name: "h2", classes: true }
+        - { name: "h3", classes: true }
+        - { name: "h4", classes: true }
+        - { name: "h5", classes: true }
+        - { name: "h6", classes: true }

--- a/.ddev/commands/web/install-v13
+++ b/.ddev/commands/web/install-v13
@@ -37,7 +37,7 @@ vendor/bin/typo3 configuration:set 'BE/debug' 1
 vendor/bin/typo3 configuration:set 'FE/debug' 1
 vendor/bin/typo3 configuration:set 'SYS/devIPmask' '*'
 vendor/bin/typo3 configuration:set 'SYS/displayErrors' 1
-# Create additional.php for trustedHostsPattern (configuration:set doesn't work reliably for this)
+# Create additional.php for trustedHostsPattern and demo RTE preset
 mkdir -p /var/www/html/$VERSION/config/system
 cat > /var/www/html/$VERSION/config/system/additional.php << 'ADDPHP'
 <?php
@@ -187,32 +187,10 @@ FILE2_INFO=($(get_file_info "public/fileadmin/user_upload/inline-small.jpg"))
 FILE3_INFO=($(get_file_info "public/fileadmin/user_upload/medium.jpg"))
 FILE4_INFO=($(get_file_info "public/fileadmin/user_upload/icon.jpg"))
 
-# Create demo-specific RTE preset with GHS (General HTML Support)
+# Copy demo-specific RTE preset with GHS (General HTML Support)
 # This preserves Bootstrap HTML elements (div, span, etc.) when editing in CKEditor
 mkdir -p /var/www/html/$VERSION/config/rte
-cat > /var/www/html/$VERSION/config/rte/demoWithImages.yaml << 'RTEYAML'
-imports:
-  - { resource: "EXT:rte_ckeditor_image/Configuration/RTE/rteWithImages.yaml" }
-
-editor:
-  config:
-    htmlSupport:
-      allow:
-        - { name: "div", classes: true, styles: true, attributes: true }
-        - { name: "span", classes: true, styles: true, attributes: true }
-        - { name: "small", classes: true }
-        - { name: "i", classes: true }
-        - { name: "p", classes: true, styles: true }
-        - { name: "ul", classes: true }
-        - { name: "ol", classes: true }
-        - { name: "li", classes: true }
-        - { name: "h1", classes: true, styles: true }
-        - { name: "h2", classes: true }
-        - { name: "h3", classes: true }
-        - { name: "h4", classes: true }
-        - { name: "h5", classes: true }
-        - { name: "h6", classes: true }
-RTEYAML
+cp /var/www/html/$EXTENSION_KEY/.ddev/assets/demoWithImages.yaml /var/www/html/$VERSION/config/rte/demoWithImages.yaml
 
 # Create FAL entries and demo content
 mysql -h "$DB_HOST" -u "$DB_USER" "$VERSION" << EOSQL

--- a/.ddev/commands/web/install-v14
+++ b/.ddev/commands/web/install-v14
@@ -220,32 +220,10 @@ FILE2_INFO=($(get_file_info "public/fileadmin/user_upload/inline-small.jpg"))
 FILE3_INFO=($(get_file_info "public/fileadmin/user_upload/medium.jpg"))
 FILE4_INFO=($(get_file_info "public/fileadmin/user_upload/icon.jpg"))
 
-# Create demo-specific RTE preset with GHS (General HTML Support)
+# Copy demo-specific RTE preset with GHS (General HTML Support)
 # This preserves Bootstrap HTML elements (div, span, etc.) when editing in CKEditor
 mkdir -p /var/www/html/$VERSION/config/rte
-cat > /var/www/html/$VERSION/config/rte/demoWithImages.yaml << 'RTEYAML'
-imports:
-  - { resource: "EXT:rte_ckeditor_image/Configuration/RTE/rteWithImages.yaml" }
-
-editor:
-  config:
-    htmlSupport:
-      allow:
-        - { name: "div", classes: true, styles: true, attributes: true }
-        - { name: "span", classes: true, styles: true, attributes: true }
-        - { name: "small", classes: true }
-        - { name: "i", classes: true }
-        - { name: "p", classes: true, styles: true }
-        - { name: "ul", classes: true }
-        - { name: "ol", classes: true }
-        - { name: "li", classes: true }
-        - { name: "h1", classes: true, styles: true }
-        - { name: "h2", classes: true }
-        - { name: "h3", classes: true }
-        - { name: "h4", classes: true }
-        - { name: "h5", classes: true }
-        - { name: "h6", classes: true }
-RTEYAML
+cp /var/www/html/$EXTENSION_KEY/.ddev/assets/demoWithImages.yaml /var/www/html/$VERSION/config/rte/demoWithImages.yaml
 
 # Create FAL entries and demo content
 mysql -h "$DB_HOST" -u "$DB_USER" "$VERSION" << EOSQL


### PR DESCRIPTION
## Summary

- Add demo-specific CKEditor RTE preset (`demoWithImages.yaml`) with General HTML Support (GHS) to preserve Bootstrap HTML elements (`div`, `span`, `small`, etc.) when editing content in the TYPO3 backend
- Constrain main content area to `max-width: 1400px` for better readability on widescreen monitors

## Details

### CKEditor HTML Preservation
The demo page uses Bootstrap `<div>` containers (cards, rows, cols, alerts) in content elements. Without GHS, CKEditor 5 strips all unrecognized elements when content is loaded and saved, breaking the frontend layout.

The fix creates a `demoWithImages.yaml` preset that imports the extension's `rteWithImages.yaml` and adds `htmlSupport.allow` rules for common HTML elements. The preset is registered in `additional.php` and assigned to the demo page via PageTSconfig.

### Widescreen Layout
Adds `page.cssInline` TypoScript to constrain `.main-section` to 1400px with auto margins, preventing content from stretching uncomfortably wide on large monitors.

Both fixes are demo-specific (install scripts only) — no changes to the extension's shipped code.

## Test plan
- [ ] `ddev install-v13` and verify demo page layout is constrained on widescreen
- [ ] Open a CE with Bootstrap HTML in backend, toggle Source view — divs should be preserved
- [ ] Save CE without changes — frontend should remain intact
- [ ] Repeat with `ddev install-v14`