### PR TITLE
chore: add OpenSSF Baseline badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CodeQL](https://github.com/netresearch/t3x-rte_ckeditor_image/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/netresearch/t3x-rte_ckeditor_image/actions/workflows/codeql-analysis.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/netresearch/t3x-rte_ckeditor_image/badge)](https://securityscorecards.dev/viewer/?uri=github.com/netresearch/t3x-rte_ckeditor_image)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11718/badge)](https://www.bestpractices.dev/projects/11718)
+[![OpenSSF Baseline](https://www.bestpractices.dev/projects/11718/baseline)](https://www.bestpractices.dev/en/projects/11718#openssf_security_baseline)
 [![PHPStan](https://img.shields.io/badge/PHPStan-level%2010-brightgreen.svg)](https://phpstan.org/)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-3.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![codecov](https://codecov.io/gh/netresearch/t3x-rte_ckeditor_image/graph/badge.svg)](https://codecov.io/gh/netresearch/t3x-rte_ckeditor_image)


### PR DESCRIPTION
## Summary
- Add OpenSSF Baseline Level 2 badge alongside the existing Best Practices silver badge
- Badge URL: `https://www.bestpractices.dev/projects/11718/baseline`

Current badge status:
- **Best Practices**: Silver (passing 100%, silver 100%, gold 91%)
- **OSPS Baseline**: Level 2 (baseline-1 100%, baseline-2 100%, baseline-3 95%)