### PR TITLE
fix: auto-detect merge strategy for signed commit compatibility

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -9,9 +9,9 @@ permissions:
 
 jobs:
   auto-merge:
+    name: Auto-merge dependency PRs
     runs-on: ubuntu-latest
-    # Only run for bot accounts
-    if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
 
     permissions:
       contents: write
@@ -33,4 +33,14 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge --auto --rebase "$PR_URL"
+        run: |
+          # Detect allowed merge strategy
+          # Prefer squash (works with signed commit requirements, clean for single-commit PRs)
+          # then merge (also works with signed commits), then rebase (cannot be auto-signed)
+          STRATEGY=$(gh api "repos/${{ github.repository }}" --jq '
+            if .allow_squash_merge then "--squash"
+            elif .allow_merge_commit then "--merge"
+            elif .allow_rebase_merge then "--rebase"
+            else "--squash" end')
+          echo "Using merge strategy: $STRATEGY"
+          gh pr merge --auto $STRATEGY "$PR_URL"


### PR DESCRIPTION
## Summary
- Auto-detect allowed merge strategy (squash > merge > rebase) instead of hardcoding `--rebase`
- Fix bot detection: use `github.event.pull_request.user.login` instead of `github.actor` (which changes on synchronize events)

**Root cause:** GitHub cannot auto-sign rebased commits. Repos with branch protection requiring signed commits block `--rebase` merges with: `Base branch requires signed commits. Rebase merges cannot be automatically signed by GitHub`. Both `--squash` and `--merge` work because GitHub can sign those merge types.

Already applied to 10 other netresearch repos via API.

## Test plan
- [ ] Workflow triggers on next Renovate/Dependabot PR
- [ ] Merge strategy auto-detected correctly (should pick `--squash` for this repo)
- [ ] PR gets approved and auto-merged