### PR TITLE
fix: add blank line between if-blocks per Rector

### DIFF
--- a/Classes/Listener/TCA/RtePreviewRendererRegistrar.php
+++ b/Classes/Listener/TCA/RtePreviewRendererRegistrar.php
@@ -230,6 +230,7 @@ final readonly class RtePreviewRendererRegistrar
             if ($fieldName === '') {
                 continue;
             }
+
             if (str_starts_with($fieldName, '--')) {
                 continue;
             }


### PR DESCRIPTION
## Summary

Adds missing blank line between consecutive if-blocks in `RtePreviewRendererRegistrar` per Rector's `NewlineAfterStatementRector`.

This was fixed in [#729](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/729) but the merge queue processed the commit before the fix was pushed.

## Context

The duplicate CI runs (`push` + `merge_group` events) on main are a separate workflow configuration issue — the CI workflow triggers on both events, causing double execution.