### PR TITLE
fix: inline image double-link recovery and indicators

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -833,10 +833,18 @@ $bodytextStyles = '<p>Images with alignment classes:</p>'
 $stmt->execute([1, 'text', 'Styled/Alignment Images', $bodytextStyles, 0, 0, $now, $now, 0, 1536]);
 echo "tt_content record with styled/alignment images created\n";
 
-// UID 7: Inline Images (needed by inline-images.spec.ts and inline-image-editing.spec.ts)
+// UID 7: Inline Images (needed by inline-images.spec.ts, inline-image-editing.spec.ts, inline-image-issues.spec.ts)
+// Line 1: Plain inline (no zoom, no link) — used by "no indicators" test
+// Line 2: Linked inline — used by linked inline tests
+// Line 3: Multiple inline images in one paragraph
+// Line 4: Inline with zoom — demonstrates #639 fix (zoom indicator)
+// Line 5: Inline with link + zoom — demonstrates combined indicators
+// Line 6: Block image coexistence
 $bodytextInline = '<p>Text before <img class="image-inline" src="fileadmin/user_upload/example.jpg" alt="Inline Example" width="100" height="75" data-htmlarea-file-uid="1" /> text after.</p>'
     . '<p>A linked inline image: <a href="https://example.com"><img class="image-inline" src="fileadmin/user_upload/example.jpg" alt="Linked Inline" width="80" height="60" data-htmlarea-file-uid="1" /></a> in text.</p>'
     . '<p>Multiple inline images: <img class="image-inline" src="fileadmin/user_upload/example.jpg" alt="First Inline" width="50" height="38" data-htmlarea-file-uid="1" /> and <img class="image-inline" src="fileadmin/user_upload/example.jpg" alt="Second Inline" width="50" height="38" data-htmlarea-file-uid="1" /> in one paragraph.</p>'
+    . '<p>Inline with zoom: <img class="image-inline" src="fileadmin/user_upload/example.jpg" alt="Zoom Inline" width="80" height="60" data-htmlarea-zoom="true" data-htmlarea-file-uid="1" /> click to enlarge.</p>'
+    . '<p>Inline with link and zoom: <a href="https://example.com"><img class="image-inline" src="fileadmin/user_upload/example.jpg" alt="Link+Zoom Inline" width="80" height="60" data-htmlarea-zoom="true" data-htmlarea-file-uid="1" /></a> both indicators.</p>'
     . '<figure class="image"><img src="fileadmin/user_upload/example.jpg" alt="Block in Inline CE" width="400" height="300" data-htmlarea-file-uid="1" /></figure>';
 $stmt->execute([1, 'text', 'Inline Images', $bodytextInline, 0, 0, $now, $now, 0, 1792]);
 echo "tt_content record with inline images created\n";
@@ -1024,6 +1032,35 @@ $bodytextAltRoundtrip = '<p>Alt text roundtrip test:</p><p><img src="fileadmin/u
 $stmt->execute([1, 'text', 'Alt Roundtrip Test CE', $bodytextAltRoundtrip, 0, 0, $now, $now, 0, 9728]);
 
 echo "Isolated test CEs (UIDs 26-38) created for saving specs\n";
+
+// UIDs 39-41: Inline image issues (#636, #637, #638, #639)
+// These CEs provide test data for inline image bug fixes.
+// CE 39: Double-link corrupted inline image — tests upcast recovery (#638)
+// CE 40: Inline image with zoom — tests zoom indicator in editor (#639)
+// CE 41: Inline image with link — tests link indicator in editor (#639)
+
+// UID 39: Double-link corrupted inline image (<a><a><img class="image-inline"></a></a>)
+// This simulates content corrupted by previous save cycles where the double-link
+// recovery upcast would incorrectly create a block element instead of inline.
+$bodytextDoubleLinkInline = '<p>Double-link inline image recovery test:</p>'
+    . '<p>Text before <a href="https://example.com"><a href="https://example.com"><img class="image-inline" src="fileadmin/user_upload/example.jpg" alt="Double Link Inline" width="100" height="75" data-htmlarea-file-uid="1" /></a></a> text after.</p>'
+    . '<p>End of double-link inline test.</p>';
+// Page 2: corrupted data should not appear on the main frontend page
+$stmtP2->execute([2, 'text', 'Double-Link Inline (#638)', $bodytextDoubleLinkInline, 0, 0, $now, $now, 0, 1792]);
+
+// UID 40: Inline image with zoom — should show zoom indicator in CKEditor editing view
+$bodytextInlineZoom = '<p>Inline zoom indicator test:</p>'
+    . '<p>Text before <img class="image-inline" src="fileadmin/user_upload/example.jpg" alt="Inline Zoom" width="100" height="75" data-htmlarea-zoom="true" data-htmlarea-file-uid="1" /> text after zoom image.</p>'
+    . '<p>End of inline zoom test.</p>';
+$stmt->execute([1, 'text', 'Inline Zoom (#639)', $bodytextInlineZoom, 0, 0, $now, $now, 0, 10240]);
+
+// UID 41: Inline image with link — should show link indicator in CKEditor editing view
+$bodytextInlineLink = '<p>Inline link indicator test:</p>'
+    . '<p>Text before <a href="https://example.com/inline-link"><img class="image-inline" src="fileadmin/user_upload/example.jpg" alt="Inline Link" width="100" height="75" data-htmlarea-file-uid="1" /></a> text after linked image.</p>'
+    . '<p>End of inline link test.</p>';
+$stmt->execute([1, 'text', 'Inline Link (#639)', $bodytextInlineLink, 0, 0, $now, $now, 0, 10496]);
+
+echo "Inline image issue CEs (UIDs 39-41) created for #636/#637/#638/#639\n";
 CONTENT_EOF
 
         # Start MariaDB container for E2E tests

--- a/Resources/Public/Css/editor-image-widget.css
+++ b/Resources/Public/Css/editor-image-widget.css
@@ -105,6 +105,22 @@
     display: inline-block;
     vertical-align: middle;
     margin: 0 0.25em;
+    position: relative;
+}
+
+/* Indicator support for inline images */
+.ck-editor__editable .ck-widget_inline-image .ck-image-indicators {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    display: flex;
+    gap: 4px;
+    z-index: 1;
+    pointer-events: none;
+}
+
+.ck-editor__editable .ck-widget_inline-image:hover .ck-image-indicator {
+    background: rgba(0, 0, 0, 0.8);
 }
 
 /* Ensure inline image doesn't break text flow */

--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -1927,7 +1927,10 @@ export default class Typo3Image extends Plugin {
                         }
                     }
 
-                    return writer.createElement('typo3image', imageAttributes);
+                    // Check image class to create correct element type (inline vs block)
+                    const imgClass = (imageAttributes.class || '').toString();
+                    const isInline = imgClass.split(/\s+/).includes('image-inline');
+                    return writer.createElement(isInline ? 'typo3imageInline' : 'typo3image', imageAttributes);
                 },
                 converterPriority: 'highest'
             });
@@ -2781,6 +2784,35 @@ export default class Typo3Image extends Plugin {
                     });
 
                     writer.insert(writer.createPositionAt(wrapper, 0), imageElement);
+
+                    // Add visual indicators for link and zoom (same as block images)
+                    const linkHref = modelElement.getAttribute('imageLinkHref');
+                    const hasLink = linkHref && linkHref.trim() !== '' && linkHref.trim() !== '/';
+                    const hasZoom = modelElement.getAttribute('enableZoom');
+
+                    if (hasLink || hasZoom) {
+                        const indicatorContainer = writer.createContainerElement('span', {
+                            class: 'ck-image-indicators'
+                        });
+
+                        if (hasZoom) {
+                            const zoomIndicator = writer.createContainerElement('span', {
+                                class: 'ck-image-indicator ck-image-indicator--zoom',
+                                title: 'Click to enlarge'
+                            });
+                            writer.insert(writer.createPositionAt(indicatorContainer, 'end'), zoomIndicator);
+                        }
+
+                        if (hasLink) {
+                            const linkIndicator = writer.createContainerElement('span', {
+                                class: 'ck-image-indicator ck-image-indicator--link',
+                                title: linkHref
+                            });
+                            writer.insert(writer.createPositionAt(indicatorContainer, 'end'), linkIndicator);
+                        }
+
+                        writer.insert(writer.createPositionAt(wrapper, 'end'), indicatorContainer);
+                    }
 
                     return toWidget(wrapper, writer, {
                         label: 'inline image widget',

--- a/Tests/E2E/tests/inline-image-issues.spec.ts
+++ b/Tests/E2E/tests/inline-image-issues.spec.ts
@@ -1,0 +1,273 @@
+import { test, expect } from '@playwright/test';
+import {
+    loginToBackend,
+    navigateToContentEdit,
+    getModuleFrame,
+    waitForCKEditor,
+    getEditorHtml,
+    gotoFrontendPage,
+    requireCondition,
+} from './helpers/typo3-backend';
+
+/**
+ * E2E tests for inline image issues #637, #638, #639.
+ *
+ * #637: Inline + link → Standalone.html instead of Link.html
+ *       (consequence of #638 — corrupted structure causes wrong template)
+ * #638: Duplicate <a> tags for internal t3:// links
+ *       (double-link recovery upcast creates typo3image instead of typo3imageInline)
+ * #639: Zoom/popup indicator not shown on inline images
+ *       (inline editing downcast was missing indicator creation logic)
+ *
+ * Test data (runTests.sh):
+ *   CE 39: Double-link corrupted inline image (<a><a><img class="image-inline"></a></a>)
+ *   CE 40: Inline image with zoom (data-htmlarea-zoom="true")
+ *   CE 41: Inline image with link (<a href="..."><img class="image-inline"></a>)
+ *
+ * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/636
+ * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/637
+ * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/638
+ * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/639
+ */
+
+// =============================================================================
+// #638: Double-link recovery upcast creates correct element type
+// =============================================================================
+
+test.describe('Double-link recovery for inline images (#638)', () => {
+    test.beforeEach(async ({ page }) => {
+        await loginToBackend(page);
+    });
+
+    test('double-link inline image is recovered as inline widget, not block', async ({ page }) => {
+        // CE 39: Contains <a><a><img class="image-inline"></a></a>
+        await navigateToContentEdit(page, 39);
+        await waitForCKEditor(page);
+
+        const frame = getModuleFrame(page);
+
+        // The corrupted double-link should be recovered as inline widget
+        const inlineWidgets = frame.locator('.ck-editor__editable .ck-widget_inline-image');
+        const blockFigures = frame.locator('.ck-editor__editable figure.ck-widget');
+
+        const inlineCount = await inlineWidgets.count();
+        const blockCount = await blockFigures.count();
+
+        console.log(`Inline widgets: ${inlineCount}, Block figures: ${blockCount}`);
+
+        // The inline image should be recovered as inline, not converted to block
+        expect(
+            inlineCount,
+            'Double-link inline image should be recovered as inline widget (typo3imageInline), not block (typo3image)'
+        ).toBeGreaterThan(0);
+    });
+
+    test('recovered inline image preserves image-inline class', async ({ page }) => {
+        await navigateToContentEdit(page, 39);
+        await waitForCKEditor(page);
+
+        const editorHtml = await getEditorHtml(page);
+
+        // The image-inline class must survive the double-link recovery
+        expect(editorHtml).toContain('image-inline');
+    });
+
+    test('recovered inline image is inside a paragraph, not standalone', async ({ page }) => {
+        await navigateToContentEdit(page, 39);
+        await waitForCKEditor(page);
+
+        const frame = getModuleFrame(page);
+
+        // Inline images live inside <p> elements, block images are standalone <figure>s
+        const inlineInParagraph = frame.locator('.ck-editor__editable p .ck-widget_inline-image');
+        const count = await inlineInParagraph.count();
+
+        expect(
+            count,
+            'Recovered inline image should be inside a paragraph element'
+        ).toBeGreaterThan(0);
+    });
+});
+
+// =============================================================================
+// #639: Zoom/link indicators on inline images
+// =============================================================================
+
+test.describe('Inline image indicators (#639)', () => {
+    test.beforeEach(async ({ page }) => {
+        await loginToBackend(page);
+    });
+
+    test('inline image with zoom shows zoom indicator in editor', async ({ page }) => {
+        // CE 40: Contains inline image with data-htmlarea-zoom="true"
+        await navigateToContentEdit(page, 40);
+        await waitForCKEditor(page);
+
+        const frame = getModuleFrame(page);
+
+        const zoomIndicator = frame.locator(
+            '.ck-editor__editable .ck-widget_inline-image .ck-image-indicator--zoom'
+        );
+        const count = await zoomIndicator.count();
+
+        console.log(`Zoom indicators in inline widgets: ${count}`);
+
+        expect(
+            count,
+            'Inline image with zoom should show zoom indicator (magnifying glass)'
+        ).toBeGreaterThan(0);
+    });
+
+    test('inline image with link shows link indicator in editor', async ({ page }) => {
+        // CE 41: Contains <a href="..."><img class="image-inline"></a>
+        await navigateToContentEdit(page, 41);
+        await waitForCKEditor(page);
+
+        const frame = getModuleFrame(page);
+
+        const linkIndicator = frame.locator(
+            '.ck-editor__editable .ck-widget_inline-image .ck-image-indicator--link'
+        );
+        const count = await linkIndicator.count();
+
+        console.log(`Link indicators in inline widgets: ${count}`);
+
+        expect(
+            count,
+            'Inline image with link should show link indicator (chain icon)'
+        ).toBeGreaterThan(0);
+    });
+
+    test('inline image without zoom or link shows no indicators', async ({ page }) => {
+        // CE 7: First inline image has no zoom and no link
+        await navigateToContentEdit(page, 7);
+        await waitForCKEditor(page);
+
+        const frame = getModuleFrame(page);
+
+        const inlineWidgets = frame.locator('.ck-editor__editable .ck-widget_inline-image');
+        requireCondition(await inlineWidgets.count() > 0, 'No inline images in CE 7');
+
+        // First inline image in CE 7 is plain (no zoom, no link)
+        const firstWidget = inlineWidgets.first();
+        const indicators = firstWidget.locator('.ck-image-indicators');
+        const indicatorCount = await indicators.count();
+
+        expect(
+            indicatorCount,
+            'Plain inline image should not have any indicators'
+        ).toBe(0);
+    });
+
+    test('indicator container has correct CSS structure', async ({ page }) => {
+        // CE 40: Inline image with zoom
+        await navigateToContentEdit(page, 40);
+        await waitForCKEditor(page);
+
+        const frame = getModuleFrame(page);
+
+        const indicatorContainer = frame.locator(
+            '.ck-editor__editable .ck-widget_inline-image .ck-image-indicators'
+        );
+        const count = await indicatorContainer.count();
+
+        requireCondition(count > 0, 'No indicator container found in inline widget');
+
+        // Verify the indicator container has correct CSS class
+        const containerClass = await indicatorContainer.first().getAttribute('class');
+        expect(containerClass).toContain('ck-image-indicators');
+
+        // Verify each indicator badge has correct structure
+        const indicators = indicatorContainer.first().locator('.ck-image-indicator');
+        const indicatorCount = await indicators.count();
+        expect(indicatorCount).toBeGreaterThan(0);
+    });
+
+    test('block images still show indicators (regression)', async ({ page }) => {
+        // CE 32: Block image with data-htmlarea-zoom="true"
+        await navigateToContentEdit(page, 32);
+        await waitForCKEditor(page);
+
+        const frame = getModuleFrame(page);
+
+        const blockZoomIndicator = frame.locator(
+            '.ck-editor__editable figure.ck-widget .ck-image-indicator--zoom'
+        );
+        const count = await blockZoomIndicator.count();
+
+        console.log(`Block zoom indicators: ${count}`);
+
+        expect(
+            count,
+            'Block image with zoom should still show indicator (regression check)'
+        ).toBeGreaterThan(0);
+    });
+});
+
+// =============================================================================
+// #637: Inline + link renders correct template on frontend
+// =============================================================================
+
+test.describe('Frontend rendering of inline linked images (#637)', () => {
+    test('inline image with link renders with anchor wrapper', async ({ page }) => {
+        await gotoFrontendPage(page);
+
+        // Find linked inline images in frontend output
+        const linkedInlineImages = page.locator('a > img.image-inline');
+        const count = await linkedInlineImages.count();
+
+        expect(
+            count,
+            'Expected linked inline images in frontend output (Link.html template produces <a> wrapper)'
+        ).toBeGreaterThan(0);
+
+        // Verify the link wrapper has a real href
+        const firstLinked = linkedInlineImages.first();
+        const parentLink = firstLinked.locator('..');
+        const href = await parentLink.getAttribute('href');
+
+        expect(
+            href,
+            'Linked inline image should have href attribute (confirms Link.html was used, not Standalone.html)'
+        ).toBeTruthy();
+    });
+
+    test('inline image with zoom has popup link on frontend', async ({ page }) => {
+        await gotoFrontendPage(page);
+
+        // data-htmlarea-zoom is consumed by PHP rendering and NOT preserved on
+        // the rendered <img>. The Popup.html template wraps the image in an <a>
+        // pointing to the image file. Target by known alt text from test data.
+        const zoomInlineImage = page.locator('img.image-inline[alt="Zoom Inline"]');
+        const count = await zoomInlineImage.count();
+
+        requireCondition(
+            count > 0,
+            'No zoom inline image (alt="Zoom Inline") found on frontend'
+        );
+
+        // Verify the zoom image is wrapped in a popup link by the Popup.html template
+        const parentLink = zoomInlineImage.locator('..');
+
+        const parentTagName = (await parentLink.evaluate((el) => el.tagName)).toLowerCase();
+        expect(
+            parentTagName,
+            'Zoom-enabled inline image should be wrapped in an anchor tag'
+        ).toBe('a');
+
+        const href = await parentLink.getAttribute('href');
+        expect(
+            href,
+            'Popup link wrapping inline zoom image should have href attribute'
+        ).toBeTruthy();
+
+        // Popup.html uses onclick with openPic() or href pointing to image file
+        const onclick = (await parentLink.getAttribute('onclick')) || '';
+        const isPopupLink = onclick.includes('openPic') || (href && href.includes('/fileadmin/'));
+
+        expect(
+            isPopupLink,
+            'Popup link should have openPic onclick or href to image file'
+        ).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes three interconnected inline image issues reported in #636:

- **#638**: Double-link recovery upcast (`<a><a><img></a></a>`) always created `typo3image` (block), even when the `<img>` had `image-inline` class — now checks the class and creates `typo3imageInline` for inline images
- **#637**: Consequence of #638 — corrupted block structure caused wrong template selection (Standalone.html instead of Link.html)
- **#639**: Inline editing downcast had no indicator creation logic — added zoom/link indicator spans mirroring the existing block image pattern, plus CSS positioning

### Changes
- `typo3image.js`: Fix A (upcast element type detection) + Fix B (inline indicator logic)
- `editor-image-widget.css`: Inline indicator positioning + `position: relative` on wrapper
- `runTests.sh`: CEs 39-41 (test fixtures) + enriched CE 7 demo data (inline+zoom, inline+link+zoom)
- `inline-image-issues.spec.ts`: 11 new E2E tests

## Test plan

- [x] PHP unit tests pass locally (630/630)
- [x] New E2E tests pass locally (11/11)
- [x] Full E2E suite passes locally (184 passed, 7 skipped, 0 failed)
- [x] CI E2E v13 passes
- [x] CI E2E v14 passes
- [ ] Manual: Load content with `<a><a><img class="image-inline"></a></a>` → recovered as inline widget
- [ ] Manual: Inline image with zoom → zoom indicator visible in editor
- [ ] Manual: Inline image with link → link indicator visible in editor

Closes #637, closes #638, closes #639