### PR TITLE
chore: add SPDX copyright and license headers

### DIFF
--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * Dist config for PHP-CS-Fixer (repo-wide).
  * Copy to .php-cs-fixer.php locally if you want to override anything.
@@ -10,10 +15,8 @@ if (PHP_SAPI !== 'cli') {
 }
 
 $header = <<<EOF
-This file is part of the package netresearch/rte-ckeditor-image.
-
-For the full copyright and license information, please read the
-LICENSE file that was distributed with this source code.
+Copyright (c) 2025-2026 Netresearch DTT GmbH
+SPDX-License-Identifier: AGPL-3.0-or-later
 EOF;
 
 $repoRoot = __DIR__ . '/..';

--- a/Build/phpstan-stubs/phpunit-attributes.php
+++ b/Build/phpstan-stubs/phpunit-attributes.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Build/phpunit/FunctionalTestsBootstrap.php
+++ b/Build/phpunit/FunctionalTestsBootstrap.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Build/phpunit/UnitTestsBootstrap.php
+++ b/Build/phpunit/UnitTestsBootstrap.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Backend/Preview/RteImagePreviewRenderer.php
+++ b/Classes/Backend/Preview/RteImagePreviewRenderer.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Command/ValidateImageReferencesCommand.php
+++ b/Classes/Command/ValidateImageReferencesCommand.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Controller/ImageRenderingAdapter.php
+++ b/Classes/Controller/ImageRenderingAdapter.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Controller/SelectImageController.php
+++ b/Classes/Controller/SelectImageController.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/DataHandling/SoftReference/RteImageSoftReferenceParser.php
+++ b/Classes/DataHandling/SoftReference/RteImageSoftReferenceParser.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Domain/Model/ImageRenderingDto.php
+++ b/Classes/Domain/Model/ImageRenderingDto.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Domain/Model/LinkDto.php
+++ b/Classes/Domain/Model/LinkDto.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Dto/ValidationIssue.php
+++ b/Classes/Dto/ValidationIssue.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Dto/ValidationIssueType.php
+++ b/Classes/Dto/ValidationIssueType.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Dto/ValidationResult.php
+++ b/Classes/Dto/ValidationResult.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Listener/FileOperation/UpdateImageReferences.php
+++ b/Classes/Listener/FileOperation/UpdateImageReferences.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Listener/TCA/RtePreviewRendererRegistrar.php
+++ b/Classes/Listener/TCA/RtePreviewRendererRegistrar.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Listener/TCA/RteSoftrefEnforcer.php
+++ b/Classes/Listener/TCA/RteSoftrefEnforcer.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/Builder/ImageTagBuilder.php
+++ b/Classes/Service/Builder/ImageTagBuilder.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/Builder/ImageTagBuilderInterface.php
+++ b/Classes/Service/Builder/ImageTagBuilderInterface.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/Environment/EnvironmentInfoInterface.php
+++ b/Classes/Service/Environment/EnvironmentInfoInterface.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/Environment/Typo3EnvironmentInfo.php
+++ b/Classes/Service/Environment/Typo3EnvironmentInfo.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/Fetcher/ExternalImageFetcher.php
+++ b/Classes/Service/Fetcher/ExternalImageFetcher.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/Fetcher/ExternalImageFetcherInterface.php
+++ b/Classes/Service/Fetcher/ExternalImageFetcherInterface.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/ImageAttributeParser.php
+++ b/Classes/Service/ImageAttributeParser.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/ImageRenderingService.php
+++ b/Classes/Service/ImageRenderingService.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/ImageResolverService.php
+++ b/Classes/Service/ImageResolverService.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/Parser/ImageTagParser.php
+++ b/Classes/Service/Parser/ImageTagParser.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/Parser/ImageTagParserInterface.php
+++ b/Classes/Service/Parser/ImageTagParserInterface.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/Processor/RteImageProcessor.php
+++ b/Classes/Service/Processor/RteImageProcessor.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/Processor/RteImageProcessorFactory.php
+++ b/Classes/Service/Processor/RteImageProcessorFactory.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/Processor/RteImageProcessorInterface.php
+++ b/Classes/Service/Processor/RteImageProcessorInterface.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/Resolver/ImageFileResolver.php
+++ b/Classes/Service/Resolver/ImageFileResolver.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/Resolver/ImageFileResolverInterface.php
+++ b/Classes/Service/Resolver/ImageFileResolverInterface.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/RteImageReferenceValidator.php
+++ b/Classes/Service/RteImageReferenceValidator.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/Security/SecurityValidator.php
+++ b/Classes/Service/Security/SecurityValidator.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Service/Security/SecurityValidatorInterface.php
+++ b/Classes/Service/Security/SecurityValidatorInterface.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Updates/ValidateRteImageReferencesWizard.php
+++ b/Classes/Updates/ValidateRteImageReferencesWizard.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/Utils/ProcessedFilesHandler.php
+++ b/Classes/Utils/ProcessedFilesHandler.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Classes/ViewHelpers/RteImagePreviewViewHelper.php
+++ b/Classes/ViewHelpers/RteImagePreviewViewHelper.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Configuration/Backend/Routes.php
+++ b/Configuration/Backend/Routes.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Architecture/ArchitectureTest.php
+++ b/Tests/Architecture/ArchitectureTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Functional/Command/ValidateImageReferencesCommandTest.php
+++ b/Tests/Functional/Command/ValidateImageReferencesCommandTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Functional/Controller/FigureCaptionRenderingTest.php
+++ b/Tests/Functional/Controller/FigureCaptionRenderingTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Functional/Controller/ImageRenderingAdapterTypoScriptTest.php
+++ b/Tests/Functional/Controller/ImageRenderingAdapterTypoScriptTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Functional/Controller/ImageTagRenderingTest.php
+++ b/Tests/Functional/Controller/ImageTagRenderingTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Functional/Controller/RteMixedContentRenderingTest.php
+++ b/Tests/Functional/Controller/RteMixedContentRenderingTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Functional/Controller/SelectImageControllerTest.php
+++ b/Tests/Functional/Controller/SelectImageControllerTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Functional/DataHandling/RteImageSoftReferenceParserTest.php
+++ b/Tests/Functional/DataHandling/RteImageSoftReferenceParserTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Functional/Database/RteImagesDbHookTest.php
+++ b/Tests/Functional/Database/RteImagesDbHookTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Functional/Listener/FileOperation/UpdateImageReferencesTest.php
+++ b/Tests/Functional/Listener/FileOperation/UpdateImageReferencesTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Functional/Service/ImageRenderingIntegrationTest.php
+++ b/Tests/Functional/Service/ImageRenderingIntegrationTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Functional/Service/PartialPathResolutionTest.php
+++ b/Tests/Functional/Service/PartialPathResolutionTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Functional/Service/RteImageReferenceValidatorTest.php
+++ b/Tests/Functional/Service/RteImageReferenceValidatorTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Functional/TypoScript/ParseFuncIntegrationTest.php
+++ b/Tests/Functional/TypoScript/ParseFuncIntegrationTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Fuzz/ImageAttributeParserTarget.php
+++ b/Tests/Fuzz/ImageAttributeParserTarget.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Fuzz/RteImageSoftReferenceParserTarget.php
+++ b/Tests/Fuzz/RteImageSoftReferenceParserTarget.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Attribute/AllowMockObjectsWithoutExpectations.php
+++ b/Tests/Unit/Attribute/AllowMockObjectsWithoutExpectations.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Backend/Preview/RteImagePreviewRendererTest.php
+++ b/Tests/Unit/Backend/Preview/RteImagePreviewRendererTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Command/ValidateImageReferencesCommandTest.php
+++ b/Tests/Unit/Command/ValidateImageReferencesCommandTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Controller/ImageRenderingAdapterTest.php
+++ b/Tests/Unit/Controller/ImageRenderingAdapterTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Controller/SelectImageControllerTest.php
+++ b/Tests/Unit/Controller/SelectImageControllerTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/DataHandling/SoftReference/RteImageSoftReferenceParserTest.php
+++ b/Tests/Unit/DataHandling/SoftReference/RteImageSoftReferenceParserTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Database/RteImagesDbHookTest.php
+++ b/Tests/Unit/Database/RteImagesDbHookTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Domain/Model/ImageRenderingDtoTest.php
+++ b/Tests/Unit/Domain/Model/ImageRenderingDtoTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Domain/Model/LinkDtoTest.php
+++ b/Tests/Unit/Domain/Model/LinkDtoTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Dto/ValidationIssueTypeTest.php
+++ b/Tests/Unit/Dto/ValidationIssueTypeTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/JavaScript/Typo3ImagePluginTest.php
+++ b/Tests/Unit/JavaScript/Typo3ImagePluginTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Listener/FileOperation/UpdateImageReferencesTest.php
+++ b/Tests/Unit/Listener/FileOperation/UpdateImageReferencesTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Listener/TCA/RtePreviewRendererRegistrarTest.php
+++ b/Tests/Unit/Listener/TCA/RtePreviewRendererRegistrarTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Listener/TCA/RteSoftrefEnforcerTest.php
+++ b/Tests/Unit/Listener/TCA/RteSoftrefEnforcerTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Service/Builder/ImageTagBuilderTest.php
+++ b/Tests/Unit/Service/Builder/ImageTagBuilderTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Service/Environment/Typo3EnvironmentInfoTest.php
+++ b/Tests/Unit/Service/Environment/Typo3EnvironmentInfoTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Service/Fetcher/ExternalImageFetcherTest.php
+++ b/Tests/Unit/Service/Fetcher/ExternalImageFetcherTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Service/ImageAttributeParserTest.php
+++ b/Tests/Unit/Service/ImageAttributeParserTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Service/ImageRenderingServiceTest.php
+++ b/Tests/Unit/Service/ImageRenderingServiceTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Service/ImageResolverServiceTest.php
+++ b/Tests/Unit/Service/ImageResolverServiceTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Service/Parser/ImageTagParserTest.php
+++ b/Tests/Unit/Service/Parser/ImageTagParserTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Service/Processor/RteImageProcessorFactoryTest.php
+++ b/Tests/Unit/Service/Processor/RteImageProcessorFactoryTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Service/Processor/RteImageProcessorTest.php
+++ b/Tests/Unit/Service/Processor/RteImageProcessorTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Service/Resolver/ImageFileResolverTest.php
+++ b/Tests/Unit/Service/Resolver/ImageFileResolverTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Service/RteImageReferenceValidatorTest.php
+++ b/Tests/Unit/Service/RteImageReferenceValidatorTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Service/Security/SecurityValidatorTest.php
+++ b/Tests/Unit/Service/Security/SecurityValidatorTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Updates/ValidateRteImageReferencesWizardTest.php
+++ b/Tests/Unit/Updates/ValidateRteImageReferencesWizardTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/Utils/ProcessedFilesHandlerTest.php
+++ b/Tests/Unit/Utils/ProcessedFilesHandlerTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/Tests/Unit/ViewHelpers/RteImagePreviewViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/RteImagePreviewViewHelperTest.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 /**
  * Extension Manager configuration for rte_ckeditor_image.
  *

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,10 +1,8 @@
 <?php
 
 /*
- * This file is part of the package netresearch/rte-ckeditor-image.
- *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
## Summary
- Add SPDX copyright and license headers (`Copyright Netresearch DTT GmbH`, `AGPL-3.0-or-later`) to all 93 PHP source files
- Update PHP-CS-Fixer `header_comment` rule to enforce the new SPDX format
- Supports OpenSSF Best Practices Gold badge criteria

## Test plan
- [ ] CI passes (PHP lint, PHP-CS-Fixer, PHPStan, unit tests)
- [ ] No functional changes — headers only