### PR TITLE
docs: address Copilot review comments from #651

### DIFF
--- a/Documentation/Architecture/System-Architecture.rst
+++ b/Documentation/Architecture/System-Architecture.rst
@@ -97,10 +97,9 @@ Backend Layer
 - **SelectImageController**: Backend image selection wizard for FAL integration
 - **ImageRenderingAdapter**: TypoScript adapter bridging ``preUserFunc`` to modern service architecture
 
-2. Event Listeners (``Classes/EventListener/``, ``Classes/Listener/``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+2. Event Listeners (``Classes/Listener/``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **RteConfigurationListener**: Injects backend route configuration into CKEditor RTE
 - **RteSoftrefEnforcer**: Auto-adds ``rtehtmlarea_images`` softref to all RTE fields
 - **RtePreviewRendererRegistrar**: Auto-registers image-aware preview renderer for all CTypes
 - **UpdateImageReferences**: Syncs ``src`` attributes when FAL files are moved or renamed


### PR DESCRIPTION
## Summary
- Remove non-existent `Classes/EventListener/` path and `RteConfigurationListener` from architecture overview (route configured via `Plugin.yaml`, not PHP listener)
- Fix `RteSoftrefEnforcer` description: scans all `type=text` columns with `enableRichtext`, not just `bodytext`

## Context
Addresses 3 Copilot review comments on #651 that were merged before review completed.

## Test plan
- [ ] CI passes
- [ ] Documentation renders correctly