### PR TITLE
fix(validator): preserve leading slash in RTE image src fixes (#778)

### DIFF
--- a/Classes/Listener/FileOperation/UpdateImageReferences.php
+++ b/Classes/Listener/FileOperation/UpdateImageReferences.php
@@ -287,8 +287,12 @@ class UpdateImageReferences
                 continue;
             }
 
+            if ($currentSrc === $newSrc) {
+                continue;
+            }
+
             // Treat "/fileadmin/x" and "fileadmin/x" as equivalent (#778)
-            if ($currentSrc === $newSrc || '/' . ltrim($currentSrc, '/') === $newSrc) {
+            if ('/' . ltrim($currentSrc, '/') === $newSrc) {
                 continue;
             }
 

--- a/Classes/Listener/FileOperation/UpdateImageReferences.php
+++ b/Classes/Listener/FileOperation/UpdateImageReferences.php
@@ -79,13 +79,19 @@ class UpdateImageReferences
             return;
         }
 
-        $publicUrl = $file->getPublicUrl();
+        $rawPublicUrl = $file->getPublicUrl();
 
-        if ($publicUrl === null || $publicUrl === '') {
+        if ($rawPublicUrl === null || $rawPublicUrl === '') {
             $this->logger->debug('Skipping file without public URL', ['fileUid' => $fileUid]);
 
             return;
         }
+
+        // Normalize publicUrl to site-root-absolute form with leading slash.
+        // TYPO3's Local driver returns "fileadmin/..." (no leading slash) while
+        // the RTE stores "/fileadmin/..." — both refer to the same resource.
+        // See issue #778.
+        $publicUrl = $this->normalizePublicUrl($rawPublicUrl);
 
         // Query sys_refindex for records referencing this file via rtehtmlarea_images
         $affectedRecords = $this->findAffectedRecords($fileUid);
@@ -215,6 +221,29 @@ class UpdateImageReferences
     }
 
     /**
+     * Normalize a FAL public URL to a site-root-absolute form with leading slash.
+     *
+     * The Local driver returns paths like "fileadmin/image.jpg" (no leading
+     * slash), while the RTE stores "/fileadmin/image.jpg". Both refer to the
+     * same resource; using the slashless form as a replacement breaks frontend
+     * and backend image rendering (#778).
+     *
+     * Absolute URLs (http://, https://, //example.com) are returned unchanged.
+     */
+    private function normalizePublicUrl(string $publicUrl): string
+    {
+        if (
+            str_starts_with($publicUrl, 'http://')
+            || str_starts_with($publicUrl, 'https://')
+            || str_starts_with($publicUrl, '//')
+        ) {
+            return $publicUrl;
+        }
+
+        return '/' . ltrim($publicUrl, '/');
+    }
+
+    /**
      * Update src attributes in HTML for img tags matching the given file UID.
      *
      * Uses the same HtmlParser::splitTags() + get_tag_attributes() pattern
@@ -258,7 +287,8 @@ class UpdateImageReferences
                 continue;
             }
 
-            if ($currentSrc === $newSrc) {
+            // Treat "/fileadmin/x" and "fileadmin/x" as equivalent (#778)
+            if ($currentSrc === $newSrc || '/' . ltrim($currentSrc, '/') === $newSrc) {
                 continue;
             }
 

--- a/Classes/Service/RteImageReferenceValidator.php
+++ b/Classes/Service/RteImageReferenceValidator.php
@@ -262,11 +262,17 @@ class RteImageReferenceValidator
             );
         }
 
-        $publicUrl = $file->getPublicUrl();
+        $rawPublicUrl = $file->getPublicUrl();
 
-        if ($publicUrl === null || $publicUrl === '') {
+        if ($rawPublicUrl === null || $rawPublicUrl === '') {
             return null;
         }
+
+        // Normalize publicUrl to site-root-absolute form with leading slash.
+        // TYPO3's Local driver returns "fileadmin/..." (no leading slash) while
+        // the RTE stores "/fileadmin/..." — both refer to the same resource.
+        // See issue #778.
+        $publicUrl = $this->normalizePublicUrl($rawPublicUrl);
 
         // Check for processed image URL
         if ($src !== null && str_contains($src, '/_processed_/')) {
@@ -282,8 +288,10 @@ class RteImageReferenceValidator
             );
         }
 
-        // Check for src mismatch
-        if (!in_array($src, [null, '', $publicUrl], true)) {
+        // Check for src mismatch. Accept both slash and slashless variants as
+        // equivalent: a stored "/fileadmin/x" and a publicUrl "fileadmin/x"
+        // must not be reported as a mismatch (#778).
+        if ($src !== null && $src !== '' && !$this->srcMatchesPublicUrl($src, $publicUrl)) {
             return new ValidationIssue(
                 type: ValidationIssueType::SrcMismatch,
                 table: $table,
@@ -311,6 +319,44 @@ class RteImageReferenceValidator
         }
 
         return null;
+    }
+
+    /**
+     * Normalize a FAL public URL to a site-root-absolute form with leading slash.
+     *
+     * The Local driver returns paths like "fileadmin/image.jpg" (no leading
+     * slash), while the RTE stores "/fileadmin/image.jpg". Both refer to the
+     * same resource; using the slashless form as a replacement breaks frontend
+     * and backend image rendering (#778).
+     *
+     * Absolute URLs (http://, https://, //example.com) are returned unchanged.
+     */
+    private function normalizePublicUrl(string $publicUrl): string
+    {
+        if (
+            str_starts_with($publicUrl, 'http://')
+            || str_starts_with($publicUrl, 'https://')
+            || str_starts_with($publicUrl, '//')
+        ) {
+            return $publicUrl;
+        }
+
+        return '/' . ltrim($publicUrl, '/');
+    }
+
+    /**
+     * Check whether a stored src is equivalent to a normalized publicUrl.
+     *
+     * Treats "/fileadmin/x" and "fileadmin/x" as equivalent so that validation
+     * does not flag correctly-stored leading-slash paths as mismatches (#778).
+     */
+    private function srcMatchesPublicUrl(string $src, string $publicUrl): bool
+    {
+        if ($src === $publicUrl) {
+            return true;
+        }
+
+        return '/' . ltrim($src, '/') === $publicUrl;
     }
 
     /**

--- a/Tests/Functional/Listener/FileOperation/Fixtures/FileMoveResult.csv
+++ b/Tests/Functional/Listener/FileOperation/Fixtures/FileMoveResult.csv
@@ -1,3 +1,3 @@
 "tt_content",,,,,,
 ,"uid","pid","sys_language_uid","deleted","hidden","bodytext"
-,1,1,0,0,0,"<img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""1"" src=""fileadmin/subdir/photo.jpg"" />"
+,1,1,0,0,0,"<img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""1"" src=""/fileadmin/subdir/photo.jpg"" />"

--- a/Tests/Functional/Listener/FileOperation/Fixtures/FileRenameResult.csv
+++ b/Tests/Functional/Listener/FileOperation/Fixtures/FileRenameResult.csv
@@ -1,3 +1,3 @@
 "tt_content",,,,,,
 ,"uid","pid","sys_language_uid","deleted","hidden","bodytext"
-,1,1,0,0,0,"<p>Text <img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""1"" src=""fileadmin/renamed.jpg"" /> more</p>"
+,1,1,0,0,0,"<p>Text <img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""1"" src=""/fileadmin/renamed.jpg"" /> more</p>"

--- a/Tests/Functional/Listener/FileOperation/Fixtures/MultipleRecordsResult.csv
+++ b/Tests/Functional/Listener/FileOperation/Fixtures/MultipleRecordsResult.csv
@@ -1,4 +1,4 @@
 "tt_content",,,,,,
 ,"uid","pid","sys_language_uid","deleted","hidden","bodytext"
-,1,1,0,0,0,"<img data-htmlarea-file-uid=""1"" src=""fileadmin/new.jpg"" />"
-,2,1,0,0,0,"<p><img data-htmlarea-file-uid=""1"" src=""fileadmin/new.jpg"" /> text</p>"
+,1,1,0,0,0,"<img data-htmlarea-file-uid=""1"" src=""/fileadmin/new.jpg"" />"
+,2,1,0,0,0,"<p><img data-htmlarea-file-uid=""1"" src=""/fileadmin/new.jpg"" /> text</p>"

--- a/Tests/Functional/Listener/FileOperation/Fixtures/UnrelatedRecordsResult.csv
+++ b/Tests/Functional/Listener/FileOperation/Fixtures/UnrelatedRecordsResult.csv
@@ -1,4 +1,4 @@
 "tt_content",,,,,,
 ,"uid","pid","sys_language_uid","deleted","hidden","bodytext"
-,1,1,0,0,0,"<img data-htmlarea-file-uid=""1"" src=""fileadmin/new.jpg"" />"
+,1,1,0,0,0,"<img data-htmlarea-file-uid=""1"" src=""/fileadmin/new.jpg"" />"
 ,2,1,0,0,0,"<img data-htmlarea-file-uid=""2"" src=""/fileadmin/other.jpg"" />"

--- a/Tests/Functional/Service/Fixtures/RteImageValidationFixResult.csv
+++ b/Tests/Functional/Service/Fixtures/RteImageValidationFixResult.csv
@@ -1,8 +1,9 @@
 "tt_content",,,,,,
 ,"uid","pid","sys_language_uid","deleted","hidden","bodytext"
-,1,1,0,0,0,"<p>Text <img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""1"" src=""fileadmin/photo.jpg"" /> more</p>"
-,2,1,0,0,0,"<p><img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""1"" src=""fileadmin/photo.jpg"" /></p>"
+,1,1,0,0,0,"<p>Text <img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""1"" src=""/fileadmin/photo.jpg"" /> more</p>"
+,2,1,0,0,0,"<p><img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""1"" src=""/fileadmin/photo.jpg"" /></p>"
 ,3,1,0,0,0,"<p>Clean <img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""2"" src=""fileadmin/banner.png"" /> content</p>"
 ,4,1,0,0,0,"<p><img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""999"" src=""/fileadmin/deleted.jpg"" /></p>"
-,5,1,0,0,0,"<p><img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""2"" src=""fileadmin/banner.png"" alt=""broken src"" /></p>"
+,5,1,0,0,0,"<p><img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""2"" src=""/fileadmin/banner.png"" alt=""broken src"" /></p>"
 ,6,1,0,0,0,""
+,7,1,0,0,0,"<p>Leading slash <img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""1"" src=""/fileadmin/photo.jpg"" /> clean</p>"

--- a/Tests/Functional/Service/Fixtures/RteImageValidationImport.csv
+++ b/Tests/Functional/Service/Fixtures/RteImageValidationImport.csv
@@ -19,6 +19,7 @@
 ,4,1,0,0,0,"<p><img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""999"" src=""/fileadmin/deleted.jpg"" /></p>"
 ,5,1,0,0,0,"<p><img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""2"" src="""" alt=""broken src"" /></p>"
 ,6,1,0,0,0,""
+,7,1,0,0,0,"<p>Leading slash <img data-htmlarea-file-table=""sys_file"" data-htmlarea-file-uid=""1"" src=""/fileadmin/photo.jpg"" /> clean</p>"
 
 "sys_refindex",,,,,,
 ,"hash","tablename","recuid","field","softref_key","ref_table","ref_uid"
@@ -29,3 +30,4 @@
 ,"hash05","tt_content",5,"bodytext","rtehtmlarea_images","sys_file",2
 ,"hash06","tt_content",6,"bodytext","rtehtmlarea_images","sys_file",1
 ,"hash07","tt_content",999,"bodytext","rtehtmlarea_images","sys_file",1
+,"hash08","tt_content",7,"bodytext","rtehtmlarea_images","sys_file",1

--- a/Tests/Functional/Service/RteImageReferenceValidatorTest.php
+++ b/Tests/Functional/Service/RteImageReferenceValidatorTest.php
@@ -126,9 +126,28 @@ class RteImageReferenceValidatorTest extends FunctionalTestCase
     {
         $result = $this->getSubject()->validate();
 
-        self::assertSame(5, $result->getScannedRecords());
-        self::assertSame(5, $result->getScannedImages());
+        self::assertSame(6, $result->getScannedRecords());
+        self::assertSame(6, $result->getScannedImages());
         self::assertGreaterThanOrEqual(4, count($result->getIssues()));
+    }
+
+    #[Test]
+    public function validateTreatsLeadingSlashSrcAsCleanForIssue778(): void
+    {
+        // Record 7 has src="/fileadmin/photo.jpg" pointing to file uid=1.
+        // TYPO3's Local driver returns "fileadmin/photo.jpg" (no leading slash)
+        // for getPublicUrl(). Before #778 was fixed, the validator flagged this
+        // as SrcMismatch and "fixed" it by dropping the leading slash, breaking
+        // frontend and backend rendering. The leading-slash form must be
+        // treated as equivalent to the slashless publicUrl.
+        $result = $this->getSubject()->validate();
+
+        $record7Issues = array_filter(
+            $result->getIssues(),
+            static fn (ValidationIssue $issue): bool => $issue->uid === 7,
+        );
+
+        self::assertCount(0, $record7Issues, 'Leading-slash src must be treated as clean (#778)');
     }
 
     #[Test]
@@ -191,7 +210,7 @@ class RteImageReferenceValidatorTest extends FunctionalTestCase
 
         self::assertCount(0, $record999Issues);
         // uid=999 must not be counted as a scanned record
-        self::assertSame(5, $result->getScannedRecords());
+        self::assertSame(6, $result->getScannedRecords());
     }
 
     #[Test]
@@ -207,7 +226,7 @@ class RteImageReferenceValidatorTest extends FunctionalTestCase
 
         self::assertCount(0, $record6Issues);
         // uid=6 must not be counted as a scanned record
-        self::assertSame(5, $result->getScannedRecords());
+        self::assertSame(6, $result->getScannedRecords());
     }
 
     #[Test]

--- a/Tests/Unit/Listener/FileOperation/UpdateImageReferencesTest.php
+++ b/Tests/Unit/Listener/FileOperation/UpdateImageReferencesTest.php
@@ -257,6 +257,55 @@ final class UpdateImageReferencesTest extends UnitTestCase
         $this->subject->handleFileRenamed($event);
     }
 
+    // -------------------------------------------------------------------------
+    // Leading-slash normalization (#778)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function handleFileRenamedNormalizesSlashlessPublicUrl(): void
+    {
+        // Real TYPO3 v13 behavior: getPublicUrl() returns path WITHOUT leading slash
+        $file = $this->createMock(File::class);
+        $file->method('getUid')->willReturn(1);
+        $file->method('getPublicUrl')->willReturn('fileadmin/renamed.jpg');
+
+        $oldHtml = '<p><img data-htmlarea-file-uid="1" src="/fileadmin/old.jpg" /></p>';
+        $newHtml = '<p><img data-htmlarea-file-uid="1" src="/fileadmin/renamed.jpg" /></p>';
+
+        $this->setupMocks(
+            [['tablename' => 'tt_content', 'recuid' => 1, 'field' => 'bodytext']],
+            ['tt_content' => [1 => ['bodytext' => $oldHtml]]],
+        );
+
+        $this->connection->expects(self::once())->method('update')
+            ->with('tt_content', ['bodytext' => $newHtml], ['uid' => 1]);
+
+        $event = new AfterFileRenamedEvent($file, 'old.jpg');
+        $this->subject->handleFileRenamed($event);
+    }
+
+    #[Test]
+    public function handleFileRenamedNoOpWhenSrcMatchesNormalizedSlashlessPublicUrl(): void
+    {
+        // getPublicUrl returns "fileadmin/current.jpg", stored src is "/fileadmin/current.jpg"
+        // Both refer to the same resource — must be treated as already correct.
+        $file = $this->createMock(File::class);
+        $file->method('getUid')->willReturn(1);
+        $file->method('getPublicUrl')->willReturn('fileadmin/current.jpg');
+
+        $html = '<img data-htmlarea-file-uid="1" src="/fileadmin/current.jpg" />';
+
+        $this->setupMocks(
+            [['tablename' => 'tt_content', 'recuid' => 1, 'field' => 'bodytext']],
+            ['tt_content' => [1 => ['bodytext' => $html]]],
+        );
+
+        $this->connection->expects(self::never())->method('update');
+
+        $event = new AfterFileRenamedEvent($file, 'old.jpg');
+        $this->subject->handleFileRenamed($event);
+    }
+
     /**
      * Set up ConnectionPool mocks for refindex query and field value fetching.
      *

--- a/Tests/Unit/Service/RteImageReferenceValidatorTest.php
+++ b/Tests/Unit/Service/RteImageReferenceValidatorTest.php
@@ -936,4 +936,146 @@ class RteImageReferenceValidatorTest extends TestCase
 
         self::assertSame($expected, $this->invokeApplyFixes($html, $issues));
     }
+
+    // -------------------------------------------------------------------------
+    // Leading-slash normalization (#778)
+    //
+    // TYPO3's File::getPublicUrl() returns a site-root-relative path WITHOUT a
+    // leading slash (e.g. "fileadmin/image.jpg") for the Local driver. The RTE
+    // stores the src with a leading slash (e.g. "/fileadmin/image.jpg"). Both
+    // forms refer to the same resource and must be treated as equivalent. Fixes
+    // must always write the leading-slash form so rendering does not break.
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function leadingSlashSrcMatchesSlashlessPublicUrl(): void
+    {
+        // Real TYPO3 v13 behavior: getPublicUrl() returns path WITHOUT leading slash
+        $file = $this->createMock(File::class);
+        $file->method('getPublicUrl')->willReturn('fileadmin/image.jpg');
+
+        $this->resourceFactory
+            ->method('getFileObject')
+            ->with(1)
+            ->willReturn($file);
+
+        // Stored src has leading slash — must be considered equivalent
+        $html = '<p><img data-htmlarea-file-uid="1" src="/fileadmin/image.jpg" alt="test" /></p>';
+
+        $issues = $this->subject->validateHtml($html, 'tt_content', 1, 'bodytext');
+
+        self::assertSame([], $issues, 'Leading-slash src must match slashless publicUrl');
+    }
+
+    #[Test]
+    public function slashlessSrcStillMatchesSlashlessPublicUrl(): void
+    {
+        // Ensure backwards compatibility: slashless form must also still match
+        $file = $this->createMock(File::class);
+        $file->method('getPublicUrl')->willReturn('fileadmin/image.jpg');
+
+        $this->resourceFactory
+            ->method('getFileObject')
+            ->with(1)
+            ->willReturn($file);
+
+        $html = '<p><img data-htmlarea-file-uid="1" src="fileadmin/image.jpg" /></p>';
+
+        $issues = $this->subject->validateHtml($html, 'tt_content', 1, 'bodytext');
+
+        self::assertSame([], $issues, 'Slashless src must still match slashless publicUrl');
+    }
+
+    #[Test]
+    public function processedImageExpectedSrcAlwaysHasLeadingSlash(): void
+    {
+        // getPublicUrl() returns slashless form; expectedSrc must be normalized
+        // to leading-slash form so the fix does not break rendering.
+        $file = $this->createMock(File::class);
+        $file->method('getPublicUrl')->willReturn('fileadmin/images/dummy.jpg');
+
+        $this->resourceFactory
+            ->method('getFileObject')
+            ->with(9)
+            ->willReturn($file);
+
+        $html = '<p><img data-htmlarea-file-uid="9" '
+            . 'src="/fileadmin/_processed_/3/4/csm_dummy_abc123.jpg" /></p>';
+
+        $issues = $this->subject->validateHtml($html, 'tt_content', 1, 'bodytext');
+
+        self::assertCount(1, $issues);
+        self::assertSame(ValidationIssueType::ProcessedImageSrc, $issues[0]->type);
+        self::assertSame(
+            '/fileadmin/images/dummy.jpg',
+            $issues[0]->expectedSrc,
+            'expectedSrc must carry leading slash even when publicUrl lacks one',
+        );
+    }
+
+    #[Test]
+    public function brokenSrcExpectedSrcAlwaysHasLeadingSlash(): void
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getPublicUrl')->willReturn('fileadmin/banner.png');
+
+        $this->resourceFactory
+            ->method('getFileObject')
+            ->with(2)
+            ->willReturn($file);
+
+        $html = '<p><img data-htmlarea-file-uid="2" src="" alt="broken" /></p>';
+
+        $issues = $this->subject->validateHtml($html, 'tt_content', 5, 'bodytext');
+
+        self::assertCount(1, $issues);
+        self::assertSame(ValidationIssueType::BrokenSrc, $issues[0]->type);
+        self::assertSame('/fileadmin/banner.png', $issues[0]->expectedSrc);
+    }
+
+    #[Test]
+    public function srcMismatchExpectedSrcAlwaysHasLeadingSlash(): void
+    {
+        $file = $this->createMock(File::class);
+        $file->method('getPublicUrl')->willReturn('fileadmin/new-location/photo.jpg');
+
+        $this->resourceFactory
+            ->method('getFileObject')
+            ->with(5)
+            ->willReturn($file);
+
+        $html = '<p><img data-htmlarea-file-uid="5" '
+            . 'src="/fileadmin/old-location/photo.jpg" /></p>';
+
+        $issues = $this->subject->validateHtml($html, 'tt_content', 10, 'bodytext');
+
+        self::assertCount(1, $issues);
+        self::assertSame(ValidationIssueType::SrcMismatch, $issues[0]->type);
+        self::assertSame('/fileadmin/new-location/photo.jpg', $issues[0]->expectedSrc);
+    }
+
+    #[Test]
+    public function applyFixesPreservesLeadingSlashWhenReplacingProcessedSrc(): void
+    {
+        // Regression #778: the fix path must write a leading-slash form
+        $issues = [
+            new ValidationIssue(
+                type: ValidationIssueType::ProcessedImageSrc,
+                table: 'tt_content',
+                uid: 1,
+                field: 'bodytext',
+                fileUid: 9,
+                currentSrc: '/fileadmin/_processed_/3/4/csm_dummy_abc123.jpg',
+                expectedSrc: '/fileadmin/images/dummy.jpg',
+                imgIndex: 0,
+            ),
+        ];
+
+        $html = '<p><img data-htmlarea-file-uid="9" '
+            . 'src="/fileadmin/_processed_/3/4/csm_dummy_abc123.jpg" /></p>';
+        $expected = '<p><img data-htmlarea-file-uid="9" '
+            . 'src="/fileadmin/images/dummy.jpg" /></p>';
+
+        self::assertSame($expected, $this->invokeApplyFixes($html, $issues));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #778. Both the `RteImageReferenceValidator` (used by CLI `rte_ckeditor_image:validate --fix` and the upgrade wizard) and the `UpdateImageReferences` listener (triggered on file rename/move) stripped the leading slash from image `src` attributes — breaking frontend and backend rendering.

### Root cause

TYPO3 v13's `File::getPublicUrl()` returns a site-root-relative path **without** a leading slash (e.g. `fileadmin/image.jpg`) for the Local driver, while the RTE stores the src **with** a leading slash (e.g. `/fileadmin/image.jpg`). Both components did naive string comparisons:

- **Validator:** Records with stored `/fileadmin/x` were falsely flagged as `SrcMismatch` when `getPublicUrl()` returned `fileadmin/x`. All fix paths (`ProcessedImageSrc`, `SrcMismatch`, `BrokenSrc`) wrote the slashless form.
- **Listener:** File rename/move events wrote the slashless `getPublicUrl()` directly into the src attribute. Also, stored `/fileadmin/current.jpg` was treated as different from `fileadmin/current.jpg`, triggering unnecessary rewrites.

### Fix

Both `RteImageReferenceValidator` and `UpdateImageReferences` now:
- Normalize `getPublicUrl()` to site-root-absolute form with leading slash via `normalizePublicUrl()` (absolute URLs like `http://` and `//` pass through unchanged).
- Treat `/fileadmin/x` and `fileadmin/x` as equivalent in all comparisons.

### Tests

**Validator (commit 1):**
- 6 new unit tests + 1 new functional regression test
- Updated `RteImageValidationFixResult.csv` to expect leading-slash output

**Listener (commit 2):**
- 2 new unit tests (slashless normalization + equivalence no-op)
- Updated all 4 functional result fixtures to expect leading-slash output

### Verification

- 767 unit tests passing
- 160 functional tests passing
- PHPStan clean on both modified production files
- PHP-CS-Fixer, Rector, phplint all clean

## Test plan

- [x] Unit test suite passes (767 tests)
- [x] Functional test suite passes (160 tests)
- [x] PHPStan clean on modified production files
- [x] CS-fixer / Rector / phplint clean
- [ ] CI pipeline green on the PR