### PR TITLE
docs: sync documentation with actual codebase

### DIFF
--- a/Documentation/API/EventListeners.rst
+++ b/Documentation/API/EventListeners.rst
@@ -179,6 +179,71 @@ preview for all record types.
 The listener respects the same ``excludedTables`` and ``includedTablesOnly`` settings
 as ``RteSoftrefEnforcer``. See :ref:`Extension Configuration <integration-configuration-extension-settings>`.
 
+RteSoftrefEnforcer
+===================
+
+.. _api-rtesoftrefenforcer:
+
+:Namespace: ``Netresearch\RteCKEditorImage\Listener\TCA``
+:Purpose: Automatically adds ``rtehtmlarea_images`` soft reference to all RTE-enabled text fields
+:Event: ``TYPO3\CMS\Core\Configuration\Event\AfterTcaCompilationEvent``
+
+Without soft references, images inserted via CKEditor are not tracked in TYPO3's
+reference index. This means images could be lost when records are moved, copied,
+or deleted. The listener scans all TCA tables for RTE-enabled ``bodytext`` fields
+and adds the ``rtehtmlarea_images`` softref parser key.
+
+**Service Configuration:**
+
+.. code-block:: yaml
+
+   Netresearch\RteCKEditorImage\Listener\TCA\RteSoftrefEnforcer:
+     tags:
+       - name: event.listener
+         identifier: 'nr-rte-softref-enforcer'
+         event: TYPO3\CMS\Core\Configuration\Event\AfterTcaCompilationEvent
+         after: '*'
+
+**Configuration options:**
+
+Controlled via :confval:`enableAutomaticRteSoftref <confval-enableautomaticrtesoftref>`,
+:confval:`excludedTables <confval-excludedtables>`, and
+:confval:`includedTablesOnly <confval-includedtablesonly>`.
+
+UpdateImageReferences
+======================
+
+.. _api-updateimagereferences:
+
+:Namespace: ``Netresearch\RteCKEditorImage\Listener\FileOperation``
+:Purpose: Updates stale ``src`` attributes when FAL files are moved or renamed
+:Events: ``AfterFileMovedEvent``, ``AfterFileRenamedEvent``
+
+When a file is moved or renamed in TYPO3's Filelist module, the ``src`` attribute
+stored in RTE HTML content becomes stale. The ``data-htmlarea-file-uid`` attribute
+still points to the correct FAL file, but the ``src`` path no longer matches.
+This listener detects affected records via the reference index and updates their
+``src`` attributes to the file's current public URL.
+
+**Service Configuration:**
+
+.. code-block:: yaml
+
+   Netresearch\RteCKEditorImage\Listener\FileOperation\UpdateImageReferences:
+     tags:
+       - name: event.listener
+         identifier: 'nr-rte-update-image-references-moved'
+         event: TYPO3\CMS\Core\Resource\Event\AfterFileMovedEvent
+         method: handleFileMoved
+       - name: event.listener
+         identifier: 'nr-rte-update-image-references-renamed'
+         event: TYPO3\CMS\Core\Resource\Event\AfterFileRenamedEvent
+         method: handleFileRenamed
+
+.. note::
+   This listener requires the reference index to be up to date. Run
+   ``bin/typo3 referenceindex:update`` if file operations are not detected.
+
 AfterPrepareConfigurationForEditorEvent
 ========================================
 
@@ -635,5 +700,5 @@ Related Documentation
 - :ref:`Controllers API <api-controllers>`
 - :ref:`Data Handling API <api-datahandling>`
 - :ref:`CKEditor Plugin Development <ckeditor-plugin-development>`
-- :ref:`Configuration Guide <integration-configuration>`
+- :ref:`Configuration Guide <integration>`
 - :ref:`Architecture Overview <architecture-overview>`

--- a/Documentation/Architecture/System-Architecture.rst
+++ b/Documentation/Architecture/System-Architecture.rst
@@ -94,14 +94,16 @@ Backend Layer
 1. Controllers (``Classes/Controller/``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **SelectImageController**: Handles image selection and processing
-- **ImageRenderingController**: Frontend image rendering
-- **ImageLinkRenderingController**: Renders images within links
+- **SelectImageController**: Backend image selection wizard for FAL integration
+- **ImageRenderingAdapter**: TypoScript adapter bridging ``preUserFunc`` to modern service architecture
 
-2. Event Listeners (``Classes/EventListener/``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2. Event Listeners (``Classes/EventListener/``, ``Classes/Listener/``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **RteConfigurationListener**: Customizes RTE configuration before initialization
+- **RteConfigurationListener**: Injects backend route configuration into CKEditor RTE
+- **RteSoftrefEnforcer**: Auto-adds ``rtehtmlarea_images`` softref to all RTE fields
+- **RtePreviewRendererRegistrar**: Auto-registers image-aware preview renderer for all CTypes
+- **UpdateImageReferences**: Syncs ``src`` attributes when FAL files are moved or renamed
 
 3. Database Hooks (``Classes/Database/``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.md
+++ b/README.md
@@ -32,11 +32,14 @@ Add issues or explore the project on [GitHub](https://github.com/netresearch/t3x
 - **Quality Selector**: Quality multipliers for optimal display (Standard 1.0x, Retina 2.0x, Ultra 3.0x, Print 6.0x)
 - **SVG Support**: Intelligent dimension extraction from viewBox and width/height attributes
 - **Custom Styles**: Configurable image styles with CKEditor 5 style system
-- **Inline Images**: True inline image support with cursor positioning before/after (new in 13.6)
+- **Inline Images**: True inline image support with cursor positioning before/after
 - **Lazy Loading**: TYPO3 native browser lazyload support
 - **Event-Driven**: PSR-14 events for extensibility
 - **Security**: Protocol blocking, XSS prevention, file visibility validation
 - **Fluid Templates**: Customizable output via template overrides
+- **Image Validation**: CLI command and upgrade wizard to detect and fix broken image references
+- **Preview Renderer**: Images preserved in page module preview with broken reference warnings
+- **Automatic Softref**: RTE image references tracked automatically across all tables
 
 ## Requirements
 
@@ -123,6 +126,16 @@ If you need to customize the RTE configuration or create your own preset:
 
 **fetchExternalImages**: By default, if an img source is an external URL, this image will be fetched and uploaded
 to the current BE users uploads folder. The default behaviour can be turned off with this option.
+
+**enableAutomaticRteSoftref**: Automatically adds `rtehtmlarea_images` soft reference to all RTE-enabled text fields. Ensures images are tracked in the reference index. Default: on.
+
+**enableAutomaticPreviewRenderer**: Registers an image-aware preview renderer for all record types with RTE bodytext. Shows images in page module preview and warns about broken references. Default: on.
+
+**excludedTables**: Comma-separated table names to exclude from automatic softref and preview renderer processing.
+
+**includedTablesOnly**: Whitelist mode — if set, only these tables are processed. Overrides excludedTables.
+
+See the [full configuration reference](https://docs.typo3.org/p/netresearch/rte-ckeditor-image/main/en-us/Integration/Advanced-Configuration.html) for details.
 
 ### Maximum width/height
 


### PR DESCRIPTION
## Summary
- **README.md**: Remove premature "(new in 13.6)", add 3 missing feature bullets, document all 5 extension configuration options with link to full docs
- **System-Architecture.rst**: Replace non-existent controllers with actual `SelectImageController`/`ImageRenderingAdapter`, expand event listeners from 1 to all 4
- **EventListeners.rst**: Add `RteSoftrefEnforcer` and `UpdateImageReferences` API reference sections, fix broken `:ref:` cross-reference

## Context
Follow-up to #647 and #650 — ensures Documentation/ and README.md accurately reflect the current codebase.

## Test plan
- [x] All 665 unit tests pass
- [ ] CI build passes
- [ ] RST renders correctly on docs.typo3.org