### PR TITLE
chore: improve OpenSSF Scorecard compliance

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -15,8 +15,13 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+              with:
+                  egress-policy: audit
+
             - name: Generate GitHub App token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
               id: app-token
               with:
                   app-id: ${{ secrets.PROJECT_APP_ID }}
@@ -24,7 +29,7 @@ jobs:
                   owner: netresearch
 
             - name: Add to project
-              uses: actions/add-to-project@v1.0.2
+              uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
               with:
                   project-url: https://github.com/orgs/netresearch/projects/4
                   github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -18,6 +18,11 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
       - name: Approve PR
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
                       run_js_tests: true
 
         steps:
+            -   name: Harden Runner
+                uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+                with:
+                    egress-policy: audit
+
             -   id: checkout
                 name: Checkout
                 uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -207,6 +212,11 @@ jobs:
                 typo3: [ '13', '14' ]
 
         steps:
+            -   name: Harden Runner
+                uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+                with:
+                    egress-policy: audit
+
             -   name: Checkout
                 uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,6 +29,11 @@ jobs:
                 language: ['javascript']
 
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+              with:
+                  egress-policy: audit
+
             - name: Checkout repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -26,6 +26,11 @@ jobs:
             INPUT_RELEASE_NOTES: ${{ inputs.release_notes }}
 
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+              with:
+                  egress-policy: audit
+
             - name: Validate version format
               run: |
                   if ! [[ "${INPUT_VERSION}" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
@@ -35,7 +40,7 @@ jobs:
                   echo "VERSION=${INPUT_VERSION}" >> $GITHUB_ENV
 
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   fetch-depth: 0
                   token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,28 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: always

--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -27,6 +27,11 @@ jobs:
             TYPO3_API_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
 
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+              with:
+                  egress-policy: audit
+
             - name: Checkout repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/release-labeler.yml
+++ b/.github/workflows/release-labeler.yml
@@ -27,6 +27,11 @@ jobs:
     name: Label PRs and Issues
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
       - name: Get release info
         id: release
         env:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,41 +1,41 @@
-# OpenSSF Scorecard
-# https://securityscorecards.dev
-# https://github.com/ossf/scorecard-action
-
-name: Scorecard
+name: OpenSSF Scorecard
 
 on:
-    branch_protection_rule:
-    schedule:
-        - cron: '30 5 * * 1'
-    push:
-        branches: [main]
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '25 6 * * 1'
 
-permissions: read-all
+permissions: {}
 
 jobs:
-    analysis:
-        name: Scorecard analysis
-        runs-on: ubuntu-latest
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
 
-        permissions:
-            security-events: write
-            id-token: write
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-        steps:
-            - name: Checkout
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-              with:
-                  persist-credentials: false
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
 
-            - name: Run analysis
-              uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
-              with:
-                  results_file: results.sarif
-                  results_format: sarif
-                  publish_results: true
-
-            - name: Upload to code-scanning
-              uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
-              with:
-                  sarif_file: results.sarif
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [published]
 
-permissions: read-all
+permissions: {}
 
 jobs:
   provenance:


### PR DESCRIPTION
## Summary
- Add `dependency-review.yml` for supply chain dependency scanning
- Add `step-security/harden-runner` to all workflow jobs (9 workflows, 11 jobs)
- Pin unpinned actions to SHA (`actions/checkout@v6` -> pinned, `actions/create-github-app-token@v2` -> pinned)
- Replace `permissions: read-all` with `permissions: {}` on scorecard and SLSA workflows
- Update `scorecard.yml` with latest SHA-pinned actions and harden-runner

## Impact
Raises OpenSSF Scorecard score by addressing:
- **Token-Permissions**: Restrict workflow token permissions (`read-all` -> `{}` + job-level)
- **Pinned-Dependencies**: SHA-pin all GitHub Actions
- **Vulnerabilities**: Dependency review on PRs

## Test plan
- [ ] All existing CI workflows still pass
- [ ] Scorecard workflow runs successfully
- [ ] Dependency review triggers on PRs
- [ ] SLSA provenance workflow still functions correctly