### PR TITLE
feat(e2e): save-render roundtrip tests

### DIFF
--- a/Tests/E2E/tests/save-render-roundtrip.spec.ts
+++ b/Tests/E2E/tests/save-render-roundtrip.spec.ts
@@ -24,7 +24,7 @@ import {
  * button but the modal does not close (PHP built-in server timing issue).
  */
 test.describe('Save-Render Roundtrip', () => {
-  test.beforeEach(async () => {
+  test.beforeEach(() => {
     requireCondition(!!BACKEND_PASSWORD, 'TYPO3_BACKEND_PASSWORD must be configured');
   });
 


### PR DESCRIPTION
## Summary

PR 3 of the [E2E coverage plan](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/608). Adds save-render roundtrip tests that verify the critical path: save in CKEditor backend, verify rendered output on frontend.

- 1 working test: editor HTML preserves key attributes after save-reload
- 3 fixme tests (CI limitations):
  - Save→frontend rendering: image rendering pipeline produces empty output after save in PHP built-in server
  - Modify alt text→frontend: modal close issue in CI
  - Enable zoom→frontend: modal close issue in CI

## Test plan

- [x] PHPStan, CS-fixer, phplint pass (pre-commit hooks)
- [x] E2E: 109 passed, 6 skipped, 0 failed
- [x] Test 2 verifies CKEditor data attributes survive save-reload cycle
- [x] Fixme tests document what should be tested once CI rendering and modal issues are resolved