### PR TITLE
docs: fix outdated references, add missing features, update installation

### DIFF
--- a/Documentation/API/ViewHelpers.rst
+++ b/Documentation/API/ViewHelpers.rst
@@ -26,7 +26,7 @@ RteImagePreviewViewHelper
     :php:`RteImagePreviewRenderer` for use in Content Blocks and other custom
     backend preview templates where the built-in renderer is not available.
 
-    .. versionadded:: 13.6.0
+    .. versionadded:: 13.7.0
 
 Arguments
 ---------

--- a/Documentation/Architecture/ADR-001-Image-Scaling.rst
+++ b/Documentation/Architecture/ADR-001-Image-Scaling.rst
@@ -397,7 +397,7 @@ Rule 4: File Size Threshold (Force Processing)
    Processing:     YES - exceeds size threshold
    Result:         Processed JPEG at 1920×1080 px (~500 KB)
 
-Frontend Rendering (ImageRenderingController)
+Frontend Rendering (ImageRenderingAdapter)
 ==============================================
 
 Processing Decision Logic
@@ -543,7 +543,7 @@ Backend (SelectImageController)
 - **Security**: Verify file access permissions (IDOR protection)
 - **Performance**: Use efficient file property access
 
-Frontend (ImageRenderingController)
+Frontend (ImageRenderingAdapter)
 ------------------------------------
 
 - **Caching**: Processed images cached in ``typo3temp/assets/``

--- a/Documentation/Architecture/ADR-002-CKEditor-Integration.rst
+++ b/Documentation/Architecture/ADR-002-CKEditor-Integration.rst
@@ -233,14 +233,14 @@ Native Plugin Model
    lib.parseFunc_RTE {
        tags.img = TEXT
        tags.img {
-           preUserFunc = Netresearch\RteCKEditorImage\Controller\ImageRenderingController->renderImageAttributes
+           preUserFunc = Netresearch\RteCKEditorImage\Controller\ImageRenderingAdapter->renderImageAttributes
        }
    }
 
 **Why Native Plugins Can't Support This**:
 
 - Native plugins use direct ``src`` URLs, not FAL UIDs
-- ``ImageRenderingController->renderImageAttributes()`` expects FAL data attributes
+- ``ImageRenderingAdapter->renderImageAttributes()`` expects FAL data attributes
 - No way to look up file in FAL without UID
 - Cannot apply magic image processing without FAL context
 
@@ -377,9 +377,9 @@ Frontend Rendering
 ------------------
 
 .. code-block:: php
-   :caption: ImageRenderingController.php (conceptual)
+   :caption: ImageRenderingAdapter.php (conceptual)
 
-   public function renderImageAttributes(string $content, array $conf): string
+   public function renderImageAttributes(?string $content, array $conf, ServerRequestInterface $request): string
    {
        // Extract data-htmlarea-file-uid from HTML
        $fileUid = $this->extractFileUid($content);

--- a/Documentation/Architecture/Design-Patterns.rst
+++ b/Documentation/Architecture/Design-Patterns.rst
@@ -209,7 +209,7 @@ Frontend Rendering Flow
     start
     :RTE content loaded from database;
     :lib.parseFunc_RTE processes content;
-    :ImageRenderingController hook invoked;
+    :ImageRenderingAdapter hook invoked;
     :FAL file loaded from UID;
     :Magic image processing applied;
     :Processed image URL generated;

--- a/Documentation/CKEditor/Model-Element.rst
+++ b/Documentation/CKEditor/Model-Element.rst
@@ -134,11 +134,6 @@ Key Differences
 Usage Example
 ^^^^^^^^^^^^^
 
-Text can flow around inline images: |inline-example|
-
-.. |inline-example| image:: /Images/inline-image-example.png
-   :height: 20px
-
 In the editor, users can type text before and after inline images on the same line,
 just like typing around any other inline element (bold text, links, etc.).
 

--- a/Documentation/Troubleshooting/Frontend-Issues.rst
+++ b/Documentation/Troubleshooting/Frontend-Issues.rst
@@ -225,7 +225,7 @@ Issue: Images Display at Wrong Size
 
    lib.parseFunc_RTE.tags.img {
        current = 1
-       preUserFunc = Netresearch\RteCKEditorImage\Controller\ImageRenderingController->renderImageAttributes
+       preUserFunc = Netresearch\RteCKEditorImage\Controller\ImageRenderingAdapter->renderImageAttributes
    }
 
 ----
@@ -248,7 +248,7 @@ Ensure both width and height are rendered:
 
    lib.parseFunc_RTE.tags.img {
        current = 1
-       preUserFunc = Netresearch\RteCKEditorImage\Controller\ImageRenderingController->renderImageAttributes
+       preUserFunc = Netresearch\RteCKEditorImage\Controller\ImageRenderingAdapter->renderImageAttributes
        stdWrap {
            wrap = <div class="rte-image">|</div>
        }
@@ -362,7 +362,7 @@ Issue: Lightbox/Zoom Not Working
 
    lib.parseFunc_RTE.tags.img {
        current = 1
-       preUserFunc = Netresearch\RteCKEditorImage\Controller\ImageRenderingController->renderImageAttributes
+       preUserFunc = Netresearch\RteCKEditorImage\Controller\ImageRenderingAdapter->renderImageAttributes
    }
 
 2. **Include Lightbox Library:**
@@ -415,7 +415,7 @@ For advanced responsive images with srcset, configure image processing:
 
    lib.parseFunc_RTE.tags.img {
        current = 1
-       preUserFunc = Netresearch\RteCKEditorImage\Controller\ImageRenderingController->renderImageAttributes
+       preUserFunc = Netresearch\RteCKEditorImage\Controller\ImageRenderingAdapter->renderImageAttributes
    }
 
 ----

--- a/Documentation/Troubleshooting/Installation-Issues.rst
+++ b/Documentation/Troubleshooting/Installation-Issues.rst
@@ -227,7 +227,7 @@ Issue: Static Template Not Included
        tags.img = TEXT
        tags.img {
            current = 1
-           preUserFunc = Netresearch\RteCKEditorImage\Controller\ImageRenderingController->renderImageAttributes
+           preUserFunc = Netresearch\RteCKEditorImage\Controller\ImageRenderingAdapter->renderImageAttributes
        }
    }
 

--- a/Documentation/Troubleshooting/Performance-Issues.rst
+++ b/Documentation/Troubleshooting/Performance-Issues.rst
@@ -151,7 +151,7 @@ Issue: Slow Page Load Due to Images
 
    lib.parseFunc_RTE.tags.img {
        current = 1
-       preUserFunc = Netresearch\RteCKEditorImage\Controller\ImageRenderingController->renderImageAttributes
+       preUserFunc = Netresearch\RteCKEditorImage\Controller\ImageRenderingAdapter->renderImageAttributes
        stdWrap.replacement {
            10 {
                search = <img

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 This extension adds comprehensive image handling capabilities to CKEditor for TYPO3.\
 Add issues or explore the project on [GitHub](https://github.com/netresearch/t3x-rte_ckeditor_image).
 
-<kbd>![](Resources/Public/Images/demo.gif?raw=true)</kbd>
+<kbd>![](Documentation/Images/backend-image-properties-dialog.png?raw=true)</kbd>
 
 ## Features
 
@@ -41,6 +41,8 @@ Add issues or explore the project on [GitHub](https://github.com/netresearch/t3x
 - **Fluid Templates**: Customizable output via template overrides with automatic figcaption width constraint
 - **Image Validation**: CLI command and upgrade wizard to detect and fix broken image references and nested link wrappers
 - **Preview Renderer**: Images preserved in page module preview with broken reference warnings
+- **Content Blocks Support**: ViewHelper for rendering RTE image previews in Content Blocks backend templates
+- **Table Images**: Images in CKEditor 5 tables get full processing (max-width, zoom, t3:// resolution)
 - **Automatic Softref**: RTE image references tracked automatically across all tables
 
 ## Requirements
@@ -61,25 +63,27 @@ Install the extension via composer:
 composer req netresearch/rte-ckeditor-image
 ```
 
-The backend RTE works immediately. For frontend rendering, include the TypoScript:
+Enable the Site Set to activate both the backend RTE preset and frontend rendering:
 
-> **Important (v13.4.0+):** TypoScript is no longer auto-injected. You must include it manually using one of the options below.
+Add the extension to your site dependencies:
 
-**Option 1: Static Template (Recommended)**
+```yaml
+# config/sites/<site>/config.yaml
+dependencies:
+  - netresearch/rte-ckeditor-image
+```
 
-1. Go to **WEB > Template** module
-2. Select your root page, edit the template
-3. In **Includes** tab, add: **CKEditor Image Support (rte_ckeditor_image)**
+This enables the RTE preset with the `insertimage` button and includes the frontend TypoScript for image processing.
 
-**Option 2: Direct Import**
+> **Using Bootstrap Package or another theme extension?** List this extension **after** them in your dependencies to override their RTE preset.
 
-Add to your site package TypoScript:
+**Alternative: Direct TypoScript Import**
+
+If you prefer manual control over TypoScript load order:
 
 ```typoscript
 @import 'EXT:rte_ckeditor_image/Configuration/TypoScript/ImageRendering/setup.typoscript'
 ```
-
-This gives you full control over TypoScript load order, allowing you to override settings (like lightbox configuration) after the import.
 
 ### Custom Configuration (Optional)
 


### PR DESCRIPTION
## Summary

Comprehensive documentation review and fixes:

- **Fix versionadded** for `RteImagePreviewViewHelper` (13.6.0 → 13.7.0 per git history)
- **Fix broken image reference** `inline-image-example.png` in `CKEditor/Model-Element.rst`
- **Fix outdated class name** `ImageRenderingController` → `ImageRenderingAdapter` in 7 files (Troubleshooting, ADRs, Design-Patterns) — TypoScript examples now match actual `setup.typoscript`
- **Add missing README features**: Content Blocks support (v13.7.0), Table image processing (v13.7.1)
- **Replace teaser image**: 2017 `demo.gif` → current `backend-image-properties-dialog.png`
- **Update installation instructions**: Site Set as primary method (matching `Introduction/Index.rst`), replaces outdated Static Template instructions

## Remaining work (separate PRs)

- [ ] Create proper teaser screenshot/animation of CKEditor image dialog workflow
- [ ] Reference orphaned screenshots (`double-link-icon-fix-687.png`, `figcaption-maxwidth-fix-686.png`) in docs or remove
- [ ] Write missing ADRs (parseFunc processing, UTF-8 handling, template selection, preview registration, PCRE limits, figure re-processing, service layering)
- [ ] Update `Security-Validation-Checklist.md` and `RFC-Fluid-Templates-Refactoring.md` class references (historical docs, lower priority)

## Test plan

- [ ] Verify docs render correctly on docs.typo3.org after merge
- [ ] Verify README renders correctly on GitHub (teaser image, feature list, installation)