### PR TITLE
fix: suppress PHPUnit 12 mock-without-expectations notices

### DIFF
--- a/Tests/Unit/Command/ValidateImageReferencesCommandTest.php
+++ b/Tests/Unit/Command/ValidateImageReferencesCommandTest.php
@@ -16,6 +16,7 @@ use Netresearch\RteCKEditorImage\Dto\ValidationIssue;
 use Netresearch\RteCKEditorImage\Dto\ValidationIssueType;
 use Netresearch\RteCKEditorImage\Dto\ValidationResult;
 use Netresearch\RteCKEditorImage\Service\RteImageReferenceValidator;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -28,6 +29,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * Tests the command output and exit codes with a mocked validator.
  */
+#[AllowMockObjectsWithoutExpectations]
 #[CoversClass(ValidateImageReferencesCommand::class)]
 final class ValidateImageReferencesCommandTest extends TestCase
 {

--- a/Tests/Unit/Listener/FileOperation/UpdateImageReferencesTest.php
+++ b/Tests/Unit/Listener/FileOperation/UpdateImageReferencesTest.php
@@ -13,6 +13,7 @@ namespace Netresearch\RteCKEditorImage\Tests\Unit\Listener\FileOperation;
 
 use Doctrine\DBAL\Result;
 use Netresearch\RteCKEditorImage\Listener\FileOperation\UpdateImageReferences;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -34,6 +35,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 /**
  * Unit tests for UpdateImageReferences event listener.
  */
+#[AllowMockObjectsWithoutExpectations]
 #[CoversClass(UpdateImageReferences::class)]
 final class UpdateImageReferencesTest extends UnitTestCase
 {

--- a/Tests/Unit/Service/RteImageReferenceValidatorTest.php
+++ b/Tests/Unit/Service/RteImageReferenceValidatorTest.php
@@ -15,6 +15,7 @@ use Netresearch\RteCKEditorImage\Dto\ValidationIssue;
 use Netresearch\RteCKEditorImage\Dto\ValidationIssueType;
 use Netresearch\RteCKEditorImage\Dto\ValidationResult;
 use Netresearch\RteCKEditorImage\Service\RteImageReferenceValidator;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -31,6 +32,7 @@ use TYPO3\CMS\Core\Resource\ResourceFactory;
  * Tests the HTML parsing and issue detection logic in isolation.
  * Database-dependent tests are in the functional test suite.
  */
+#[AllowMockObjectsWithoutExpectations]
 #[CoversClass(RteImageReferenceValidator::class)]
 class RteImageReferenceValidatorTest extends TestCase
 {

--- a/Tests/Unit/Updates/ValidateRteImageReferencesWizardTest.php
+++ b/Tests/Unit/Updates/ValidateRteImageReferencesWizardTest.php
@@ -16,6 +16,7 @@ use Netresearch\RteCKEditorImage\Dto\ValidationIssueType;
 use Netresearch\RteCKEditorImage\Dto\ValidationResult;
 use Netresearch\RteCKEditorImage\Service\RteImageReferenceValidator;
 use Netresearch\RteCKEditorImage\Updates\ValidateRteImageReferencesWizard;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -25,6 +26,7 @@ use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
 /**
  * Unit tests for ValidateRteImageReferencesWizard.
  */
+#[AllowMockObjectsWithoutExpectations]
 #[CoversClass(ValidateRteImageReferencesWizard::class)]
 final class ValidateRteImageReferencesWizardTest extends TestCase
 {


### PR DESCRIPTION
## Summary

- Add `#[AllowMockObjectsWithoutExpectations]` attribute to 4 test classes that were missing it
- Consistent with all other test classes in the project that already use this attribute
- Eliminates 3 PHPUnit 12 notices from mock objects created in `setUp()` without expectations

## Affected files

- `Tests/Unit/Command/ValidateImageReferencesCommandTest.php`
- `Tests/Unit/Listener/FileOperation/UpdateImageReferencesTest.php`
- `Tests/Unit/Service/RteImageReferenceValidatorTest.php`
- `Tests/Unit/Updates/ValidateRteImageReferencesWizardTest.php`

## Test plan

- [x] All 707 unit tests pass with 0 notices
- [ ] CI passes (all checks green)