### PR TITLE
chore: replace generic emails with GitHub references

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -43,7 +43,7 @@ We agree to restrict the following behaviors in our community. Instances, threat
 
 Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
 
-When an incident does occur, it is important to report it promptly. To report a possible violation, contact the project team at **typo3@netresearch.de**.
+When an incident does occur, it is important to report it promptly. To report a possible violation, contact the project team via [GitHub Issues](https://github.com/netresearch/t3x-rte_ckeditor_image/issues).
 
 Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
 

--- a/Tests/Functional/Controller/FigureCaptionRenderingTest.php
+++ b/Tests/Functional/Controller/FigureCaptionRenderingTest.php
@@ -25,7 +25,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * Tests to reproduce and verify fix for issue #546:
  * - Double figure/figcaption wrapping in frontend output
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  *
  * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/546

--- a/Tests/Functional/Controller/ImageRenderingAdapterTypoScriptTest.php
+++ b/Tests/Functional/Controller/ImageRenderingAdapterTypoScriptTest.php
@@ -26,7 +26,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * Tests the actual TypoScript preUserFunc path to ensure the adapter
  * is callable via TypoScript (requires #[AsAllowedCallable] in TYPO3 v14+).
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  *
  * @see https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Breaking-108054-EnforceExplicitOpt-inForTypoScriptTSconfigCallables.html

--- a/Tests/Functional/Controller/ImageTagRenderingTest.php
+++ b/Tests/Functional/Controller/ImageTagRenderingTest.php
@@ -26,7 +26,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * processing for captioned images to preserve data-htmlarea-file-uid for
  * the subsequent tags.figure handler (renderFigure).
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  *
  * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/546

--- a/Tests/Functional/Controller/RteMixedContentRenderingTest.php
+++ b/Tests/Functional/Controller/RteMixedContentRenderingTest.php
@@ -39,7 +39,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * - Figures WITHOUT caption → output as just <img> (Standalone template)
  * - This is semantically correct: <figure> should only be used with <figcaption>
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  *
  * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/580

--- a/Tests/Functional/Service/ImageRenderingIntegrationTest.php
+++ b/Tests/Functional/Service/ImageRenderingIntegrationTest.php
@@ -24,7 +24,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  *
  * Tests the complete pipeline: Parser → Resolver → Renderer
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  */
 final class ImageRenderingIntegrationTest extends FunctionalTestCase

--- a/Tests/Functional/Service/PartialPathResolutionTest.php
+++ b/Tests/Functional/Service/PartialPathResolutionTest.php
@@ -29,7 +29,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  *
  * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/547
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  */
 final class PartialPathResolutionTest extends FunctionalTestCase

--- a/Tests/Functional/TypoScript/ParseFuncIntegrationTest.php
+++ b/Tests/Functional/TypoScript/ParseFuncIntegrationTest.php
@@ -29,7 +29,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * This simulates what would happen if parseFunc_RTE processed content
  * that already went through the image rendering pipeline.
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  *
  * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/546

--- a/Tests/Unit/Backend/Preview/RteImagePreviewRendererTest.php
+++ b/Tests/Unit/Backend/Preview/RteImagePreviewRendererTest.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Backend\View\BackendLayout\Grid\GridColumnItem;
 /**
  * Test case for RteImagePreviewRenderer.
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  */
 #[AllowMockObjectsWithoutExpectations]

--- a/Tests/Unit/Controller/ImageRenderingAdapterTest.php
+++ b/Tests/Unit/Controller/ImageRenderingAdapterTest.php
@@ -28,7 +28,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 /**
  * Unit tests for ImageRenderingAdapter.
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  */
 #[AllowMockObjectsWithoutExpectations]

--- a/Tests/Unit/Domain/Model/ImageRenderingDtoTest.php
+++ b/Tests/Unit/Domain/Model/ImageRenderingDtoTest.php
@@ -19,7 +19,7 @@ use ReflectionClass;
 /**
  * Test case for ImageRenderingDto.
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  */
 class ImageRenderingDtoTest extends TestCase

--- a/Tests/Unit/Domain/Model/LinkDtoTest.php
+++ b/Tests/Unit/Domain/Model/LinkDtoTest.php
@@ -18,7 +18,7 @@ use ReflectionClass;
 /**
  * Test case for LinkDto.
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  */
 class LinkDtoTest extends TestCase

--- a/Tests/Unit/JavaScript/Typo3ImagePluginTest.php
+++ b/Tests/Unit/JavaScript/Typo3ImagePluginTest.php
@@ -21,7 +21,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * These tests validate critical JavaScript configurations by parsing
  * the source files. This ensures important fixes aren't accidentally reverted.
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  *
  * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/546

--- a/Tests/Unit/Service/ImageAttributeParserTest.php
+++ b/Tests/Unit/Service/ImageAttributeParserTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Test case for ImageAttributeParser.
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  */
 class ImageAttributeParserTest extends TestCase

--- a/Tests/Unit/Service/ImageRenderingServiceTest.php
+++ b/Tests/Unit/Service/ImageRenderingServiceTest.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\Core\View\ViewInterface;
 /**
  * Test case for ImageRenderingService.
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  */
 #[AllowMockObjectsWithoutExpectations]

--- a/Tests/Unit/Service/ImageResolverServiceTest.php
+++ b/Tests/Unit/Service/ImageResolverServiceTest.php
@@ -28,7 +28,7 @@ use TYPO3\CMS\Core\Resource\Security\SvgSanitizer;
 /**
  * Test case for ImageResolverService.
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  */
 #[AllowMockObjectsWithoutExpectations]

--- a/Tests/Unit/Service/Processor/RteImageProcessorFactoryTest.php
+++ b/Tests/Unit/Service/Processor/RteImageProcessorFactoryTest.php
@@ -34,7 +34,7 @@ use TYPO3\CMS\Core\Resource\DefaultUploadFolderResolver;
 /**
  * Test case for RteImageProcessorFactory.
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  */
 #[AllowMockObjectsWithoutExpectations]

--- a/Tests/Unit/Service/Processor/RteImageProcessorTest.php
+++ b/Tests/Unit/Service/Processor/RteImageProcessorTest.php
@@ -36,7 +36,7 @@ use TYPO3\CMS\Core\Resource\ProcessedFile;
 /**
  * Test case for RteImageProcessor.
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  */
 #[AllowMockObjectsWithoutExpectations]

--- a/Tests/Unit/Service/Resolver/ImageFileResolverTest.php
+++ b/Tests/Unit/Service/Resolver/ImageFileResolverTest.php
@@ -31,7 +31,7 @@ use TYPO3\CMS\Core\Resource\ResourceFactory;
 /**
  * Test case for ImageFileResolver.
  *
- * @author  Netresearch DTT GmbH <info@netresearch.de>
+ * @author  Netresearch DTT GmbH
  * @license https://www.gnu.org/licenses/agpl-3.0.de.html
  */
 #[AllowMockObjectsWithoutExpectations]


### PR DESCRIPTION
## Summary

- Replace generic `@netresearch.de` email addresses with GitHub-native references
- Add `support` section to package metadata with Issues/Source URLs
- Use GitHub Security Advisories for vulnerability reporting
- Use GitHub Issues for general support/contact

## Motivation

Generic email addresses in public repositories attract spam and create maintenance overhead. GitHub provides better mechanisms for each use case:
- **Security**: Private vulnerability reporting via Security Advisories
- **Support**: Issue tracker with templates and labels
- **Contact**: Discussions for general questions

## Test plan

- [ ] Verify package metadata is valid (composer validate)
- [ ] Verify links in documentation point to correct URLs
- [ ] Verify no functional email addresses were removed (only metadata/docs)
