### PR TITLE
fix(ci): remove merge_group trigger from CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,7 +5,6 @@ on:
         branches: [main]
     pull_request:
         branches: [main]
-    merge_group:
     schedule:
         - cron: '30 6 * * 1'
 


### PR DESCRIPTION
## Summary
- Remove `merge_group:` trigger from CodeQL workflow to fix race condition

## Context
CodeQL analysis takes longer than the merge queue lifecycle. By the time analysis finishes, the temporary merge queue branch (`gh-readonly-queue/main/pr-NNN-...`) is already deleted, causing:

```
ref 'refs/heads/gh-readonly-queue/main/pr-652-...' not found in this repository
```

These failure annotations bleed into the main branch commit (same SHA), making main CI appear broken.

CodeQL already runs on `pull_request` and `push` to main — the `merge_group` trigger is redundant. Removing it eliminates the race condition.

## Test plan
- [ ] CI passes
- [ ] CodeQL still runs on PRs and push-to-main
- [ ] No more "ref not found" annotations after merge queue completes