### PR TITLE
fix(ci): remove merge_group trigger from DCO workflow

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -3,7 +3,6 @@ name: DCO Check
 on:
   pull_request:
     branches: [main]
-  merge_group:
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
- Remove `merge_group:` trigger from DCO Check workflow

## Context
The DCO workflow uses `tim-actions/get-pr-commits` which reads `github.event.pull_request.number`. This property doesn't exist in `merge_group:` event context, causing:

```
Cannot read properties of undefined (reading 'number')
```

This failure annotation bleeds into the main branch commit (same SHA), making main CI show a red X for "Developer Certificate of Origin".

Same root cause as the CodeQL fix in #653 — `merge_group:` triggers are incompatible with PR-specific actions. DCO already runs on `pull_request:` which is sufficient.

## Test plan
- [ ] CI passes
- [ ] DCO check still runs on PRs
- [ ] No more DCO failure annotations on main after merge queue completes