### PR TITLE
fix: resolve inline image bugs with class, link, toggle, and indicators

### DIFF
--- a/Documentation/Integration/Frontend-Rendering.rst
+++ b/Documentation/Integration/Frontend-Rendering.rst
@@ -340,6 +340,38 @@ Encapsulation Configuration
         remapTag.img = p
     }
 
+Backend Preview Styling
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 13.5
+   The extension automatically registers an image-aware preview renderer for
+   all CTypes with RTE-enabled bodytext (e.g. ``text``, ``textmedia``,
+   ``textpic``). This ensures images are visible in the Page module preview.
+
+By default, preview images render at their original size. To limit image
+dimensions in the backend Page module, add a custom backend stylesheet:
+
+..  code-block:: css
+    :caption: EXT:your_sitepackage/Resources/Public/Css/backend.css
+
+    /* Limit RTE image preview size in Page module */
+    .t3-page-ce-body img {
+        max-width: 200px;
+        max-height: 150px;
+    }
+
+Register the stylesheet in your site package:
+
+..  code-block:: php
+    :caption: EXT:your_sitepackage/ext_localconf.php
+
+    $GLOBALS['TYPO3_CONF_VARS']['BE']['stylesheets']['your_sitepackage']
+        = 'EXT:your_sitepackage/Resources/Public/Css/backend.css';
+
+.. seealso::
+   `TYPO3 Changelog: Load additional stylesheets in backend
+   <https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Feature-100232-LoadAdditionalStylesheetsInTYPO3Backend.html>`__
+
 Related Documentation
 =====================
 

--- a/Resources/Public/Css/editor-image-widget.css
+++ b/Resources/Public/Css/editor-image-widget.css
@@ -35,6 +35,16 @@ figure.ck-widget.image .ck-image-indicators {
     pointer-events: none;
 }
 
+/* Suppress CKEditor's built-in link indicator (::after on figure > a)
+   since we provide our own .ck-image-indicator--link badges.
+   See: CKEditor linkimage.css adds ::after to figure.image > a
+   and a span.image-inline — without this override, both indicators show.
+   Scoped to .ck-widget selectors to avoid affecting non-editor content. */
+figure.ck-widget.image > a::after,
+span.ck-widget.ck-widget_inline-image > a::after {
+    display: none !important;
+}
+
 /* ========================================
    Shared Indicator Styles
    ======================================== */

--- a/Tests/Unit/JavaScript/Typo3ImagePluginTest.php
+++ b/Tests/Unit/JavaScript/Typo3ImagePluginTest.php
@@ -25,11 +25,30 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  *
  * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/546
+ * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/655
  */
 #[CoversNothing]
 final class Typo3ImagePluginTest extends UnitTestCase
 {
     private const TYPO3IMAGE_JS_PATH = __DIR__ . '/../../../Resources/Public/JavaScript/Plugins/typo3image.js';
+
+    private string $jsContent = '';
+
+    /**
+     * Lazily load JS content — only when tests actually need it.
+     * This allows typo3imageJsFileExists() to run first and provide
+     * a clear assertion message if the file is missing.
+     */
+    private function getJsContent(): string
+    {
+        if ($this->jsContent === '') {
+            $content = file_get_contents(self::TYPO3IMAGE_JS_PATH);
+            self::assertNotFalse($content, 'Could not read typo3image.js');
+            $this->jsContent = $content;
+        }
+
+        return $this->jsContent;
+    }
 
     #[Test]
     public function allowedAttributesIncludesCaption(): void
@@ -37,9 +56,7 @@ final class Typo3ImagePluginTest extends UnitTestCase
         // Regression test for https://github.com/netresearch/t3x-rte_ckeditor_image/issues/546
         // Caption must be in allowedAttributes to persist dialog-entered captions
 
-        $jsContent = file_get_contents(self::TYPO3IMAGE_JS_PATH);
-
-        self::assertNotFalse($jsContent, 'Could not read typo3image.js');
+        $jsContent = $this->getJsContent();
 
         // Find the allowedAttributes array definition
         // Pattern matches: allowedAttributes = [ ... ]
@@ -72,14 +89,10 @@ final class Typo3ImagePluginTest extends UnitTestCase
     #[Test]
     public function typo3imageJsContainsCaptionFieldDefinition(): void
     {
-        $jsContent = file_get_contents(self::TYPO3IMAGE_JS_PATH);
-
-        self::assertNotFalse($jsContent, 'Could not read typo3image.js');
-
         // Verify the caption field is defined in the dialog fields
         self::assertStringContainsString(
             "caption: { label: 'Caption'",
-            $jsContent,
+            $this->getJsContent(),
             'Caption field must be defined in the image dialog',
         );
     }
@@ -87,15 +100,119 @@ final class Typo3ImagePluginTest extends UnitTestCase
     #[Test]
     public function typo3imageJsContainsCaptionElementCreation(): void
     {
-        $jsContent = file_get_contents(self::TYPO3IMAGE_JS_PATH);
-
-        self::assertNotFalse($jsContent, 'Could not read typo3image.js');
-
         // Verify caption element creation code exists
         self::assertStringContainsString(
             "createElement('typo3imageCaption')",
-            $jsContent,
+            $this->getJsContent(),
             'Code to create typo3imageCaption element must exist',
+        );
+    }
+
+    // ========================================================================
+    // Issue #655 Regression Tests
+    // ========================================================================
+
+    /**
+     * Bug 1: New block images must get a default 'image-block' class.
+     *
+     * When inserting a new image, the dialog's "none" click behavior sets
+     * class = preservedAlignmentClasses.join(' '). For new images this is empty.
+     * The edit() function must ensure a default class is applied.
+     *
+     * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/655
+     */
+    #[Test]
+    public function newBlockImageGetsDefaultClass(): void
+    {
+        // The edit() function must ensure new block images get a default class.
+        // Find the edit() function's model.change block where newImageAttributes is built.
+        $editPos = strpos($this->getJsContent(), 'function edit(selectedImage, editor, imageAttributes)');
+        self::assertNotFalse($editPos, 'edit() function must exist');
+
+        // Get code from edit() up to the next top-level function
+        $nextFuncPos = strpos($this->getJsContent(), "\nfunction ", $editPos + 10);
+        self::assertIsInt($nextFuncPos, 'Next function after edit() must exist');
+        $editCode = substr($this->getJsContent(), $editPos, $nextFuncPos - $editPos);
+
+        // The edit function must detect new images and default the class to 'image-block'
+        self::assertStringContainsString(
+            'isNewImage',
+            $editCode,
+            'edit() must check isNewImage flag to conditionally default class (#655 bug 1)',
+        );
+        self::assertMatchesRegularExpression(
+            '/class.*(?:attributes\.class|\|\|).*image-block/',
+            $editCode,
+            'edit() must default class to image-block for new block images (#655 bug 1)',
+        );
+    }
+
+    /**
+     * Bug 2b: Inline image upcast must filter alignment classes from link class.
+     *
+     * When upcasting <a class="image-inline" href="..."><img class="image-inline"...></a>,
+     * the alignment class 'image-inline' on the <a> must NOT be stored as imageLinkClass.
+     * Only the block image upcast filtered these; the inline upcast did not.
+     *
+     * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/655
+     */
+    #[Test]
+    public function inlineImageUpcastFiltersAlignmentClassesFromLinkClass(): void
+    {
+        // The inline image upcast (for bare <img> with image-inline class) must
+        // filter alignment classes from the parent <a> class, just like block upcast does.
+
+        // Find the inline image upcast section (after "Upcast converter for inline images")
+        $inlineUpcastPos = strpos($this->getJsContent(), 'Upcast converter for inline images');
+        self::assertNotFalse($inlineUpcastPos, 'Inline image upcast section must exist');
+
+        // Get the code from inline upcast to the next upcast converter
+        $nextUpcastPos = strpos($this->getJsContent(), 'Upcast converter for standalone img', $inlineUpcastPos);
+        self::assertIsInt($nextUpcastPos, 'Next upcast converter after inline upcast must exist');
+        $inlineUpcastCode = substr($this->getJsContent(), $inlineUpcastPos, $nextUpcastPos - $inlineUpcastPos);
+
+        // The inline upcast must filter alignment classes from the link class
+        // before storing as imageLinkClass. Look for the actualLinkClass pattern
+        // that filters out alignment classes (same pattern used in block upcast).
+        self::assertStringContainsString(
+            'actualLinkClass',
+            $inlineUpcastCode,
+            'Inline image upcast must filter alignment classes via actualLinkClass (#655 bug 2b)',
+        );
+    }
+
+    /**
+     * Bug 3: ToggleImageTypeCommand must clean imageLinkClass of alignment classes.
+     *
+     * When toggling inline→block, the 'image-inline' class must be removed from
+     * imageLinkClass, not just from the image's own class attribute.
+     *
+     * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/655
+     */
+    #[Test]
+    public function toggleCommandCleansImageLinkClass(): void
+    {
+        // Find the ToggleImageTypeCommand execute() method
+        $togglePos = strpos($this->getJsContent(), 'class ToggleImageTypeCommand');
+        self::assertNotFalse($togglePos, 'ToggleImageTypeCommand class must exist');
+
+        // Get ToggleImageTypeCommand code (up to next class or function declaration)
+        $nextClassPos = strpos($this->getJsContent(), "\nclass ", $togglePos + 10);
+        $nextFuncPos  = strpos($this->getJsContent(), "\nfunction ", $togglePos + 10);
+        $endPos       = min(
+            $nextClassPos !== false ? $nextClassPos : PHP_INT_MAX,
+            $nextFuncPos !== false ? $nextFuncPos : PHP_INT_MAX,
+        );
+        $toggleCode = substr($this->getJsContent(), $togglePos, $endPos - $togglePos);
+
+        // Must actively filter/clean imageLinkClass during toggle, not just copy it.
+        // The execute() method must contain code that reads imageLinkClass and
+        // removes alignment classes from it (like image-inline, image-block).
+        // Look for getAttribute('imageLinkClass') followed by filtering logic.
+        self::assertMatchesRegularExpression(
+            "/getAttribute\('imageLinkClass'\).*(?:filter|replace|split)/s",
+            $toggleCode,
+            'ToggleImageTypeCommand must filter alignment classes from imageLinkClass (#655 bug 3)',
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes 5 bugs reported in #655 involving inline image handling in CKEditor:

- **Bug 1 — Empty class on new images**: `edit()` now defaults to `image-block` (or `image-inline`) when the dialog returns an empty class string for newly inserted images
- **Bug 2a — Double `<a>` tags**: Inline image upcast now consumes the parent `<a>` element to prevent CKEditor's link plugin from double-processing it
- **Bug 2b — Alignment class leaks to `imageLinkClass`**: Inline upcast filters `image-inline`, `image-block`, etc. from link class before storing as `imageLinkClass` (same pattern already used in block upcast)
- **Bug 3 — `image-inline` persists on `<a>` after toggle**: `ToggleImageTypeCommand` now strips alignment classes from `imageLinkClass` when switching between inline/block
- **Bug 4 — Double link indicators**: Suppresses CKEditor's built-in `::after` link icon on `figure.image > a` since we provide custom `.ck-image-indicator--link` badges

Bug 2c (t3:// link not resolved on FE) is a downstream consequence of bug 2a — the double `<a>` tags cause the outer link to bypass TYPO3's link resolution. Fixed by fixing 2a.

Bug 5 (preview image docs) is an enhancement request tracked separately.

## Test plan

- [x] 3 new PHP regression tests (TDD red→green) verify JS source patterns
- [x] All 668 unit tests pass (665 baseline + 3 new)
- [x] PHPStan clean, CS fixer clean
- [ ] E2E tests pass in CI
- [ ] Manual: insert new image → verify `image-block` class applied
- [ ] Manual: insert inline image with link → verify single `<a>`, no double wrapping
- [ ] Manual: toggle inline→block on linked image → verify `image-inline` removed from `<a>`
- [ ] Manual: linked block image → verify single link indicator badge (no duplicate)

Closes #655