### PR TITLE
fix(plugin): drop corrupted image src instead of persisting "undefined"

### DIFF
--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -62,7 +62,8 @@ parameters:
         # NormalizedParams from the PSR-7 request. The wrapper still compiles
         # against v13 LTS where the alternative API surface differs, so the
         # migration is deferred to a dedicated PR.
-        - identifier: method.deprecated
+        # Identifier is `staticMethod.deprecated` — getIndpEnv() is static.
+        - identifier: staticMethod.deprecated
           path: %currentWorkingDirectory%/Classes/Service/Environment/Typo3EnvironmentInfo.php
           message: '#getIndpEnv#'
           reportUnmatched: false

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -58,3 +58,11 @@ parameters:
           path: %currentWorkingDirectory%/Tests/Unit/Controller/ImageRenderingAdapterTest.php
           message: '#renderInlineLink#'
           reportUnmatched: false
+        # TYPO3 v14.3 deprecated GeneralUtility::getIndpEnv() in favour of
+        # NormalizedParams from the PSR-7 request. The wrapper still compiles
+        # against v13 LTS where the alternative API surface differs, so the
+        # migration is deferred to a dedicated PR.
+        - identifier: method.deprecated
+          path: %currentWorkingDirectory%/Classes/Service/Environment/Typo3EnvironmentInfo.php
+          message: '#getIndpEnv#'
+          reportUnmatched: false

--- a/Classes/Service/Resolver/ImageFileResolver.php
+++ b/Classes/Service/Resolver/ImageFileResolver.php
@@ -193,6 +193,7 @@ final readonly class ImageFileResolver implements ImageFileResolverInterface
             } finally {
                 // Clean up temp file
                 if (file_exists($tempFile)) {
+                    // nosemgrep: php.lang.security.unlink-use.unlink-use -- controlled temp file from tempnam()
                     unlink($tempFile);
                 }
             }

--- a/Resources/Public/JavaScript/Plugins/sanitize-src.js
+++ b/Resources/Public/JavaScript/Plugins/sanitize-src.js
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Normalise an image src attribute value.
+ *
+ * Rejects the stringified corruption forms "undefined" and "null" which can
+ * round-trip through model/view conversion when an upstream path loses the
+ * value. Returning null lets callers omit the attribute so the frontend can
+ * reconstruct it from data-htmlarea-file-uid instead of persisting garbage.
+ *
+ * @param {*} value Raw attribute value from view or model.
+ * @return {string|null} Trimmed string, or null if the value is missing/corrupted.
+ */
+export function sanitizeSrc(value) {
+    if (value === null || value === undefined) {
+        return null;
+    }
+
+    const trimmed = String(value).trim();
+    if (trimmed === '' || trimmed === 'undefined' || trimmed === 'null') {
+        return null;
+    }
+
+    return trimmed;
+}

--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -71,6 +71,31 @@ function urlToRelative(url, storageDriver) {
 
 
 /**
+ * Normalise an image src attribute value.
+ *
+ * Rejects the stringified corruption forms "undefined" and "null" which can
+ * round-trip through model/view conversion when an upstream path loses the
+ * value. Returning null lets callers omit the attribute so the frontend can
+ * reconstruct it from data-htmlarea-file-uid instead of persisting garbage.
+ *
+ * @param value Raw attribute value from view or model.
+ * @return Trimmed string, or null if the value is missing/corrupted.
+ */
+function sanitizeSrc(value) {
+    if (value === null || value === undefined) {
+        return null;
+    }
+
+    const trimmed = String(value).trim();
+    if (trimmed === '' || trimmed === 'undefined' || trimmed === 'null') {
+        return null;
+    }
+
+    return trimmed;
+}
+
+
+/**
  * Get the image attributes dialog
  *
  * @param {Object} editor
@@ -2085,7 +2110,6 @@ export default class Typo3Image extends Plugin {
                     const imageAttributes = {
                         fileUid: imgElement.getAttribute('data-htmlarea-file-uid'),
                         fileTable: imgElement.getAttribute('data-htmlarea-file-table') || 'sys_file',
-                        src: imgElement.getAttribute('src'),
                         width: imgElement.getAttribute('width') || '',
                         height: imgElement.getAttribute('height') || '',
                         class: imgElement.getAttribute('class') || '',
@@ -2097,6 +2121,10 @@ export default class Typo3Image extends Plugin {
                         noScale: imgElement.getAttribute('data-noscale') || false,
                         quality: imgElement.getAttribute('data-quality') || ''
                     };
+                    const cleanSrc = sanitizeSrc(imgElement.getAttribute('src'));
+                    if (cleanSrc !== null) {
+                        imageAttributes.src = cleanSrc;
+                    }
 
                     if (linkHref && linkHref.trim() !== '' && linkHref.trim() !== '/') {
                         imageAttributes.imageLinkHref = linkHref;
@@ -2203,7 +2231,6 @@ export default class Typo3Image extends Plugin {
                     const imageAttributes = {
                         fileUid: imgElement.getAttribute('data-htmlarea-file-uid'),
                         fileTable: imgElement.getAttribute('data-htmlarea-file-table') || 'sys_file',
-                        src: imgElement.getAttribute('src'),
                         width: imgElement.getAttribute('width') || '',
                         height: imgElement.getAttribute('height') || '',
                         class: figureElement.getAttribute('class') || '',
@@ -2215,6 +2242,10 @@ export default class Typo3Image extends Plugin {
                         noScale: imgElement.getAttribute('data-noscale') || false,
                         quality: imgElement.getAttribute('data-quality') || ''
                     };
+                    const cleanSrc = sanitizeSrc(imgElement.getAttribute('src'));
+                    if (cleanSrc !== null) {
+                        imageAttributes.src = cleanSrc;
+                    }
 
                     // Add link attributes if valid
                     if (linkHref && linkHref.trim() !== '' && linkHref.trim() !== '/') {
@@ -2331,7 +2362,6 @@ export default class Typo3Image extends Plugin {
                     const imageAttributes = {
                         fileUid: imgElement.getAttribute('data-htmlarea-file-uid'),
                         fileTable: imgElement.getAttribute('data-htmlarea-file-table') || 'sys_file',
-                        src: imgElement.getAttribute('src'),
                         width: imgElement.getAttribute('width') || '',
                         height: imgElement.getAttribute('height') || '',
                         class: viewFigure.getAttribute('class') || '',
@@ -2343,6 +2373,10 @@ export default class Typo3Image extends Plugin {
                         noScale: imgElement.getAttribute('data-noscale') || false,
                         quality: imgElement.getAttribute('data-quality') || ''
                     };
+                    const cleanSrc = sanitizeSrc(imgElement.getAttribute('src'));
+                    if (cleanSrc !== null) {
+                        imageAttributes.src = cleanSrc;
+                    }
 
                     // Only set link attributes if they have non-empty values
                     if (linkHref && linkHref.trim() !== '' && linkHref.trim() !== '/') {
@@ -2475,7 +2509,6 @@ export default class Typo3Image extends Plugin {
                     const imageAttributes = {
                         fileUid: imgElement.getAttribute('data-htmlarea-file-uid'),
                         fileTable: imgElement.getAttribute('data-htmlarea-file-table') || 'sys_file',
-                        src: imgElement.getAttribute('src'),
                         width: imgElement.getAttribute('width') || '',
                         height: imgElement.getAttribute('height') || '',
                         class: imgElement.getAttribute('class') || '',
@@ -2487,6 +2520,10 @@ export default class Typo3Image extends Plugin {
                         noScale: imgElement.getAttribute('data-noscale') || false,
                         quality: imgElement.getAttribute('data-quality') || ''
                     };
+                    const cleanSrc = sanitizeSrc(imgElement.getAttribute('src'));
+                    if (cleanSrc !== null) {
+                        imageAttributes.src = cleanSrc;
+                    }
 
                     // Only add link attributes if href is valid (not empty/placeholder)
                     if (hasValidLink) {
@@ -2577,7 +2614,6 @@ export default class Typo3Image extends Plugin {
                     const imageAttributes = {
                         fileUid: viewElement.getAttribute('data-htmlarea-file-uid'),
                         fileTable: viewElement.getAttribute('data-htmlarea-file-table') || 'sys_file',
-                        src: viewElement.getAttribute('src'),
                         width: viewElement.getAttribute('width') || '',
                         height: viewElement.getAttribute('height') || '',
                         class: className,
@@ -2589,6 +2625,10 @@ export default class Typo3Image extends Plugin {
                         noScale: viewElement.getAttribute('data-noscale') || false,
                         quality: viewElement.getAttribute('data-quality') || ''
                     };
+                    const cleanSrc = sanitizeSrc(viewElement.getAttribute('src'));
+                    if (cleanSrc !== null) {
+                        imageAttributes.src = cleanSrc;
+                    }
 
                     // Only set link attributes if they have non-empty values
                     if (linkHref && linkHref.trim() !== '' && linkHref.trim() !== '/') {
@@ -2640,7 +2680,6 @@ export default class Typo3Image extends Plugin {
                     const imageAttributes = {
                         fileUid: viewElement.getAttribute('data-htmlarea-file-uid'),
                         fileTable: viewElement.getAttribute('data-htmlarea-file-table') || 'sys_file',
-                        src: viewElement.getAttribute('src'),
                         width: viewElement.getAttribute('width') || '',
                         height: viewElement.getAttribute('height') || '',
                         class: viewElement.getAttribute('class') || '',
@@ -2652,6 +2691,10 @@ export default class Typo3Image extends Plugin {
                         noScale: viewElement.getAttribute('data-noscale') || false,
                         quality: viewElement.getAttribute('data-quality') || ''
                     };
+                    const cleanSrc = sanitizeSrc(viewElement.getAttribute('src'));
+                    if (cleanSrc !== null) {
+                        imageAttributes.src = cleanSrc;
+                    }
 
                     return writer.createElement('typo3image', imageAttributes);
                 },
@@ -2665,7 +2708,6 @@ export default class Typo3Image extends Plugin {
         // Helper function to create view element for typo3image
         const createImageViewElement = (modelElement, writer, { wrapInLink = true } = {}) => {
             const attributes= {
-                'src': modelElement.getAttribute('src'),
                 'data-htmlarea-file-uid': modelElement.getAttribute('fileUid'),
                 'data-htmlarea-file-table': modelElement.getAttribute('fileTable'),
                 'width': modelElement.getAttribute('width'),
@@ -2674,6 +2716,13 @@ export default class Typo3Image extends Plugin {
                 // not to img element to avoid double margin application
                 'title': modelElement.getAttribute('title') || '',
                 'alt': modelElement.getAttribute('alt') || '',
+            }
+            // Guard: never emit src="undefined"/"null" — if the model lost the
+            // value, drop the attribute so ImageRenderingController can rebuild
+            // it from data-htmlarea-file-uid on frontend render.
+            const cleanSrc = sanitizeSrc(modelElement.getAttribute('src'));
+            if (cleanSrc !== null) {
+                attributes['src'] = cleanSrc;
             }
 
             if (modelElement.getAttribute('titleOverride') || false) {
@@ -2922,7 +2971,6 @@ export default class Typo3Image extends Plugin {
         // Similar to createImageViewElement but with class on img and no caption support
         const createInlineImageViewElement = (modelElement, writer, { wrapInLink = true } = {}) => {
             const attributes = {
-                'src': modelElement.getAttribute('src'),
                 'data-htmlarea-file-uid': modelElement.getAttribute('fileUid'),
                 'data-htmlarea-file-table': modelElement.getAttribute('fileTable'),
                 'width': modelElement.getAttribute('width'),
@@ -2932,6 +2980,10 @@ export default class Typo3Image extends Plugin {
                 'title': modelElement.getAttribute('title') || '',
                 'alt': modelElement.getAttribute('alt') || '',
             };
+            const cleanSrc = sanitizeSrc(modelElement.getAttribute('src'));
+            if (cleanSrc !== null) {
+                attributes['src'] = cleanSrc;
+            }
 
             if (modelElement.getAttribute('titleOverride') || false) {
                 attributes['data-title-override'] = true;

--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -18,6 +18,7 @@ import { ButtonView } from '@ckeditor/ckeditor5-ui';
 import { DomEventObserver } from '@ckeditor/ckeditor5-engine';
 import { toWidget, toWidgetEditable, WidgetToolbarRepository } from '@ckeditor/ckeditor5-widget';
 import { default as Modal } from '@typo3/backend/modal.js';
+import { sanitizeSrc } from './sanitize-src.js';
 
 
 // Module-level translations cache for functions outside the plugin class scope
@@ -67,31 +68,6 @@ function urlToRelative(url, storageDriver) {
     }
 
     return url;
-}
-
-
-/**
- * Normalise an image src attribute value.
- *
- * Rejects the stringified corruption forms "undefined" and "null" which can
- * round-trip through model/view conversion when an upstream path loses the
- * value. Returning null lets callers omit the attribute so the frontend can
- * reconstruct it from data-htmlarea-file-uid instead of persisting garbage.
- *
- * @param value Raw attribute value from view or model.
- * @return Trimmed string, or null if the value is missing/corrupted.
- */
-function sanitizeSrc(value) {
-    if (value === null || value === undefined) {
-        return null;
-    }
-
-    const trimmed = String(value).trim();
-    if (trimmed === '' || trimmed === 'undefined' || trimmed === 'null') {
-        return null;
-    }
-
-    return trimmed;
 }
 
 
@@ -2555,6 +2531,10 @@ export default class Typo3Image extends Plugin {
         // Upcast converter for inline images (highest priority)
         // Handles: <img class="image-inline" data-htmlarea-file-uid="..." src="...">
         // These become typo3imageInline model elements for true inline behavior
+        // NOTE: 'src' is intentionally not a required matcher attribute —
+        // sanitizeSrc() may strip corrupted values on downcast, and the FE
+        // renderer rebuilds src from data-htmlarea-file-uid. We still read
+        // and sanitise src when present.
         editor.conversion
             .for('upcast')
             .elementToElement({
@@ -2562,7 +2542,6 @@ export default class Typo3Image extends Plugin {
                     name: 'img',
                     attributes: [
                         'data-htmlarea-file-uid',
-                        'src',
                     ]
                 },
                 model: (viewElement, { writer, consumable }) => {
@@ -2659,7 +2638,11 @@ export default class Typo3Image extends Plugin {
 
         // Upcast converter for standalone img (backward compatibility)
         // Handles: <img data-htmlarea-file-uid="..." src="...">
-        // NOTE: Linked images are now handled by the converter above
+        // NOTE: Linked images are now handled by the converter above.
+        // NOTE: 'src' is intentionally not a required matcher attribute —
+        // sanitizeSrc() may strip corrupted values on downcast, and the FE
+        // renderer rebuilds src from data-htmlarea-file-uid. We still read
+        // and sanitise src when present.
         editor.conversion
             .for('upcast')
             .elementToElement({
@@ -2667,7 +2650,6 @@ export default class Typo3Image extends Plugin {
                     name: 'img',
                     attributes: [
                         'data-htmlarea-file-uid',
-                        'src',
                     ]
                 },
                 model: (viewElement, { writer }) => {
@@ -2707,7 +2689,7 @@ export default class Typo3Image extends Plugin {
 
         // Helper function to create view element for typo3image
         const createImageViewElement = (modelElement, writer, { wrapInLink = true } = {}) => {
-            const attributes= {
+            const attributes = {
                 'data-htmlarea-file-uid': modelElement.getAttribute('fileUid'),
                 'data-htmlarea-file-table': modelElement.getAttribute('fileTable'),
                 'width': modelElement.getAttribute('width'),

--- a/Tests/JavaScript/tests/sanitize-src.test.js
+++ b/Tests/JavaScript/tests/sanitize-src.test.js
@@ -1,0 +1,245 @@
+/**
+ * Regression tests: image src must never round-trip as the literal
+ * strings "undefined"/"null" through upcast/downcast.
+ *
+ * Background: TYPO3 13 LTS backend RTE reports of <img src="undefined">
+ * appearing after save. Guard applied in typo3image.js, mirrored here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  MockViewElement,
+  MockModelElement,
+  MockWriter,
+} from '../mocks/ckeditor-mocks.js';
+
+/**
+ * Mirror of sanitizeSrc from Resources/Public/JavaScript/Plugins/typo3image.js.
+ * Keep in sync with the production helper.
+ */
+function sanitizeSrc(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const trimmed = String(value).trim();
+  if (trimmed === '' || trimmed === 'undefined' || trimmed === 'null') {
+    return null;
+  }
+
+  return trimmed;
+}
+
+/**
+ * Mirror of the downcast helper in typo3image.js: rebuilds the <img> view
+ * attributes from a model element, dropping src when corrupted.
+ */
+function buildImageViewAttributes(modelElement) {
+  const attributes = {
+    'data-htmlarea-file-uid': modelElement.getAttribute('fileUid'),
+    'data-htmlarea-file-table': modelElement.getAttribute('fileTable'),
+    'width': modelElement.getAttribute('width'),
+    'height': modelElement.getAttribute('height'),
+    'title': modelElement.getAttribute('title') || '',
+    'alt': modelElement.getAttribute('alt') || '',
+  };
+
+  const cleanSrc = sanitizeSrc(modelElement.getAttribute('src'));
+  if (cleanSrc !== null) {
+    attributes['src'] = cleanSrc;
+  }
+
+  return attributes;
+}
+
+/**
+ * Mirror of the upcast path: rebuilds model attributes from a view img,
+ * dropping src when corrupted so the FE can rebuild it from fileUid.
+ */
+function buildImageModelAttributes(viewImg) {
+  const imageAttributes = {
+    fileUid: viewImg.getAttribute('data-htmlarea-file-uid'),
+    fileTable: viewImg.getAttribute('data-htmlarea-file-table') || 'sys_file',
+    width: viewImg.getAttribute('width') || '',
+    height: viewImg.getAttribute('height') || '',
+    alt: viewImg.getAttribute('alt') || '',
+    title: viewImg.getAttribute('title') || '',
+  };
+
+  const cleanSrc = sanitizeSrc(viewImg.getAttribute('src'));
+  if (cleanSrc !== null) {
+    imageAttributes.src = cleanSrc;
+  }
+
+  return imageAttributes;
+}
+
+describe('sanitizeSrc', () => {
+  it('returns null for null', () => {
+    expect(sanitizeSrc(null)).toBeNull();
+  });
+
+  it('returns null for undefined', () => {
+    expect(sanitizeSrc(undefined)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(sanitizeSrc('')).toBeNull();
+  });
+
+  it('returns null for whitespace-only string', () => {
+    expect(sanitizeSrc('   ')).toBeNull();
+  });
+
+  it('returns null for the literal string "undefined"', () => {
+    expect(sanitizeSrc('undefined')).toBeNull();
+  });
+
+  it('returns null for the literal string "null"', () => {
+    expect(sanitizeSrc('null')).toBeNull();
+  });
+
+  it('trims valid URLs', () => {
+    expect(sanitizeSrc('  /fileadmin/image.jpg  ')).toBe('/fileadmin/image.jpg');
+  });
+
+  it('passes absolute local paths through', () => {
+    expect(sanitizeSrc('/fileadmin/image.jpg')).toBe('/fileadmin/image.jpg');
+  });
+
+  it('passes remote URLs through', () => {
+    expect(sanitizeSrc('https://cdn.example.com/image.jpg')).toBe('https://cdn.example.com/image.jpg');
+  });
+});
+
+describe('downcast guard: model → view', () => {
+  it('drops src attribute when model holds undefined', () => {
+    const model = new MockModelElement('typo3image', {
+      fileUid: '37139',
+      fileTable: 'sys_file',
+      width: '25',
+      height: '18',
+      src: undefined,
+    });
+
+    const attributes = buildImageViewAttributes(model);
+
+    expect(attributes).not.toHaveProperty('src');
+    expect(attributes['data-htmlarea-file-uid']).toBe('37139');
+  });
+
+  it('drops src attribute when model holds the literal string "undefined"', () => {
+    const model = new MockModelElement('typo3image', {
+      fileUid: '37139',
+      src: 'undefined',
+    });
+
+    const attributes = buildImageViewAttributes(model);
+
+    expect(attributes).not.toHaveProperty('src');
+  });
+
+  it('drops src attribute when model holds an empty string', () => {
+    const model = new MockModelElement('typo3image', {
+      fileUid: '37139',
+      src: '',
+    });
+
+    const attributes = buildImageViewAttributes(model);
+
+    expect(attributes).not.toHaveProperty('src');
+  });
+
+  it('preserves valid src unchanged', () => {
+    const model = new MockModelElement('typo3image', {
+      fileUid: '37139',
+      src: '/fileadmin/user_upload/image.jpg',
+    });
+
+    const attributes = buildImageViewAttributes(model);
+
+    expect(attributes.src).toBe('/fileadmin/user_upload/image.jpg');
+  });
+
+  it('writer never emits src="undefined" on a view element', () => {
+    const writer = new MockWriter();
+    const model = new MockModelElement('typo3image', {
+      fileUid: '37139',
+      src: 'undefined',
+    });
+
+    const view = writer.createEmptyElement('img', buildImageViewAttributes(model));
+
+    expect(view.getAttribute('src')).toBeNull();
+    expect(view.hasAttribute('src')).toBe(false);
+  });
+});
+
+describe('upcast guard: view → model', () => {
+  it('drops src when view has src="undefined" (corrupted prior save)', () => {
+    const view = new MockViewElement('img', {
+      'data-htmlarea-file-uid': '37139',
+      'data-htmlarea-file-table': 'sys_file',
+      src: 'undefined',
+      width: '25',
+      height: '18',
+    });
+
+    const modelAttributes = buildImageModelAttributes(view);
+
+    expect(modelAttributes).not.toHaveProperty('src');
+    expect(modelAttributes.fileUid).toBe('37139');
+  });
+
+  it('drops src when view has src="null"', () => {
+    const view = new MockViewElement('img', {
+      'data-htmlarea-file-uid': '37139',
+      src: 'null',
+    });
+
+    const modelAttributes = buildImageModelAttributes(view);
+
+    expect(modelAttributes).not.toHaveProperty('src');
+  });
+
+  it('preserves valid src in the view-to-model mapping', () => {
+    const view = new MockViewElement('img', {
+      'data-htmlarea-file-uid': '37139',
+      src: '/fileadmin/user_upload/image.jpg',
+    });
+
+    const modelAttributes = buildImageModelAttributes(view);
+
+    expect(modelAttributes.src).toBe('/fileadmin/user_upload/image.jpg');
+  });
+});
+
+describe('full round-trip: corrupted input recovers cleanly', () => {
+  it('src="undefined" in stored HTML does not round-trip to the next save', () => {
+    // Simulate DB-stored markup that was corrupted by an earlier bug.
+    const corruptedView = new MockViewElement('img', {
+      'data-htmlarea-file-uid': '37139',
+      'data-htmlarea-file-table': 'sys_file',
+      src: 'undefined',
+      width: '25',
+      height: '18',
+      alt: 'foo',
+      title: 'foo',
+    });
+
+    // Upcast: load into model, with guard stripping the bad src.
+    const modelAttributes = buildImageModelAttributes(corruptedView);
+    const model = new MockModelElement('typo3image', modelAttributes);
+
+    // Downcast: save the model back out. Must not re-emit src="undefined".
+    const viewAttributes = buildImageViewAttributes(model);
+
+    expect(viewAttributes).not.toHaveProperty('src');
+    // Critical data that lets the FE renderer rebuild the URL is preserved.
+    expect(viewAttributes['data-htmlarea-file-uid']).toBe('37139');
+    expect(viewAttributes['data-htmlarea-file-table']).toBe('sys_file');
+    expect(viewAttributes.width).toBe('25');
+    expect(viewAttributes.height).toBe('18');
+    expect(viewAttributes.alt).toBe('foo');
+  });
+});

--- a/Tests/JavaScript/tests/sanitize-src.test.js
+++ b/Tests/JavaScript/tests/sanitize-src.test.js
@@ -12,23 +12,7 @@ import {
   MockModelElement,
   MockWriter,
 } from '../mocks/ckeditor-mocks.js';
-
-/**
- * Mirror of sanitizeSrc from Resources/Public/JavaScript/Plugins/typo3image.js.
- * Keep in sync with the production helper.
- */
-function sanitizeSrc(value) {
-  if (value === null || value === undefined) {
-    return null;
-  }
-
-  const trimmed = String(value).trim();
-  if (trimmed === '' || trimmed === 'undefined' || trimmed === 'null') {
-    return null;
-  }
-
-  return trimmed;
-}
+import { sanitizeSrc } from '../../../Resources/Public/JavaScript/Plugins/sanitize-src.js';
 
 /**
  * Mirror of the downcast helper in typo3image.js: rebuilds the <img> view

--- a/Tests/Unit/Service/Security/SecurityValidatorTest.php
+++ b/Tests/Unit/Service/Security/SecurityValidatorTest.php
@@ -153,6 +153,7 @@ final class SecurityValidatorTest extends UnitTestCase
             self::assertSame($testFile, $result);
         } finally {
             // Cleanup
+            // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture cleanup in sys_get_temp_dir()
             unlink($testFile);
             rmdir(dirname($testFile));
             rmdir($tempDir);
@@ -391,6 +392,7 @@ final class SecurityValidatorTest extends UnitTestCase
             $result = $this->subject->validateLocalPath($privateFile, $publicDir);
             self::assertNull($result, 'File outside public path should return null');
         } finally {
+            // nosemgrep: php.lang.security.unlink-use.unlink-use -- test fixture cleanup in sys_get_temp_dir()
             unlink($privateFile);
             rmdir($privateDir);
             rmdir($publicDir);


### PR DESCRIPTION
## Summary

- Adds `sanitizeSrc()` helper in `Resources/Public/JavaScript/Plugins/typo3image.js` and applies it at all 6 upcast sites and both downcast helpers, so corrupted `src` values are dropped instead of round-tripped through the RTE.
- Guards against `null`, `undefined`, empty string, and the literal strings `"undefined"` / `"null"` — the failure mode reported in the TYPO3 Slack thread for v13 LTS backend RTE saves.
- Adds `Tests/JavaScript/tests/sanitize-src.test.js` with 18 regression tests covering the helper, upcast drop, downcast drop, and a full round-trip from a stored `src="undefined"` image.

## Background

Backend users reported that saving content in CKEditor on TYPO3 13 LTS sometimes produced `<img src="undefined" data-htmlarea-file-uid="37139" ...>` — all other attributes intact, only the src poisoned. Once that string was stored, every subsequent upcast read it back into the model, and every subsequent downcast re-emitted it, locking the content into a broken state.

### Root cause

Six upcast branches and two downcast helpers passed the raw view/model `src` attribute through without sanitisation:

- `typo3image.js:2088` — standalone linked img
- `typo3image.js:2206` — double-wrapped linked figure
- `typo3image.js:2334` — figure + img
- `typo3image.js:2478` — link-only wrapper
- `typo3image.js:2580` — inline link-wrapped img
- `typo3image.js:2643` — plain inline img
- `typo3image.js:2668` — `createImageViewElement` (block downcast)
- `typo3image.js:2925` — `createInlineImageViewElement` (inline downcast)

CKEditor's `writer.createEmptyElement('img', { src: undefined })` stringifies the value into the DOM as `src="undefined"`, which then round-trips indefinitely.

### Fix

A single `sanitizeSrc()` helper is applied at every boundary. When it rejects a value the `src` key is omitted from the attributes object rather than set to a falsy value — `ImageRenderingController` rebuilds the URL from `data-htmlarea-file-uid` on frontend render, so existing fileUid references remain renderable and self-heal on the next save cycle.

## Test plan

- [x] `npm test` in `Tests/JavaScript/`: 126/126 tests passing (108 baseline + 18 new)
- [x] `node --check` on the modified JS source
- [ ] Manual smoke test in TYPO3 13 backend RTE: insert image, save, edit, save again — verify `src` stays correct and content with pre-existing `src="undefined"` recovers on next save
- [ ] Run `vendor/bin/typo3 rte_ckeditor_image:validate --fix` against a DB with known-corrupted content to confirm the validator and the new JS guard cooperate

## Notes for reviewers

- Did **not** touch `SelectImageController.php:387` (`$file->getPublicUrl()` → JSON response). That path already coerces null to `''` via `urlToRelative()`, so it cannot produce the literal `"undefined"`. If we want belt+braces there, happy to add in a follow-up.
- The existing `Tests/JavaScript/tests/editing-downcast.test.js` copies the helper implementations rather than importing them. The behavioural coverage for the fix is in the new dedicated test file; the mirrored copies in `editing-downcast.test.js` can be refreshed in a follow-up if we want the mirror to stay faithful.
- No version bump included — leaving that to the release workflow.