### PR TITLE
chore: adopt release-typo3-extension orchestrator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   release:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/release.yml@main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/release-typo3-extension.yml@main
     permissions:
       contents: write
       id-token: write
@@ -17,11 +17,6 @@ jobs:
     with:
       archive-prefix: rte-ckeditor-image
       package-name: netresearch/rte-ckeditor-image
-
-  publish-to-ter:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
-    permissions:
-      contents: read
+      extension-key: rte_ckeditor_image
     secrets:
-      TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
       TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -1,0 +1,34 @@
+name: Republish
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to republish (e.g. "v1.2.3")'
+        required: true
+        type: string
+      target:
+        description: 'Which publish target(s) to re-run'
+        required: true
+        type: choice
+        options:
+          - all
+          - ter
+          - docs
+          - packagist
+        default: all
+
+permissions: {}
+
+jobs:
+  republish:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/republish.yml@main
+    permissions:
+      contents: read
+    with:
+      tag: ${{ inputs.tag }}
+      target: ${{ inputs.target }}
+      extension-key: rte_ckeditor_image
+      package-name: netresearch/rte-ckeditor-image
+    secrets:
+      TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "require-dev": {
         "bk2k/bootstrap-package": "^15.0 || ^16.0",
-        "netresearch/typo3-ci-workflows": "^1.0"
+        "netresearch/typo3-ci-workflows": "~1.2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Sweep PR — adopt the unified release orchestrator from [`netresearch/typo3-ci-workflows`](https://github.com/netresearch/typo3-ci-workflows/blob/main/.github/workflows/release-typo3-extension.yml), same pattern as pilot [netresearch/t3x-nr-passkeys-be#53](https://github.com/netresearch/t3x-nr-passkeys-be/pull/53).

## Changes
- `.github/workflows/release.yml`: thin caller of the orchestrator (single workflow run covers build + TER publish + Packagist verify + docs verify + atomic GitHub release).
- `.github/workflows/republish.yml`: new `workflow_dispatch` entry to manually re-run any subset of {TER, docs, Packagist} verification for an existing tag.
- `.github/workflows/ter-publish.yml`: deleted (superseded by `republish.yml`).

## Side effects (inherited from the orchestrator)
- TER listing Manual/Issues/Repository links are auto-synced on publish.
- docs.typo3.org render is verified via the upstream t3docs-ci-deploy run (authoritative; fails fast on render errors).
- Release body gets a Publication-status block citing TER, Packagist, docs URLs.

## Test plan
- [ ] CI on this PR passes.
- [ ] Next tag push runs the orchestrator end-to-end green.