### PR TITLE
fix: correct demoWithImages.yaml copy path to public/ directory

### DIFF
--- a/.ddev/commands/web/install-v13
+++ b/.ddev/commands/web/install-v13
@@ -189,8 +189,8 @@ FILE4_INFO=($(get_file_info "public/fileadmin/user_upload/icon.jpg"))
 
 # Copy demo-specific RTE preset with GHS (General HTML Support)
 # This preserves Bootstrap HTML elements (div, span, etc.) when editing in CKEditor
-mkdir -p /var/www/html/$VERSION/config/rte
-cp /var/www/$EXTENSION_KEY/.ddev/assets/demoWithImages.yaml /var/www/html/$VERSION/config/rte/demoWithImages.yaml
+mkdir -p /var/www/html/$VERSION/public/config/rte
+cp /var/www/$EXTENSION_KEY/.ddev/assets/demoWithImages.yaml /var/www/html/$VERSION/public/config/rte/demoWithImages.yaml
 
 # Create FAL entries and demo content
 mysql -h "$DB_HOST" -u "$DB_USER" "$VERSION" << EOSQL

--- a/.ddev/commands/web/install-v14
+++ b/.ddev/commands/web/install-v14
@@ -222,8 +222,8 @@ FILE4_INFO=($(get_file_info "public/fileadmin/user_upload/icon.jpg"))
 
 # Copy demo-specific RTE preset with GHS (General HTML Support)
 # This preserves Bootstrap HTML elements (div, span, etc.) when editing in CKEditor
-mkdir -p /var/www/html/$VERSION/config/rte
-cp /var/www/$EXTENSION_KEY/.ddev/assets/demoWithImages.yaml /var/www/html/$VERSION/config/rte/demoWithImages.yaml
+mkdir -p /var/www/html/$VERSION/public/config/rte
+cp /var/www/$EXTENSION_KEY/.ddev/assets/demoWithImages.yaml /var/www/html/$VERSION/public/config/rte/demoWithImages.yaml
 
 # Create FAL entries and demo content
 mysql -h "$DB_HOST" -u "$DB_USER" "$VERSION" << EOSQL


### PR DESCRIPTION
## Summary

- Fix `YamlParseException` when opening text content elements in v13/v14 backend
- TYPO3's `GeneralUtility::getFileAbsFileName()` resolves relative paths against `Environment::getPublicPath()` (`public/`), so the YAML preset must be placed under `public/config/rte/`, not `config/rte/`
- Updates both `install-v13` and `install-v14` ddev commands

## Test plan

- [ ] `ddev restart && make up` with v13
- [ ] Open any text content element in the backend — RTE loads without `YamlParseException`
- [ ] Repeat with v14