### PR TITLE
fix: skip preview renderer for CTypes with file fields

### DIFF
--- a/Classes/Listener/TCA/RtePreviewRendererRegistrar.php
+++ b/Classes/Listener/TCA/RtePreviewRendererRegistrar.php
@@ -217,38 +217,98 @@ final readonly class RtePreviewRendererRegistrar
             return false;
         }
 
-        // Collect FILE-type column names
-        $fileColumns = [];
+        // Collect effective field names from showitem, resolving palette references
+        $fieldNames = $this->extractFieldNames($showitem, $tableConfig);
 
-        foreach ($columns as $columnName => $columnConfig) {
-            if (!is_string($columnName) || !is_array($columnConfig)) {
+        // Check each field against its column config (single-pass over showitem fields)
+        foreach ($fieldNames as $fieldName) {
+            $columnConfig = $columns[$fieldName] ?? null;
+
+            if (!is_array($columnConfig)) {
                 continue;
             }
 
             $config = $columnConfig['config'] ?? null;
 
             if (is_array($config) && ($config['type'] ?? null) === 'file') {
-                $fileColumns[] = $columnName;
-            }
-        }
-
-        if ($fileColumns === []) {
-            return false;
-        }
-
-        // Parse showitem field names (format: "field;label;palette, --div--;Tab, ...")
-        foreach (explode(',', $showitem) as $part) {
-            $fieldName = trim(explode(';', trim($part))[0]);
-
-            if ($fieldName === '' || str_starts_with($fieldName, '--')) {
-                continue;
-            }
-
-            if (in_array($fieldName, $fileColumns, true)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * Extract field names from a showitem string, resolving palette references.
+     *
+     * Showitem format: "field1;label, --div--;Tab, --palette--;Label;palette_name"
+     * Palette showitem: "field2, field3" (no tabs or nested palettes)
+     *
+     * @param array<mixed> $tableConfig
+     *
+     * @return string[]
+     */
+    private function extractFieldNames(string $showitem, array $tableConfig): array
+    {
+        $fieldNames = [];
+
+        foreach (explode(',', $showitem) as $part) {
+            $segments  = explode(';', trim($part));
+            $firstPart = trim($segments[0]);
+
+            if ($firstPart === '') {
+                continue;
+            }
+
+            // Palette reference: --palette--;Label;palette_name
+            if ($firstPart === '--palette--') {
+                $paletteName = trim($segments[2] ?? '');
+
+                if ($paletteName === '') {
+                    continue;
+                }
+
+                $palettes = $tableConfig['palettes'] ?? null;
+
+                if (!is_array($palettes)) {
+                    continue;
+                }
+
+                $palette = $palettes[$paletteName] ?? null;
+
+                if (!is_array($palette)) {
+                    continue;
+                }
+
+                $paletteShowitem = $palette['showitem'] ?? null;
+                if (!is_string($paletteShowitem)) {
+                    continue;
+                }
+
+                if ($paletteShowitem === '') {
+                    continue;
+                }
+
+                // Palette showitem is flat (no nested palettes or tabs)
+                foreach (explode(',', $paletteShowitem) as $palettePart) {
+                    $paletteField = trim(explode(';', trim($palettePart))[0]);
+
+                    if ($paletteField !== '') {
+                        $fieldNames[] = $paletteField;
+                    }
+                }
+
+                continue;
+            }
+
+            // Skip tab dividers and other markers
+            if (str_starts_with($firstPart, '--')) {
+                continue;
+            }
+
+            $fieldNames[] = $firstPart;
+        }
+
+        return $fieldNames;
     }
 }

--- a/Tests/Unit/Listener/TCA/RtePreviewRendererRegistrarTest.php
+++ b/Tests/Unit/Listener/TCA/RtePreviewRendererRegistrarTest.php
@@ -477,6 +477,52 @@ final class RtePreviewRendererRegistrarTest extends UnitTestCase
     }
 
     #[Test]
+    public function skipsTypesWithFileFieldsInPalette(): void
+    {
+        $tca = [
+            'tt_content' => [
+                'columns' => [
+                    'bodytext' => [
+                        'config' => [
+                            'type' => 'text',
+                        ],
+                    ],
+                    'image' => [
+                        'config' => [
+                            'type' => 'file',
+                        ],
+                    ],
+                ],
+                'palettes' => [
+                    'imagelinks' => [
+                        'showitem' => 'image_zoom,image',
+                    ],
+                ],
+                'types' => [
+                    'textpic' => [
+                        'showitem'         => 'bodytext,--palette--;Images;imagelinks',
+                        'columnsOverrides' => [
+                            'bodytext' => [
+                                'config' => [
+                                    'enableRichtext' => true,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $modifiedTca = $this->invokeListenerAndGetTca($tca);
+
+        self::assertArrayNotHasKey(
+            'previewRenderer',
+            $modifiedTca['tt_content']['types']['textpic'],
+            'Types with file fields in palettes should not get RteImagePreviewRenderer (#720)',
+        );
+    }
+
+    #[Test]
     public function columnsOverridesFalseDoesNotRegister(): void
     {
         $tca = [


### PR DESCRIPTION
## Summary

Fixes #720 — `RteImagePreviewRenderer` was breaking `textpic`/`textmedia` preview thumbnails.

- `RtePreviewRendererRegistrar` now checks if a CType's `showitem` references any FILE-type columns (e.g. `image`, `assets`)
- Resolves `--palette--` references to detect file fields hidden in palettes (e.g. `textmedia`'s `assets` in `imageoverlayPalette`)
- CTypes with file fields are skipped — they need `StandardContentPreviewRenderer` to render file thumbnails
- CTypes with only RTE bodytext (like `text`) still get our enhanced preview renderer

## Before / After

| Before (Bug) | After (Fix) |
|---|---|
| `textpic` / `textmedia` get `RteImagePreviewRenderer` | `textpic` / `textmedia` keep `StandardContentPreviewRenderer` |
| Page module shows **no image thumbnails** for FAL file fields | Page module shows **file field thumbnails** as expected |
| Only bodytext HTML is rendered | Both bodytext **and** file field thumbnails rendered |
| `text` CType works fine (no file fields) | `text` CType still gets enhanced RTE preview ✓ |

## Root cause

`StandardContentPreviewRenderer::renderPageModulePreviewContent()` renders both bodytext **and** file field thumbnails in its `default` case. Our `RteImagePreviewRenderer` only renders bodytext, so replacing it on CTypes like `textpic` caused their image thumbnails to disappear.

## Changes

1. **`hasFileFieldsInShowitem()`** — single-pass check over showitem fields (addresses Gemini review)
2. **`extractFieldNames()`** — resolves `--palette--` references to find all effective fields (addresses Copilot review)
3. **Tests** — `skipsTypesWithFileFieldsInShowitem` + `skipsTypesWithFileFieldsInPalette` + updated `worksWithMultipleTablesAndTypes`

## Test plan

- [x] Unit tests: 752 pass (2 new tests for file field detection)
- [x] `skipsTypesWithFileFieldsInShowitem` — direct file field with tab dividers
- [x] `skipsTypesWithFileFieldsInPalette` — file field inside palette reference
- [x] `worksWithMultipleTablesAndTypes` — updated assertions for textpic/textmedia
- [x] PHPStan, CS-Fixer, Rector, PHP Lint all green
