### PR TITLE
ci: update TER publish workflow to ubuntu-latest

### DIFF
--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     name: Publish new version to TER
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
       TYPO3_API_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

- Fix TER publish workflow stuck in queue: `ubuntu-20.04` runners were removed from GitHub Actions
- Update to `ubuntu-latest` so the v12.0.6 release can be published to TER

## Test plan

- [ ] Merge this PR
- [ ] Re-run the TER publish workflow for v12.0.6