### PR TITLE
feat(validator): skip out-of-scope src origins by default

### DIFF
--- a/Classes/Command/ValidateImageReferencesCommand.php
+++ b/Classes/Command/ValidateImageReferencesCommand.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\RteCKEditorImage\Command;
 
+use Netresearch\RteCKEditorImage\Dto\SrcOrigin;
 use Netresearch\RteCKEditorImage\Dto\ValidationResult;
 use Netresearch\RteCKEditorImage\Service\RteImageReferenceValidator;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -59,6 +60,16 @@ class ValidateImageReferencesCommand extends Command
             InputOption::VALUE_NONE,
             'Explicitly request dry-run mode (default behavior)',
         );
+        $this->addOption(
+            'include',
+            null,
+            InputOption::VALUE_REQUIRED,
+            sprintf(
+                'Comma-separated origins that are skipped by default but should be reported: %s. '
+                . 'Use "all" to disable all skipping.',
+                implode(', ', array_map(static fn (SrcOrigin $o): string => $o->value, SrcOrigin::defaultSkipSet())),
+            ),
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -78,7 +89,9 @@ class ValidateImageReferencesCommand extends Command
             $io->note('Limiting scan to table: ' . $limitToTable);
         }
 
-        $result = $this->validator->validate($limitToTable);
+        $includeOrigins = $this->parseIncludeOption($input->getOption('include'), $io);
+
+        $result = $this->validator->validate($limitToTable, $includeOrigins);
 
         $this->renderSummary($io, $result);
 
@@ -105,12 +118,65 @@ class ValidateImageReferencesCommand extends Command
 
     private function renderSummary(SymfonyStyle $io, ValidationResult $result): void
     {
-        $io->definitionList(
+        $definitions = [
             ['Scanned records' => (string) $result->getScannedRecords()],
             ['Scanned images'   => (string) $result->getScannedImages()],
             ['Issues found'     => (string) count($result->getIssues())],
             ['Affected records' => (string) $result->getAffectedRecords()],
-        );
+        ];
+
+        $skipped = $result->getSkippedByOrigin();
+        if ($skipped !== []) {
+            $parts = [];
+            foreach ($skipped as $origin => $count) {
+                $parts[] = sprintf('%d %s', $count, $origin);
+            }
+            $definitions[] = [
+                'Skipped (out of scope)' => sprintf('%d total (%s)', $result->getSkippedTotal(), implode(', ', $parts)),
+            ];
+        }
+
+        $io->definitionList(...$definitions);
+    }
+
+    /**
+     * @param mixed $rawInclude
+     *
+     * @return list<SrcOrigin>
+     */
+    private function parseIncludeOption(mixed $rawInclude, SymfonyStyle $io): array
+    {
+        if (!is_string($rawInclude) || trim($rawInclude) === '') {
+            return [];
+        }
+
+        $tokens = array_filter(array_map('trim', explode(',', $rawInclude)), static fn (string $t): bool => $t !== '');
+
+        if (in_array('all', $tokens, true)) {
+            return SrcOrigin::defaultSkipSet();
+        }
+
+        $origins  = [];
+        $skipSet  = SrcOrigin::defaultSkipSet();
+        $knownMap = [];
+        foreach ($skipSet as $origin) {
+            $knownMap[$origin->value] = $origin;
+        }
+
+        foreach ($tokens as $token) {
+            if (isset($knownMap[$token])) {
+                $origins[] = $knownMap[$token];
+                continue;
+            }
+
+            $io->warning(sprintf(
+                'Unknown --include value "%s". Allowed: %s, all.',
+                $token,
+                implode(', ', array_keys($knownMap)),
+            ));
+        }
+
+        return array_values(array_unique($origins, SORT_REGULAR));
     }
 
     private function renderIssueTable(SymfonyStyle $io, OutputInterface $output, ValidationResult $result): void

--- a/Classes/Command/ValidateImageReferencesCommand.php
+++ b/Classes/Command/ValidateImageReferencesCommand.php
@@ -91,7 +91,11 @@ class ValidateImageReferencesCommand extends Command
 
         $includeOrigins = $this->parseIncludeOption($input->getOption('include'), $io);
 
-        $result = $this->validator->validate($limitToTable, $includeOrigins);
+        // Only pass $includeOrigins when non-empty so existing mocks/subclasses
+        // that still expect validate($limitToTable) arity keep working.
+        $result = $includeOrigins === []
+            ? $this->validator->validate($limitToTable)
+            : $this->validator->validate($limitToTable, $includeOrigins);
 
         $this->renderSummary($io, $result);
 
@@ -131,6 +135,7 @@ class ValidateImageReferencesCommand extends Command
             foreach ($skipped as $origin => $count) {
                 $parts[] = sprintf('%d %s', $count, $origin);
             }
+
             $definitions[] = [
                 'Skipped (out of scope)' => sprintf('%d total (%s)', $result->getSkippedTotal(), implode(', ', $parts)),
             ];
@@ -150,7 +155,7 @@ class ValidateImageReferencesCommand extends Command
             return [];
         }
 
-        $tokens = array_filter(array_map('trim', explode(',', $rawInclude)), static fn (string $t): bool => $t !== '');
+        $tokens = array_filter(array_map(trim(...), explode(',', $rawInclude)), static fn (string $t): bool => $t !== '');
 
         if (in_array('all', $tokens, true)) {
             return SrcOrigin::defaultSkipSet();

--- a/Classes/Dto/SrcOrigin.php
+++ b/Classes/Dto/SrcOrigin.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\RteCKEditorImage\Dto;
+
+/**
+ * Classification of an <img src=""> value encountered in RTE content.
+ *
+ * The validator uses this to filter out false positives for references the
+ * command cannot fix — external URLs, inline data URIs, legacy extension
+ * paths and secure-download URLs are all reported as "missing file uid"
+ * under naive scanning but none of them are FAL-backed.
+ */
+enum SrcOrigin: string
+{
+    /** Absolute http/https URL — external to FAL regardless of host. */
+    case ExternalUrl = 'external';
+
+    /** Inline data: URI (data:image/jpeg;base64,…). */
+    case DataUri = 'data';
+
+    /** Legacy hardcoded path under typo3conf/ext/ (no FAL mapping possible). */
+    case LegacyExtensionPath = 'legacy';
+
+    /** /securedl/ TYPO3 secure download URL (not a plain FAL public URL). */
+    case SecureDownload = 'securedl';
+
+    /** _processed_ variant URL (resized/cropped output, not a canonical src). */
+    case ProcessedVariant = 'processed';
+
+    /** Site-root-relative or plausibly local FAL path. */
+    case LocalFal = 'local';
+
+    /** Missing/empty src or unrecognised form. */
+    case Unknown = 'unknown';
+
+    /**
+     * Default skip set: categories the validator cannot meaningfully fix.
+     *
+     * @return list<self>
+     */
+    public static function defaultSkipSet(): array
+    {
+        return [
+            self::ExternalUrl,
+            self::DataUri,
+            self::LegacyExtensionPath,
+            self::SecureDownload,
+        ];
+    }
+}

--- a/Classes/Dto/ValidationResult.php
+++ b/Classes/Dto/ValidationResult.php
@@ -24,10 +24,19 @@ final class ValidationResult
     /** @var array<string, true> table:uid keys of affected records */
     private array $affectedRecordKeys = [];
 
+    /** @var array<string, int> origin value => skipped count */
+    private array $skippedByOrigin = [];
+
     public function addIssue(ValidationIssue $issue): void
     {
         $this->issues[]                                              = $issue;
         $this->affectedRecordKeys[$issue->table . ':' . $issue->uid] = true;
+    }
+
+    public function recordSkipped(SrcOrigin $origin): void
+    {
+        $key                         = $origin->value;
+        $this->skippedByOrigin[$key] = ($this->skippedByOrigin[$key] ?? 0) + 1;
     }
 
     public function incrementScannedRecords(): void
@@ -38,6 +47,19 @@ final class ValidationResult
     public function incrementScannedImages(): void
     {
         ++$this->scannedImages;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function getSkippedByOrigin(): array
+    {
+        return $this->skippedByOrigin;
+    }
+
+    public function getSkippedTotal(): int
+    {
+        return array_sum($this->skippedByOrigin);
     }
 
     public function hasIssues(): bool

--- a/Classes/Service/RteImageReferenceValidator.php
+++ b/Classes/Service/RteImageReferenceValidator.php
@@ -40,10 +40,10 @@ class RteImageReferenceValidator
     /**
      * Scan all RTE fields and return validation issues.
      *
-     * @param string|null  $limitToTable   Restrict scan to a specific table (e.g. 'tt_content')
-     * @param list<SrcOrigin> $includeOrigins Origins that would otherwise be
-     *                                       skipped ({@see SrcOrigin::defaultSkipSet()}) but
-     *                                       should still produce MissingFileUid issues.
+     * @param string|null     $limitToTable   Restrict scan to a specific table (e.g. 'tt_content')
+     * @param list<SrcOrigin> $includeOrigins origins that would otherwise be
+     *                                        skipped ({@see SrcOrigin::defaultSkipSet()}) but
+     *                                        should still produce MissingFileUid issues
      */
     public function validate(?string $limitToTable = null, array $includeOrigins = []): ValidationResult
     {
@@ -173,8 +173,8 @@ class RteImageReferenceValidator
     /**
      * Validate HTML content and return issues found.
      *
-     * @param list<SrcOrigin> $includeOrigins Origins that would otherwise be
-     *                                        skipped but should still be reported.
+     * @param list<SrcOrigin> $includeOrigins origins that would otherwise be
+     *                                        skipped but should still be reported
      *
      * @return list<ValidationIssue>
      */
@@ -231,8 +231,8 @@ class RteImageReferenceValidator
     /**
      * Detect what kind of issue (if any) exists for a single img tag.
      *
-     * @param list<SrcOrigin> $includeOrigins Origins reported even if in the
-     *                                        default skip set.
+     * @param list<SrcOrigin> $includeOrigins origins reported even if in the
+     *                                        default skip set
      */
     private function detectIssue(
         ?string $src,

--- a/Classes/Service/RteImageReferenceValidator.php
+++ b/Classes/Service/RteImageReferenceValidator.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\RteCKEditorImage\Service;
 
+use Netresearch\RteCKEditorImage\Dto\SrcOrigin;
 use Netresearch\RteCKEditorImage\Dto\ValidationIssue;
 use Netresearch\RteCKEditorImage\Dto\ValidationIssueType;
 use Netresearch\RteCKEditorImage\Dto\ValidationResult;
@@ -33,14 +34,18 @@ class RteImageReferenceValidator
         private readonly ConnectionPool $connectionPool,
         private readonly ResourceFactory $resourceFactory,
         private readonly HtmlParser $htmlParser,
+        private readonly SrcOriginClassifier $srcOriginClassifier = new SrcOriginClassifier(),
     ) {}
 
     /**
      * Scan all RTE fields and return validation issues.
      *
-     * @param string|null $limitToTable Restrict scan to a specific table (e.g. 'tt_content')
+     * @param string|null  $limitToTable   Restrict scan to a specific table (e.g. 'tt_content')
+     * @param list<SrcOrigin> $includeOrigins Origins that would otherwise be
+     *                                       skipped ({@see SrcOrigin::defaultSkipSet()}) but
+     *                                       should still produce MissingFileUid issues.
      */
-    public function validate(?string $limitToTable = null): ValidationResult
+    public function validate(?string $limitToTable = null, array $includeOrigins = []): ValidationResult
     {
         $result  = new ValidationResult();
         $records = $this->findAffectedRecords($limitToTable);
@@ -75,7 +80,7 @@ class RteImageReferenceValidator
             }
 
             $result->incrementScannedRecords();
-            $issues = $this->validateHtml($currentValue, $tableName, $recuid, $field, $result);
+            $issues = $this->validateHtml($currentValue, $tableName, $recuid, $field, $result, $includeOrigins);
 
             foreach ($issues as $issue) {
                 $result->addIssue($issue);
@@ -168,6 +173,9 @@ class RteImageReferenceValidator
     /**
      * Validate HTML content and return issues found.
      *
+     * @param list<SrcOrigin> $includeOrigins Origins that would otherwise be
+     *                                        skipped but should still be reported.
+     *
      * @return list<ValidationIssue>
      */
     public function validateHtml(
@@ -176,6 +184,7 @@ class RteImageReferenceValidator
         int $uid,
         string $field,
         ?ValidationResult $result = null,
+        array $includeOrigins = [],
     ): array {
         $splitContent = $this->htmlParser->splitTags('img', $html);
         $issues       = [];
@@ -204,7 +213,7 @@ class RteImageReferenceValidator
             $src     = $this->getStringAttribute($tagAttributes, 'src');
             $fileUid = $this->getStringAttribute($tagAttributes, 'data-htmlarea-file-uid');
 
-            $issue = $this->detectIssue($src, $fileUid, $table, $uid, $field, $imgIndex);
+            $issue = $this->detectIssue($src, $fileUid, $table, $uid, $field, $imgIndex, $result, $includeOrigins);
 
             if ($issue instanceof ValidationIssue) {
                 $issues[] = $issue;
@@ -221,6 +230,9 @@ class RteImageReferenceValidator
 
     /**
      * Detect what kind of issue (if any) exists for a single img tag.
+     *
+     * @param list<SrcOrigin> $includeOrigins Origins reported even if in the
+     *                                        default skip set.
      */
     private function detectIssue(
         ?string $src,
@@ -229,9 +241,19 @@ class RteImageReferenceValidator
         int $uid,
         string $field,
         int $imgIndex,
+        ?ValidationResult $result = null,
+        array $includeOrigins = [],
     ): ?ValidationIssue {
         // Missing file-uid attribute
         if ($fileUidStr === null || $fileUidStr === '') {
+            $origin = $this->srcOriginClassifier->classify($src);
+
+            if ($this->shouldSkipOrigin($origin, $includeOrigins)) {
+                $result?->recordSkipped($origin);
+
+                return null;
+            }
+
             return new ValidationIssue(
                 type: ValidationIssueType::MissingFileUid,
                 table: $table,
@@ -319,6 +341,23 @@ class RteImageReferenceValidator
         }
 
         return null;
+    }
+
+    /**
+     * Decide whether a src origin should be suppressed from reporting.
+     *
+     * Default-skipped origins ({@see SrcOrigin::defaultSkipSet()}) can be
+     * re-enabled by listing them in $includeOrigins.
+     *
+     * @param list<SrcOrigin> $includeOrigins
+     */
+    private function shouldSkipOrigin(SrcOrigin $origin, array $includeOrigins): bool
+    {
+        if (!in_array($origin, SrcOrigin::defaultSkipSet(), true)) {
+            return false;
+        }
+
+        return !in_array($origin, $includeOrigins, true);
     }
 
     /**

--- a/Classes/Service/SrcOriginClassifier.php
+++ b/Classes/Service/SrcOriginClassifier.php
@@ -32,7 +32,13 @@ final class SrcOriginClassifier
             return SrcOrigin::DataUri;
         }
 
-        if (str_starts_with($trimmed, 'http://') || str_starts_with($trimmed, 'https://')) {
+        // Absolute http(s) URLs and protocol-relative URLs (//cdn.example.com/…)
+        // are all external references — no FAL mapping regardless of host.
+        if (
+            str_starts_with($trimmed, 'http://')
+            || str_starts_with($trimmed, 'https://')
+            || str_starts_with($trimmed, '//')
+        ) {
             return SrcOrigin::ExternalUrl;
         }
 

--- a/Classes/Service/SrcOriginClassifier.php
+++ b/Classes/Service/SrcOriginClassifier.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\RteCKEditorImage\Service;
+
+use Netresearch\RteCKEditorImage\Dto\SrcOrigin;
+
+/**
+ * Classifies an <img src=""> value into a {@see SrcOrigin}.
+ *
+ * Pure, stateless, no HTTP — pattern-matching only. The validator uses this
+ * to filter out references it cannot fix (external URLs, data URIs, legacy
+ * paths, secure-download URLs) from its "missing file uid" report.
+ */
+final class SrcOriginClassifier
+{
+    public function classify(?string $src): SrcOrigin
+    {
+        if ($src === null || trim($src) === '') {
+            return SrcOrigin::Unknown;
+        }
+
+        $trimmed = ltrim($src);
+
+        if (str_starts_with($trimmed, 'data:')) {
+            return SrcOrigin::DataUri;
+        }
+
+        if (str_starts_with($trimmed, 'http://') || str_starts_with($trimmed, 'https://')) {
+            return SrcOrigin::ExternalUrl;
+        }
+
+        // Legacy extension paths are commonly stored without a leading slash
+        // (typo3conf/ext/...) or with one (/typo3conf/ext/...).
+        if (preg_match('#^/?typo3conf/ext/#', $trimmed) === 1) {
+            return SrcOrigin::LegacyExtensionPath;
+        }
+
+        // Secure downloads may appear mid-path (e.g. /fileadmin/securedl/...).
+        if (str_contains($trimmed, '/securedl/')) {
+            return SrcOrigin::SecureDownload;
+        }
+
+        if (str_contains($trimmed, '/_processed_/')) {
+            return SrcOrigin::ProcessedVariant;
+        }
+
+        if (str_starts_with($trimmed, '/') || str_starts_with($trimmed, 'fileadmin/')) {
+            return SrcOrigin::LocalFal;
+        }
+
+        return SrcOrigin::Unknown;
+    }
+}

--- a/Tests/Unit/Service/RteImageReferenceValidatorTest.php
+++ b/Tests/Unit/Service/RteImageReferenceValidatorTest.php
@@ -130,6 +130,65 @@ class RteImageReferenceValidatorTest extends TestCase
     }
 
     #[Test]
+    public function skipsExternalDataLegacyAndSecuredlByDefault(): void
+    {
+        $html = '<p>'
+            . '<img src="https://typo3.github.io/TYPO3.Icons/images/actions-add.svg" />'
+            . '<img src="data:image/jpeg;base64,/9j/4AAQ" />'
+            . '<img src="/typo3conf/ext/foo/bar.png" />'
+            . '<img src="/securedl/sdl-eyJ0eXAi" />'
+            . '</p>';
+
+        $result = new ValidationResult();
+        $issues = $this->subject->validateHtml($html, 'tt_content', 1, 'bodytext', $result);
+
+        self::assertSame([], $issues);
+        self::assertSame(
+            [
+                'external' => 1,
+                'data'     => 1,
+                'legacy'   => 1,
+                'securedl' => 1,
+            ],
+            $result->getSkippedByOrigin(),
+        );
+        self::assertSame(4, $result->getSkippedTotal());
+    }
+
+    #[Test]
+    public function localFalMissingFileUidIsStillReported(): void
+    {
+        $html = '<p><img src="/fileadmin/processed_copy_paste.jpg" /></p>';
+
+        $result = new ValidationResult();
+        $issues = $this->subject->validateHtml($html, 'tt_content', 7, 'bodytext', $result);
+
+        self::assertCount(1, $issues);
+        self::assertSame(ValidationIssueType::MissingFileUid, $issues[0]->type);
+        self::assertSame([], $result->getSkippedByOrigin());
+    }
+
+    #[Test]
+    public function includeOriginOverridesDefaultSkip(): void
+    {
+        $html = '<p><img src="https://external.example.com/foo.jpg" /></p>';
+
+        $result = new ValidationResult();
+        $issues = $this->subject->validateHtml(
+            $html,
+            'tt_content',
+            1,
+            'bodytext',
+            $result,
+            [\Netresearch\RteCKEditorImage\Dto\SrcOrigin::ExternalUrl],
+        );
+
+        self::assertCount(1, $issues);
+        self::assertSame(ValidationIssueType::MissingFileUid, $issues[0]->type);
+        self::assertSame([], $result->getSkippedByOrigin());
+    }
+
+    #[Test]
     public function detectsOrphanedFileUid(): void
     {
         $this->resourceFactory

--- a/Tests/Unit/Service/SrcOriginClassifierTest.php
+++ b/Tests/Unit/Service/SrcOriginClassifierTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\RteCKEditorImage\Tests\Unit\Service;
+
+use Netresearch\RteCKEditorImage\Dto\SrcOrigin;
+use Netresearch\RteCKEditorImage\Service\SrcOriginClassifier;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SrcOriginClassifier::class)]
+#[CoversClass(SrcOrigin::class)]
+final class SrcOriginClassifierTest extends TestCase
+{
+    private SrcOriginClassifier $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = new SrcOriginClassifier();
+    }
+
+    /**
+     * @return iterable<string, array{0: ?string, 1: SrcOrigin}>
+     */
+    public static function classificationProvider(): iterable
+    {
+        yield 'null src'                 => [null, SrcOrigin::Unknown];
+        yield 'empty string'             => ['', SrcOrigin::Unknown];
+        yield 'whitespace only'          => ['   ', SrcOrigin::Unknown];
+        yield 'https URL'                => ['https://typo3.github.io/TYPO3.Icons/images/a.svg', SrcOrigin::ExternalUrl];
+        yield 'http URL'                 => ['http://example.com/foo.jpg', SrcOrigin::ExternalUrl];
+        yield 'data URI jpeg'            => ['data:image/jpeg;base64,/9j/4AAQSkZ', SrcOrigin::DataUri];
+        yield 'data URI svg'             => ['data:image/svg+xml;utf8,<svg/>', SrcOrigin::DataUri];
+        yield 'legacy ext path absolute' => ['/typo3conf/ext/foo/bar.png', SrcOrigin::LegacyExtensionPath];
+        yield 'legacy ext path relative' => ['typo3conf/ext/foo/bar.png', SrcOrigin::LegacyExtensionPath];
+        yield 'secure download leading'  => ['/securedl/sdl-eyJ0eXAi', SrcOrigin::SecureDownload];
+        yield 'secure download nested'   => ['/fileadmin/securedl/sdl-X', SrcOrigin::SecureDownload];
+        yield 'processed variant'        => ['/fileadmin/_processed_/a/b/csm_image_1234.jpg', SrcOrigin::ProcessedVariant];
+        yield 'local fal absolute'       => ['/fileadmin/user_upload/image.jpg', SrcOrigin::LocalFal];
+        yield 'local fal relative'       => ['fileadmin/user_upload/image.jpg', SrcOrigin::LocalFal];
+        yield 'unrecognised form'        => ['something-weird-no-slash.png', SrcOrigin::Unknown];
+    }
+
+    #[Test]
+    #[DataProvider('classificationProvider')]
+    public function classifyMapsSrcToOrigin(?string $src, SrcOrigin $expected): void
+    {
+        self::assertSame($expected, $this->subject->classify($src));
+    }
+
+    #[Test]
+    public function defaultSkipSetContainsTheOutOfScopeCategories(): void
+    {
+        self::assertSame(
+            [
+                SrcOrigin::ExternalUrl,
+                SrcOrigin::DataUri,
+                SrcOrigin::LegacyExtensionPath,
+                SrcOrigin::SecureDownload,
+            ],
+            SrcOrigin::defaultSkipSet(),
+        );
+    }
+}

--- a/Tests/Unit/Service/SrcOriginClassifierTest.php
+++ b/Tests/Unit/Service/SrcOriginClassifierTest.php
@@ -33,21 +33,22 @@ final class SrcOriginClassifierTest extends TestCase
      */
     public static function classificationProvider(): iterable
     {
-        yield 'null src'                 => [null, SrcOrigin::Unknown];
-        yield 'empty string'             => ['', SrcOrigin::Unknown];
-        yield 'whitespace only'          => ['   ', SrcOrigin::Unknown];
-        yield 'https URL'                => ['https://typo3.github.io/TYPO3.Icons/images/a.svg', SrcOrigin::ExternalUrl];
-        yield 'http URL'                 => ['http://example.com/foo.jpg', SrcOrigin::ExternalUrl];
-        yield 'data URI jpeg'            => ['data:image/jpeg;base64,/9j/4AAQSkZ', SrcOrigin::DataUri];
-        yield 'data URI svg'             => ['data:image/svg+xml;utf8,<svg/>', SrcOrigin::DataUri];
+        yield 'null src' => [null, SrcOrigin::Unknown];
+        yield 'empty string' => ['', SrcOrigin::Unknown];
+        yield 'whitespace only' => ['   ', SrcOrigin::Unknown];
+        yield 'https URL' => ['https://typo3.github.io/TYPO3.Icons/images/a.svg', SrcOrigin::ExternalUrl];
+        yield 'http URL' => ['http://example.com/foo.jpg', SrcOrigin::ExternalUrl];
+        yield 'protocol-relative URL' => ['//cdn.example.com/foo.jpg', SrcOrigin::ExternalUrl];
+        yield 'data URI jpeg' => ['data:image/jpeg;base64,/9j/4AAQSkZ', SrcOrigin::DataUri];
+        yield 'data URI svg' => ['data:image/svg+xml;utf8,<svg/>', SrcOrigin::DataUri];
         yield 'legacy ext path absolute' => ['/typo3conf/ext/foo/bar.png', SrcOrigin::LegacyExtensionPath];
         yield 'legacy ext path relative' => ['typo3conf/ext/foo/bar.png', SrcOrigin::LegacyExtensionPath];
-        yield 'secure download leading'  => ['/securedl/sdl-eyJ0eXAi', SrcOrigin::SecureDownload];
-        yield 'secure download nested'   => ['/fileadmin/securedl/sdl-X', SrcOrigin::SecureDownload];
-        yield 'processed variant'        => ['/fileadmin/_processed_/a/b/csm_image_1234.jpg', SrcOrigin::ProcessedVariant];
-        yield 'local fal absolute'       => ['/fileadmin/user_upload/image.jpg', SrcOrigin::LocalFal];
-        yield 'local fal relative'       => ['fileadmin/user_upload/image.jpg', SrcOrigin::LocalFal];
-        yield 'unrecognised form'        => ['something-weird-no-slash.png', SrcOrigin::Unknown];
+        yield 'secure download leading' => ['/securedl/sdl-eyJ0eXAi', SrcOrigin::SecureDownload];
+        yield 'secure download nested' => ['/fileadmin/securedl/sdl-X', SrcOrigin::SecureDownload];
+        yield 'processed variant' => ['/fileadmin/_processed_/a/b/csm_image_1234.jpg', SrcOrigin::ProcessedVariant];
+        yield 'local fal absolute' => ['/fileadmin/user_upload/image.jpg', SrcOrigin::LocalFal];
+        yield 'local fal relative' => ['fileadmin/user_upload/image.jpg', SrcOrigin::LocalFal];
+        yield 'unrecognised form' => ['something-weird-no-slash.png', SrcOrigin::Unknown];
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Adds a `SrcOrigin` enum + `SrcOriginClassifier` service to classify `<img src>` values without any network calls.
- `rte_ckeditor_image:validate` now skips four categories by default: external URLs, inline `data:` URIs, legacy `typo3conf/ext/` paths, and `/securedl/` URLs — all cases where the validator cannot meaningfully fix the reference.
- `ValidationResult` tracks per-origin skip counts; the CLI summary reports them so skipping stays visible.
- New `--include=external,data,legacy,securedl` flag opts categories back in (`--include=all` disables all skipping).
- 14 new unit tests: classifier behaviour, skip/include round-trip, local-FAL not-skipped path.

## Background

After running the validator on real production content, the user reported that out of hundreds of `MissingFileUid` hits only ~10 were genuine (copy-pasted `/fileadmin/…` URLs from other RTEs). The rest were noise:

| Category | Example |
|----------|---------|
| External URL | `https://typo3.github.io/TYPO3.Icons/images/…` |
| Data URI | `data:image/jpeg;base64,/9j/4AAQ…` |
| Legacy ext path | `/typo3conf/ext/foo/bar.png` (dead for ~10 years) |
| Secure download | `/securedl/sdl-eyJ0eXAi…` (from a 6-week broken period) |

None of these are FAL-backed, so the validator cannot rewrite them. Reporting them just hides the real issues.

## Design

### Classifier (`Classes/Service/SrcOriginClassifier.php`)

Pure, stateless, string-pattern matching only. Rules:

- `ExternalUrl` — `http://` or `https://` prefix
- `DataUri` — `data:` prefix
- `LegacyExtensionPath` — `^/?typo3conf/ext/`
- `SecureDownload` — contains `/securedl/`
- `ProcessedVariant` — contains `/_processed_/`
- `LocalFal` — starts with `/` or `fileadmin/`
- `Unknown` — everything else

### Filter (`Classes/Service/RteImageReferenceValidator.php:260`)

Applied only in the `MissingFileUid` branch. Other issue types (OrphanedFileUid, SrcMismatch, ProcessedImageSrc, BrokenSrc, NestedLinkWrapper) already imply a FAL-resolvable fileUid, so no risk of filtering real problems.

### CLI (`Classes/Command/ValidateImageReferencesCommand.php`)

`--include=external,data` reports the listed categories but still skips the others. `--include=all` disables skipping entirely. The summary table gains a "Skipped (out of scope)" line when the counter is non-zero.

## Test plan

- [x] `.Build/bin/phpunit Tests/Unit` — 786 tests, 1828 assertions (14 new)
- [x] `node --check` on touched JS — unchanged from last PR
- [x] `npm test` in `Tests/JavaScript` — 126/126 still passing
- [x] Local PHPStan — only the pre-existing test `property.uninitialized` pattern (matches project-wide baseline)
- [ ] Run on the user's real DB: confirm only genuine `/fileadmin/…` `MissingFileUid` remain and the skip counts match the previous noise volume
- [ ] Run with `--include=external,data,legacy,securedl` and verify the old output reappears

## Notes for reviewers

- `SrcOriginClassifier` is deliberately pure string matching — no site-URL lookup, no `GeneralUtility::getIndpEnv` detour. Same-site absolute URLs (`https://site.example/fileadmin/x.jpg`) fall into `ExternalUrl` and therefore skipped. That is intentional: if someone stored an absolute external-style URL, they did it deliberately and the validator still can't rewrite it into a FAL reference.
- The `MissingFileUid` branch is the only site that applies the filter. Other branches require the `data-htmlarea-file-uid` attribute to be present and a FAL file to be resolvable, so false-positive cases cannot reach them.
- The classifier is constructed with a default value in the validator's constructor (`new SrcOriginClassifier()`) so existing DI wiring in extensions that instantiate the validator directly keeps working without Services.yaml changes.