### PR TITLE
fix: pin Content Blocks version constraints in DDEV install scripts

### DIFF
--- a/.ddev/commands/web/install-v13
+++ b/.ddev/commands/web/install-v13
@@ -20,7 +20,7 @@ composer config --no-plugins allow-plugins.typo3/class-alias-loader true -d /var
 composer req t3/cms:'^13' $PACKAGE_NAME:'*@dev' --no-progress -n -d /var/www/html/$VERSION
 composer req typo3/cms-extensionmanager typo3/cms-dashboard typo3/cms-reports --no-progress -n -d /var/www/html/$VERSION
 composer req --dev typo3/cms-styleguide bk2k/bootstrap-package:'^15.0' --no-progress -n -d /var/www/html/$VERSION
-composer req friendsoftypo3/content-blocks --no-progress -n -d /var/www/html/$VERSION
+composer req friendsoftypo3/content-blocks:'^1.3' --no-progress -n -W -d /var/www/html/$VERSION
 
 cd /var/www/html/$VERSION
 

--- a/.ddev/commands/web/install-v14
+++ b/.ddev/commands/web/install-v14
@@ -22,7 +22,7 @@ composer config --no-plugins allow-plugins.typo3/class-alias-loader true -d /var
 composer req $PACKAGE_NAME:'*@dev' --no-progress -n -d /var/www/html/$VERSION
 composer req typo3/cms-extensionmanager typo3/cms-dashboard typo3/cms-reports --no-progress -n -d /var/www/html/$VERSION
 composer req --dev typo3/cms-styleguide bk2k/bootstrap-package:'^16.0' --no-progress -n -d /var/www/html/$VERSION
-composer req friendsoftypo3/content-blocks --no-progress -n -d /var/www/html/$VERSION
+composer req friendsoftypo3/content-blocks:'^2.0' --no-progress -n -W -d /var/www/html/$VERSION
 
 cd /var/www/html/$VERSION
 


### PR DESCRIPTION
## Summary

- Pins `friendsoftypo3/content-blocks` to `^1.3` (v13) and `^2.0` (v14) in DDEV install scripts
- Adds `-W` flag to allow dependency resolution (symfony/var-exporter conflict)

## Problem

Without explicit version constraints, `composer req friendsoftypo3/content-blocks` installs v0.2.1 (2023) which is incompatible with both TYPO3 v13 and v14, causing `TcaPreparation class not found` errors.

## Changes

| File | Change |
|------|--------|
| `.ddev/commands/web/install-v13` | `^1.3` constraint + `-W` flag |
| `.ddev/commands/web/install-v14` | `^2.0` constraint + `-W` flag |

## Test plan

- [x] `ddev install-v13` installs Content Blocks v1.3.19 successfully
- [x] Content Blocks Demo page renders correctly in TYPO3 v13 backend
- [x] Unit tests: 741 pass