### PR TITLE
fix(e2e): isolate save-render-roundtrip from shared CE 1

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -1010,7 +1010,20 @@ $stmt->execute([1, 'text', 'Alignment Roundtrip Test CE', $bodytextAlignRoundtri
 $bodytextZoomRoundtrip = '<p>Zoom roundtrip test:</p><p><img src="fileadmin/user_upload/example.jpg" alt="Zoom Roundtrip Test" width="800" height="600" data-htmlarea-file-uid="1" /></p><p>End of zoom roundtrip test.</p>';
 $stmt->execute([1, 'text', 'Zoom Roundtrip Test CE', $bodytextZoomRoundtrip, 0, 0, $now, $now, 0, 8960]);
 
-echo "Isolated test CEs (UIDs 26-35) created for saving specs\n";
+// UID 36: For save-render-roundtrip.spec.ts "save unchanged" test (saves CE without changes)
+// Dedicated CE to avoid corrupting CE 1 which is used by read-only tests.
+$bodytextSaveRoundtrip = '<p>Save roundtrip test:</p><p><img src="fileadmin/user_upload/example.jpg" alt="Save Roundtrip" width="800" height="600" data-htmlarea-zoom="true" data-htmlarea-file-uid="1" /></p><p>End of save roundtrip test.</p>';
+$stmt->execute([1, 'text', 'Save Roundtrip Test CE', $bodytextSaveRoundtrip, 0, 0, $now, $now, 0, 9216]);
+
+// UID 37: For save-render-roundtrip.spec.ts "preserves attributes" test
+$bodytextAttrRoundtrip = '<p>Attribute roundtrip test:</p><p><img src="fileadmin/user_upload/example.jpg" alt="Attr Roundtrip" width="800" height="600" data-htmlarea-file-uid="1" /></p><p>End of attribute roundtrip test.</p>';
+$stmt->execute([1, 'text', 'Attr Roundtrip Test CE', $bodytextAttrRoundtrip, 0, 0, $now, $now, 0, 9472]);
+
+// UID 38: For save-render-roundtrip.spec.ts "modify alt text" test
+$bodytextAltRoundtrip = '<p>Alt text roundtrip test:</p><p><img src="fileadmin/user_upload/example.jpg" alt="Alt Roundtrip" width="800" height="600" data-htmlarea-file-uid="1" /></p><p>End of alt text roundtrip test.</p>';
+$stmt->execute([1, 'text', 'Alt Roundtrip Test CE', $bodytextAltRoundtrip, 0, 0, $now, $now, 0, 9728]);
+
+echo "Isolated test CEs (UIDs 26-38) created for saving specs\n";
 CONTENT_EOF
 
         # Start MariaDB container for E2E tests

--- a/Tests/E2E/tests/save-render-roundtrip.spec.ts
+++ b/Tests/E2E/tests/save-render-roundtrip.spec.ts
@@ -18,7 +18,8 @@ import {
  * Tests the critical path: save in CKEditor backend, verify rendered output
  * on the frontend. Catches "works in editor, broken on frontend" bugs.
  *
- * Test content: CE 1 has a basic image with data-htmlarea-zoom="true".
+ * Test content: CE 36 is a dedicated CE for save-unchanged tests.
+ * CE 1 is shared by many read-only specs so saving it causes pollution.
  *
  * E2E tests use Apache + PHP-FPM (not PHP built-in server) to support
  * TYPO3's URL rewriting and FAL image processing pipeline.
@@ -30,7 +31,7 @@ test.describe('Save-Render Roundtrip', () => {
 
   test('save unchanged content element — images still render on frontend', async ({ page }) => {
     await loginToBackend(page);
-    await navigateToContentEdit(page, 1);
+    await navigateToContentEdit(page, 36);
     await waitForCKEditor(page);
 
     const editorHtml = await getEditorHtml(page);
@@ -44,7 +45,7 @@ test.describe('Save-Render Roundtrip', () => {
     await page.context().clearCookies();
     await gotoFrontendPage(page);
 
-    const images = page.locator('img[alt="Example"]');
+    const images = page.locator('img[alt="Save Roundtrip"]');
     expect(await images.count(), 'Expected images on frontend after save').toBeGreaterThan(0);
     await expect(images.first()).toBeVisible();
 
@@ -54,9 +55,9 @@ test.describe('Save-Render Roundtrip', () => {
   });
 
   test('editor HTML preserves key attributes after save-reload', async ({ page }) => {
-    // Step 1: Login and open CE 1
+    // Step 1: Login and open CE 37 (dedicated for attribute preservation test)
     await loginToBackend(page);
-    await navigateToContentEdit(page, 1);
+    await navigateToContentEdit(page, 37);
     await waitForCKEditor(page);
 
     // Step 2: Capture key attributes from editor HTML
@@ -72,7 +73,7 @@ test.describe('Save-Render Roundtrip', () => {
     await page.waitForTimeout(2000);
 
     // Step 4: Re-open the same CE
-    await navigateToContentEdit(page, 1);
+    await navigateToContentEdit(page, 37);
     await waitForCKEditor(page);
 
     // Step 5: Verify key attributes are preserved
@@ -89,7 +90,7 @@ test.describe('Save-Render Roundtrip', () => {
     // Backend-only roundtrip: confirm dialog → save → reload CE → verify editor HTML.
     // Avoids frontend navigation (PHP built-in server FAL issue).
     await loginToBackend(page);
-    await navigateToContentEdit(page, 1);
+    await navigateToContentEdit(page, 38);
     await waitForCKEditor(page);
 
     // Open image dialog
@@ -127,7 +128,7 @@ test.describe('Save-Render Roundtrip', () => {
     await page.waitForTimeout(2000);
 
     // Re-open the same CE and verify the alt text persisted
-    await navigateToContentEdit(page, 1);
+    await navigateToContentEdit(page, 38);
     await waitForCKEditor(page);
 
     const editorHtml = await getEditorHtml(page);


### PR DESCRIPTION
## Summary

- Fixes flaky `save-render-roundtrip.spec.ts` failure on main (v13 shard 11)
- Also includes review feedback fixes from PR #626

## Root cause

`save-render-roundtrip.spec.ts` was saving CE 1, which is shared by many read-only specs. When the save corrupts the content (0x0 dimensions from CI fake JPEG), Playwright retries find the same corrupted content and all 3 attempts fail.

## Fixes

- **CE isolation**: Create dedicated CEs 36-38 for save-render-roundtrip tests, stop saving CE 1
- **loginToBackend() retry**: Use `gotoFrontendPage('/typo3/')` for infrastructure retry on initial backend page load
- **loginToBackend() error message**: Use `expect().toBeVisible()` with descriptive message for clearer CI failure triage
- **Composer cache key**: Include `runTests.sh` hash since it pins TYPO3 version constraints

## Test plan

- [ ] All 22 E2E shards (v13 + v14) pass
- [ ] `save-render-roundtrip` tests use dedicated CEs 36-38 (no CE 1 references)