### PR TITLE
fix: remove strict_types from ext_emconf.php for TER compatibility

### DIFF
--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -20,7 +20,8 @@ $repoRoot = __DIR__ . '/..';
 
 $finder = PhpCsFixer\Finder::create()
     ->in($repoRoot)
-    ->exclude(['.build', 'config', 'node_modules', 'var']);
+    ->exclude(['.build', 'config', 'node_modules', 'var'])
+    ->notPath('ext_emconf.php');
 
 return (new PhpCsFixer\Config())
     // Enable fixers that might change behavior (you control which via setRules)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 12.0.9
+
+## BUGFIX
+
+- [BUGFIX] Remove declare(strict_types=1) from ext_emconf.php (TER cannot parse it)
+
+## MISC
+
+- [TASK] Sync TER publish workflow from main branch (fixes TER publishing)
+
 # 12.0.8
 
 ## MISC

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,13 +1,11 @@
 <?php
 
-/*
- * This file is part of the package netresearch/rte-ckeditor-image.
+/**
+ * Extension Manager configuration for rte_ckeditor_image.
  *
- * For the full copyright and license information, please read the
- * LICENSE file that was distributed with this source code.
+ * Do NOT add declare(strict_types=1) here.
+ * TER cannot parse ext_emconf.php with strict_types.
  */
-
-declare(strict_types=1);
 
 $EM_CONF[$_EXTKEY] = [
     'title'            => 'CKEditor Rich Text Editor Image Support',
@@ -17,7 +15,7 @@ $EM_CONF[$_EXTKEY] = [
     'clearCacheOnLoad' => 0,
     'author'           => 'Sebastian Koschel',
     'author_email'     => 'sebastian.koschel@netresearch.de',
-    'version'          => '12.0.8',
+    'version'          => '12.0.9',
     'constraints'      => [
         'depends' => [
             'php'          => '8.1.0-8.9.99',


### PR DESCRIPTION
## Summary

- Remove `declare(strict_types=1)` from `ext_emconf.php` — TER cannot parse it
- This was the root cause of all TER publish failures for v12.0.6, v12.0.7, and v12.0.8
- Bump version to 12.0.9

## Root cause

The TYPO3 Extension Repository (TER) uses a custom PHP parser to extract metadata from `ext_emconf.php`. This parser does not support `declare(strict_types=1)`, causing the error: "Details could not be extracted from the provided file."

The v13 branch already had this fix (discovered independently).