### PR TITLE
fix: replace removed getFileStorageRecords() with checkActionPermission()

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -104,6 +104,11 @@ parameters:
 			path: ../Classes/Controller/ImageRenderingController.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 2
+			path: ../Classes/Controller/SelectImageController.php
+
+		-
 			message: "#^Method Netresearch\\\\RteCKEditorImage\\\\DataHandling\\\\SoftReference\\\\RteImageSoftReferenceParser\\:\\:findImageTags\\(\\) should return array\\<string, array\\<array\\<string, mixed\\>\\>\\|string\\> but returns array\\<array\\<string, mixed\\>\\>\\.$#"
 			count: 1
 			path: ../Classes/DataHandling/SoftReference/RteImageSoftReferenceParser.php

--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -104,11 +104,6 @@ parameters:
 			path: ../Classes/Controller/ImageRenderingController.php
 
 		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 2
-			path: ../Classes/Controller/SelectImageController.php
-
-		-
 			message: "#^Method Netresearch\\\\RteCKEditorImage\\\\DataHandling\\\\SoftReference\\\\RteImageSoftReferenceParser\\:\\:findImageTags\\(\\) should return array\\<string, array\\<array\\<string, mixed\\>\\>\\|string\\> but returns array\\<array\\<string, mixed\\>\\>\\.$#"
 			count: 1
 			path: ../Classes/DataHandling/SoftReference/RteImageSoftReferenceParser.php

--- a/Classes/Controller/SelectImageController.php
+++ b/Classes/Controller/SelectImageController.php
@@ -193,6 +193,11 @@ class SelectImageController extends ElementBrowserController
      * Verifies if the current backend user can access the given file.
      * Implements IDOR protection by checking file mount permissions.
      *
+     * Uses TYPO3's built-in permission system which correctly checks:
+     * - User action permissions (readFile)
+     * - File extension restrictions
+     * - File mount boundaries (isWithinFileMountBoundaries)
+     *
      * @param File $file The file to check access for
      *
      * @return bool True if user can access the file
@@ -211,26 +216,12 @@ class SelectImageController extends ElementBrowserController
             return false;
         }
 
-        // Admin users have access to all files
-        if ($backendUser->isAdmin()) {
-            return true;
-        }
-
-        // Check if file storage is within user's file mounts
-        $storage       = $file->getStorage();
-        $storageRecord = $storage->getStorageRecord();
-
-        // Get user's file mounts
-        $fileMounts = $backendUser->getFileStorageRecords();
-
-        // Check if storage is in user's accessible storages
-        foreach ($fileMounts as $fileMount) {
-            if ((int) $fileMount['uid'] === (int) $storageRecord['uid']) {
-                return true;
-            }
-        }
-
-        return false;
+        // Use TYPO3's built-in permission check which handles:
+        // - Admin users (automatic full access)
+        // - File mount boundaries
+        // - User group permissions
+        // This replaces the broken getFileStorageRecords() approach
+        return $file->checkActionPermission('read');
     }
 
     /**

--- a/Classes/Controller/SelectImageController.php
+++ b/Classes/Controller/SelectImageController.php
@@ -190,17 +190,16 @@ class SelectImageController extends ElementBrowserController
     }
 
     /**
-     * Verifies if the current backend user can access the given file.
-     * Implements IDOR protection by checking file mount permissions.
+     * Verifies if the current backend user can read the given file.
+     * Implements IDOR protection by delegating to TYPO3's FAL permission checks.
      *
-     * Uses TYPO3's built-in permission system which correctly checks:
-     * - User action permissions (readFile)
-     * - File extension restrictions
-     * - File mount boundaries (isWithinFileMountBoundaries)
+     * This method uses {@see File::checkActionPermission()} with the 'read'
+     * action, which evaluates the current backend user's file permissions together
+     * with storage configuration (including file mounts and related restrictions).
      *
      * @param File $file The file to check access for
      *
-     * @return bool True if user can access the file
+     * @return bool True if the current backend user is allowed to read the file
      */
     protected function isFileAccessibleByUser(File $file): bool
     {
@@ -216,11 +215,6 @@ class SelectImageController extends ElementBrowserController
             return false;
         }
 
-        // Use TYPO3's built-in permission check which handles:
-        // - Admin users (automatic full access)
-        // - File mount boundaries
-        // - User group permissions
-        // This replaces the broken getFileStorageRecords() approach
         return $file->checkActionPermission('read');
     }
 


### PR DESCRIPTION
## Summary

- Replace `getFileStorageRecords()` (removed in TYPO3 12.4) with `File::checkActionPermission('read')` — the TYPO3 core API for file access checks
- Remove now-unnecessary PHPStan baseline entry for `(int)` casts on removed code

Backport of the fix already present on `main` since [`8d89536`](https://github.com/netresearch/t3x-rte_ckeditor_image/commit/8d89536).

Fixes #749

## Test plan

- [ ] CI passes on TYPO3_12 branch
- [ ] Non-admin backend user can insert images without fatal error