### PR TITLE
ci: sync TER publish workflow from main branch

### DIFF
--- a/.github/workflows/publish-to-ter.yml
+++ b/.github/workflows/publish-to-ter.yml
@@ -1,51 +1,139 @@
 name: Publish new extension version to TER
 
 on:
-  release:
-    types: [published]
+    release:
+        types: [published]
+    workflow_dispatch:
+        inputs:
+            version:
+                description: 'Version to publish (e.g., 13.1.0)'
+                required: true
+                type: string
+
+permissions:
+    contents: read
 
 jobs:
-  publish:
-    name: Publish new version to TER
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    env:
-      TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
-      TYPO3_API_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+    publish:
+        name: Publish new version to TER
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+        runs-on: ubuntu-latest
 
-      - name: Check tag
-        run: |
-          if ! [[ ${{ github.ref }} =~ ^refs/tags/v[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
-            exit 1
-          fi
+        permissions:
+            contents: read
 
-      - name: Get version
-        id: get-version
-        run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+        env:
+            TYPO3_EXTENSION_KEY: rte_ckeditor_image
+            TYPO3_API_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
 
-      - name: Get comment
-        id: get-comment
-        run: |
-          readonly local comment=$(git tag -n10 -l v${{ env.version }} | sed "s/^v[0-9.]*[ ]*//g")
+        steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
+              with:
+                  egress-policy: audit
 
-          if [[ -z "${comment// }" ]]; then
-            echo "comment=Released version ${{ env.version }} of ${{ env.TYPO3_EXTENSION_KEY }} -- for details see $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases" >> $GITHUB_ENV
-          else
-            echo "comment=$comment -- for details see $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases" >> $GITHUB_ENV
-          fi
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 7.4
-          extensions: intl, mbstring, json, zip, curl
-          tools: composer:v2
+            - name: Validate and extract version
+              id: get-version
+              env:
+                  INPUT_VERSION: ${{ inputs.version }}
+              run: |
+                  if [[ -n "${INPUT_VERSION}" ]]; then
+                      # Manual dispatch - validate and normalize input version
+                      if ! [[ "${INPUT_VERSION}" =~ ^v?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+                          echo "Invalid input version format: ${INPUT_VERSION}"
+                          echo "Expected format: 13.1.0 or v13.1.0"
+                          exit 1
+                      fi
+                      # Strip optional leading 'v' for internal use
+                      normalized_version="${INPUT_VERSION#v}"
+                      echo "version=${normalized_version}" >> $GITHUB_ENV
+                  else
+                      # Release event - extract from tag
+                      if ! [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+                          echo "Invalid tag format: ${GITHUB_REF}"
+                          exit 1
+                      fi
+                      echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+                  fi
 
-      - name: Install tailor
-        run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
+            - name: Checkout tag
+              if: inputs.version != ''
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  ref: v${{ env.version }}
+                  fetch-tags: true
 
-      - name: Publish to TER
-        run: php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ env.comment }}" ${{ env.version }}
+            - name: Validate ext_emconf.php version
+              env:
+                  TAG_VERSION: ${{ env.version }}
+              run: |
+                  EMCONF_VERSION=$(sed -nE "s/.*'version'[[:space:]]*=>[[:space:]]*'([^']+)'.*/\1/p" ext_emconf.php)
+                  if [[ -z "${EMCONF_VERSION}" ]]; then
+                    echo "::error file=ext_emconf.php::Could not extract version from ext_emconf.php"
+                    exit 1
+                  fi
+                  if [[ "${TAG_VERSION}" != "${EMCONF_VERSION}" ]]; then
+                    echo "::error file=ext_emconf.php::Tag version (${TAG_VERSION}) does not match ext_emconf.php version (${EMCONF_VERSION}). Update ext_emconf.php before tagging."
+                    exit 1
+                  fi
+                  echo "Version validated: ${TAG_VERSION} matches ext_emconf.php"
+
+            - name: Prepare release comment
+              id: get-comment
+              env:
+                  TAG_VERSION: ${{ env.version }}
+                  EXT_KEY: ${{ env.TYPO3_EXTENSION_KEY }}
+                  RELEASE_BODY: ${{ github.event.release.body }}
+                  RELEASE_NAME: ${{ github.event.release.name }}
+                  RELEASE_URL: ${{ github.event.release.html_url }}
+              run: |
+                  # Use release body (GitHub release notes) as primary source
+                  # TER only supports plain text - no markdown, no special characters
+                  if [[ -n "${RELEASE_BODY}" ]]; then
+                      # Strip markdown formatting and limit length
+                      # TER supports newlines (rendered as <br> on frontend)
+                      COMMENT=$(echo "${RELEASE_BODY}" | head -c 1000)
+                      # Strip characters not supported in TER XML export
+                      # Allowed: word chars, whitespace, " % & [ ] ( ) . , ; : / ? { } ! $ - @
+                      COMMENT=$(echo "${COMMENT}" | sed 's/[#*+=~^|\\<>]//g')
+                  elif [[ -n "${RELEASE_NAME}" ]]; then
+                      COMMENT="${RELEASE_NAME}"
+                  else
+                      COMMENT="Released version ${TAG_VERSION} of ${EXT_KEY}"
+                  fi
+
+                  # For workflow_dispatch, fall back to simple message
+                  if [[ -z "${COMMENT// }" ]]; then
+                      COMMENT="Released version ${TAG_VERSION} of ${EXT_KEY}"
+                  fi
+
+                  # Append release link if available
+                  if [[ -n "${RELEASE_URL}" ]]; then
+                      COMMENT=$(printf '%s\n\nDetails: %s' "${COMMENT}" "${RELEASE_URL}")
+                  fi
+
+                  # Use heredoc for multiline support in GitHub Actions
+                  {
+                      echo "comment<<EOF"
+                      echo "${COMMENT}"
+                      echo "EOF"
+                  } >> $GITHUB_ENV
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
+              with:
+                  php-version: 8.3
+                  extensions: intl, mbstring, json, zip, curl
+                  tools: composer:v2
+
+            - name: Install tailor
+              run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
+
+            - name: Publish to TER
+              env:
+                  RELEASE_COMMENT: ${{ env.comment }}
+                  RELEASE_VERSION: ${{ env.version }}
+              run: php ~/.composer/vendor/bin/tailor ter:publish --comment "${RELEASE_COMMENT}" "${RELEASE_VERSION}"


### PR DESCRIPTION
## Summary

- v12.0.6 and v12.0.7 releases failed to publish to TER due to an outdated workflow
- Sync the proven publish workflow from `main` which fixes:
  - `ubuntu-20.04` runner (removed from GitHub Actions)
  - PHP 7.4 (unsupported)
  - Multiline tag messages breaking `GITHUB_ENV` format
  - `TYPO3_EXTENSION_KEY` relying on a missing secret (now hardcoded)
- Adds `workflow_dispatch` support for manual re-runs
- Adds `ext_emconf.php` version validation

## Test plan

- [ ] Merge this PR
- [ ] Create v12.0.8 release to trigger TER publish