### PR TITLE
[BUGFIX] Revert PCRE limits to original values

### DIFF
--- a/Classes/Controller/ImageLinkRenderingController.php
+++ b/Classes/Controller/ImageLinkRenderingController.php
@@ -136,8 +136,6 @@ class ImageLinkRenderingController extends AbstractPlugin
                                 ],
                             );
 
-                            $this->revertPCRELimits();
-
                             // Skip processing and continue with next image
                             throw new FileDoesNotExistException();
                         }


### PR DESCRIPTION
Revert modified PHP values to initial ones to avoid side effect with subsequent code outside of current extension.

**Closing issues**

Fixes #731: pcre.backtrack_limit could negatively affect subsequent code
