### PR TITLE
feat: read link browser restrictions from RTE preset configuration

### DIFF
--- a/Classes/Controller/SelectImageController.php
+++ b/Classes/Controller/SelectImageController.php
@@ -283,14 +283,16 @@ class SelectImageController extends ElementBrowserController
                 );
             }
 
-            $params['allowedTypes'] = implode(',', $allowed);
+            if ($allowed !== []) {
+                $params['allowedTypes'] = implode(',', $allowed);
+            }
         } else {
             // Blacklist: combine blindLinkOptions and removeItems
-            $blind = [];
-
-            if (isset($rteConfig['blindLinkOptions']) && is_string($rteConfig['blindLinkOptions'])) {
-                $blind = GeneralUtility::trimExplode(',', $rteConfig['blindLinkOptions'], true);
-            }
+            $blind = GeneralUtility::trimExplode(
+                ',',
+                is_string($rteConfig['blindLinkOptions'] ?? null) ? $rteConfig['blindLinkOptions'] : '',
+                true,
+            );
 
             if ($removeItems !== '') {
                 $blind = array_unique(

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -16,6 +16,7 @@ services:
       $resourceFactory: '@TYPO3\CMS\Core\Resource\ResourceFactory'
       $uploadFolderResolver: '@TYPO3\CMS\Core\Resource\DefaultUploadFolderResolver'
       $elementBrowserRegistry: '@TYPO3\CMS\Backend\ElementBrowser\ElementBrowserRegistry'
+      $richtext: '@TYPO3\CMS\Core\Configuration\Richtext'
 
   # TypoScript adapter for frontend image rendering
   # Bridges TypoScript preUserFunc to modern service architecture

--- a/Tests/Unit/Controller/SelectImageControllerTest.php
+++ b/Tests/Unit/Controller/SelectImageControllerTest.php
@@ -1119,6 +1119,26 @@ final class SelectImageControllerTest extends UnitTestCase
     }
 
     #[Test]
+    public function buildLinkBrowserParamsSkipsEmptyAllowedTypes(): void
+    {
+        // When removeItems removes all allowed types, don't pass empty allowedTypes
+        $rteConfig = [
+            'allowedTypes' => 'page',
+            'buttons'      => [
+                'link' => [
+                    'options' => [
+                        'removeItems' => 'page',
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->callProtectedMethod('buildLinkBrowserParams', [$rteConfig]);
+
+        self::assertArrayNotHasKey('allowedTypes', $result);
+    }
+
+    #[Test]
     public function buildLinkBrowserParamsAllowedTypesTakesPrecedenceOverBlindLinkOptions(): void
     {
         $rteConfig = [


### PR DESCRIPTION
## Summary

Closes #596

- The image dialog's link browser now automatically respects the same `allowedTypes`, `blindLinkOptions`, and `buttons.link.options.removeItems` settings from the active RTE preset configuration
- Mirrors the logic from TYPO3 core's `BrowseLinksController::getAllowedItems()` — zero new configuration keys needed
- Also handles `allowedOptions`/`blindLinkFields` for link field restrictions
- Fixes `pid` reading from the `P` array (where `RichTextElement` actually puts it) with backward-compatible fallback

### How it works

1. `linkBrowserAction()` reads the `P` array from query params (populated by `RichTextElement` via `routeUrl`)
2. `resolveLinkBrowserParams()` loads the RTE config via `Richtext::getConfiguration()` using the page context and preset name
3. `buildLinkBrowserParams()` extracts type/field restrictions following core's priority:
   - `allowedTypes` (whitelist) takes precedence over `blindLinkOptions` (blacklist)
   - `buttons.link.options.removeItems` is always applied on top
4. Computed params are passed to the `wizard_link` route

### Configuration example

Integrators can now restrict link types in their RTE preset YAML:

```yaml
# Only allow page and URL links in the image dialog
allowedTypes: 'page,url'

# Or use removeItems in button config (same as core link browser)
buttons:
  link:
    options:
      removeItems: 'telephone,folder'
```

## Test plan

- [ ] Unit tests pass locally (564 tests, 1273 assertions)
- [ ] PHPStan level 10+ clean
- [ ] CI pipeline green
- [ ] Verify in DDEV demo: image dialog link browser respects RTE preset `removeItems` setting
- [ ] Verify default behavior unchanged when no restrictions configured (all link types shown)