### PR TITLE
chore(deps): pin TYPO3 v14 requirement to v14.3 LTS

### DIFF
--- a/.ddev/AGENTS.md
+++ b/.ddev/AGENTS.md
@@ -30,7 +30,7 @@ DDEV local development environment for multi-version TYPO3 testing. Supports v13
 | Command | Purpose |
 |---------|---------|
 | `ddev install-v13` | Install TYPO3 v13.4 LTS instance |
-| `ddev install-v14` | Install TYPO3 v14.0 instance |
+| `ddev install-v14` | Install TYPO3 v14.3 LTS instance |
 | `ddev install-all` | Install both v13 and v14 |
 
 ## Quick Start

--- a/.ddev/commands/web/install-v14
+++ b/.ddev/commands/web/install-v14
@@ -18,7 +18,9 @@ composer config repositories.$EXTENSION_KEY path ../../$EXTENSION_KEY -d /var/ww
 composer config --no-plugins allow-plugins.typo3/cms-composer-installers true -d /var/www/html/$VERSION
 composer config --no-plugins allow-plugins.typo3/class-alias-loader true -d /var/www/html/$VERSION
 composer req t3/cms:'^14.3' $PACKAGE_NAME:'*@dev' --no-progress -n -d /var/www/html/$VERSION
-composer req typo3/cms-extensionmanager typo3/cms-dashboard typo3/cms-reports --no-progress -n -d /var/www/html/$VERSION
+# Note: typo3/cms-extensionmanager, cms-dashboard, cms-reports are pulled in
+# transitively by the t3/cms metapackage (it `replace`s them) — no need to
+# require them separately here.
 composer req --dev typo3/cms-styleguide bk2k/bootstrap-package:'^16.0' --no-progress -n -d /var/www/html/$VERSION
 composer req friendsoftypo3/content-blocks:'^2.0' --no-progress -n -W -d /var/www/html/$VERSION
 

--- a/.ddev/commands/web/install-v14
+++ b/.ddev/commands/web/install-v14
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-## Description: Install TYPO3 14.0 with your extension
+## Description: Install TYPO3 14.3 LTS with your extension
 ## Usage: install-v14
 ## Example: ddev install-v14
 
@@ -17,9 +17,7 @@ composer config extra.typo3/cms.web-dir public -d /var/www/html/$VERSION
 composer config repositories.$EXTENSION_KEY path ../../$EXTENSION_KEY -d /var/www/html/$VERSION
 composer config --no-plugins allow-plugins.typo3/cms-composer-installers true -d /var/www/html/$VERSION
 composer config --no-plugins allow-plugins.typo3/class-alias-loader true -d /var/www/html/$VERSION
-# Note: t3/cms metapackage doesn't have v14 yet, so install components separately
-# First install the extension with TYPO3 core requirements
-composer req $PACKAGE_NAME:'*@dev' --no-progress -n -d /var/www/html/$VERSION
+composer req t3/cms:'^14.3' $PACKAGE_NAME:'*@dev' --no-progress -n -d /var/www/html/$VERSION
 composer req typo3/cms-extensionmanager typo3/cms-dashboard typo3/cms-reports --no-progress -n -d /var/www/html/$VERSION
 composer req --dev typo3/cms-styleguide bk2k/bootstrap-package:'^16.0' --no-progress -n -d /var/www/html/$VERSION
 composer req friendsoftypo3/content-blocks:'^2.0' --no-progress -n -W -d /var/www/html/$VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     with:
         php-versions: '["8.2","8.3","8.4","8.5"]'
-        typo3-versions: '["^13.4.21","^14.0"]'
+        typo3-versions: '["^13.4.21","^14.3"]'
         run-functional-tests: true
         typo3-packages: '["typo3/cms-core","typo3/cms-rte-ckeditor"]'
     secrets:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Handles image insertion, processing, rendering with captions, links, popups, qua
 - **Package**: `netresearch/rte-ckeditor-image` (Composer) / `rte_ckeditor_image` (TER)
 - **Namespace**: `Netresearch\RteCKEditorImage\`
 - **Repository**: [github.com/netresearch/t3x-rte_ckeditor_image](https://github.com/netresearch/t3x-rte_ckeditor_image)
-- **Tech Stack**: PHP ^8.2, TYPO3 ^13.4.21 || ^14.0, CKEditor 5
+- **Tech Stack**: PHP ^8.2, TYPO3 ^13.4.21 || ^14.3, CKEditor 5
 - **License**: AGPL-3.0-or-later
 - **Current Version**: 13.8.0
 
@@ -168,7 +168,7 @@ See [ADR-003: Security Responsibility Boundaries](Documentation/Architecture/ADR
 | Mutation | `composer ci:mutation` | Local or CI |
 | Architecture | Part of unit suite via phpat | Local or CI |
 
-**CI matrix**: PHP 8.2/8.3/8.4/8.5 x TYPO3 ^13.4/^14.0 (8 combinations for build, E2E on v13+v14)
+**CI matrix**: PHP 8.2/8.3/8.4/8.5 x TYPO3 ^13.4/^14.3 (8 combinations for build, E2E on v13+v14)
 
 ## Index of Scoped AGENTS.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Pin TYPO3 v14 requirement to v14.3 LTS** ([released 2026-04-21](https://typo3.org/article/typo3-v143-released)) — drop pre-LTS v14.0/v14.1/v14.2 from the supported range. Composer constraint now `^13.4.21 || ^14.3` (was `^13.4.21 || ^14.0`); `ext_emconf` constraint now `13.4.21-14.99.99` (was `13.4.0-14.4.99`). CI matrix and DDEV `install-v14` aligned accordingly. Installs still on v14.0-v14.2 should upgrade to v14.3 LTS.
+
 ## [13.8.3] - 2026-04-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Pin TYPO3 v14 requirement to v14.3 LTS** ([released 2026-04-21](https://typo3.org/article/typo3-v143-released)) — drop pre-LTS v14.0/v14.1/v14.2 from the supported range. Composer constraint now `^13.4.21 || ^14.3` (was `^13.4.21 || ^14.0`); `ext_emconf` constraint now `13.4.21-14.99.99` (was `13.4.0-14.4.99`). CI matrix and DDEV `install-v14` aligned accordingly. Installs still on v14.0-v14.2 should upgrade to v14.3 LTS.
+- **Pin TYPO3 v14 requirement to v14.3 LTS** ([released 2026-04-21](https://typo3.org/article/typo3-v143-released)) — Composer-based installs (the default and recommended path) are now pinned to `^13.4.21 || ^14.3` (was `^13.4.21 || ^14.0`). The `ext_emconf` constraint widens its lower bound to `13.4.21` and accepts `14.99.99` as upper (was `13.4.0-14.4.99`). Note that `ext_emconf` syntax does not support disjoint ranges, so TER/non-Composer installs on the unmaintained pre-LTS releases v14.0/v14.1/v14.2 are still technically permitted by `ext_emconf`; this is not a supported configuration and such installs should upgrade to v14.3 LTS. CI matrix and DDEV `install-v14` aligned to v14.3.
 
 ## [13.8.3] - 2026-04-10
 

--- a/Documentation/Architecture/System-Architecture.rst
+++ b/Documentation/Architecture/System-Architecture.rst
@@ -150,7 +150,7 @@ Technology Stack
 ================
 
 - **PHP**: 8.2+ with strict types
-- **TYPO3**: 13.4 LTS / 14.0+ (Core, Backend, Frontend, Extbase, RTE CKEditor)
+- **TYPO3**: 13.4 LTS / 14.3 LTS (Core, Backend, Frontend, Extbase, RTE CKEditor)
 - **JavaScript**: ES6 modules
 - **CKEditor**: 5.x provided by TYPO3 core with direct imports from @ckeditor/* namespace
 - **Dependency Injection**: Symfony service container

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -184,7 +184,7 @@ Visual Preview
 Version Information
 ===================
 
-:Supported TYPO3: 13.4.21+ LTS, 14.0+
+:Supported TYPO3: 13.4.21+ LTS, 14.3+ LTS
 :License: AGPL-3.0-or-later
 :Repository: `github.com/netresearch/t3x-rte_ckeditor_image <https://github.com/netresearch/t3x-rte_ckeditor_image>`__
 :Maintainer: `Netresearch DTT GmbH <https://www.netresearch.de/>`__
@@ -199,7 +199,7 @@ Requirements
 System Requirements
 ===================
 
-- **TYPO3:** 13.4.21+ LTS or 14.0+
+- **TYPO3:** 13.4.21+ LTS or 14.3+ LTS
 - **PHP:** 8.2 or later
 - **Extensions:** cms-rte-ckeditor (included in TYPO3 core)
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add issues or explore the project on [GitHub](https://github.com/netresearch/t3x
 
 ## Requirements
 
-- **TYPO3:** 13.4.21+ or 14.0+
+- **TYPO3:** 13.4.21+ (LTS) or 14.3+ (LTS)
 - **PHP:** 8.2 or later
 - **Extensions:** cms-rte-ckeditor (included in TYPO3 core)
 

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -97,9 +97,9 @@ Tests/
 
 ## CI Environment
 
-- CI matrix: PHP 8.2/8.3/8.4/8.5 x TYPO3 ^13.4/^14.0
+- CI matrix: PHP 8.2/8.3/8.4/8.5 x TYPO3 ^13.4/^14.3
 - CGL runs only on PHP 8.2 (code style is PHP version independent)
-- Coverage runs only on PHP 8.5 + TYPO3 ^14.0
+- Coverage runs only on PHP 8.5 + TYPO3 ^14.3
 - JavaScript tests run once (not PHP/TYPO3 version dependent)
 - E2E runs after build jobs pass, on v13 (blocking) and v14 (informational)
 

--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,11 @@
         "php": "^8.2",
         "ext-dom": "*",
         "ext-libxml": "*",
-        "typo3/cms-core": "^13.4.21 || ^14.0",
-        "typo3/cms-backend": "^13.4.21 || ^14.0",
-        "typo3/cms-frontend": "^13.4.21 || ^14.0",
-        "typo3/cms-extbase": "^13.4.21 || ^14.0",
-        "typo3/cms-rte-ckeditor": "^13.4.21 || ^14.0"
+        "typo3/cms-core": "^13.4.21 || ^14.3",
+        "typo3/cms-backend": "^13.4.21 || ^14.3",
+        "typo3/cms-frontend": "^13.4.21 || ^14.3",
+        "typo3/cms-extbase": "^13.4.21 || ^14.3",
+        "typo3/cms-rte-ckeditor": "^13.4.21 || ^14.3"
     },
     "require-dev": {
         "bk2k/bootstrap-package": "^15.0 || ^16.0",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -24,8 +24,8 @@ $EM_CONF[$_EXTKEY] = [
     'constraints'    => [
         'depends' => [
             'php'          => '8.2.0-8.9.99',
-            'typo3'        => '13.4.0-14.4.99',
-            'rte_ckeditor' => '13.4.0-14.4.99',
+            'typo3'        => '13.4.21-14.99.99',
+            'rte_ckeditor' => '13.4.21-14.99.99',
         ],
         'conflicts' => [],
         'suggests'  => [

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -23,6 +23,12 @@ $EM_CONF[$_EXTKEY] = [
     'version'        => '13.8.3',
     'constraints'    => [
         'depends' => [
+            // ext_emconf does not support disjoint ranges. The supported
+            // configuration is v13.4 LTS (>=13.4.21) and v14.3 LTS;
+            // unmaintained pre-LTS v14.0/v14.1/v14.2 are technically
+            // accepted by this range but not officially supported. The
+            // composer.json constraint (^13.4.21 || ^14.3) is the
+            // authoritative source for supported versions.
             'php'          => '8.2.0-8.9.99',
             'typo3'        => '13.4.21-14.99.99',
             'rte_ckeditor' => '13.4.21-14.99.99',


### PR DESCRIPTION
## Summary

TYPO3 v14.3 LTS was released [2026-04-21](https://typo3.org/article/typo3-v143-released). This PR drops pre-LTS v14.0/v14.1/v14.2 from the supported range and pins to the maintained LTS line.

- `composer.json` — `typo3/cms-*` constraints `^13.4.21 || ^14.0` → `^13.4.21 || ^14.3`
- `ext_emconf.php` — `typo3` + `rte_ckeditor` constraints `13.4.0-14.4.99` → `13.4.21-14.99.99` (lower bound aligned with composer; upper bound permits future v14.x patches)
- `.github/workflows/ci.yml` — matrix `^14.0` → `^14.3` (resolves identically to current v14.3.0, but makes intent explicit in CI logs)
- `.ddev/commands/web/install-v14` — switch to `t3/cms:'^14.3'` metapackage now that v14.3 is on Packagist (was installing components separately with a stale "metapackage doesn't have v14 yet" comment)
- `AGENTS.md`, `Tests/AGENTS.md`, `.ddev/AGENTS.md`, `README.md`, `Documentation/*` — align version references and CI matrix descriptions

## Why now

This is the first of three PRs addressing [#790](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/790). That report exposed that we have **no CI coverage for minimal/vanilla TYPO3 setups** (no Bootstrap Package, no `fluid_styled_content` site set) — exactly the configuration most fresh-install evaluators use. The bug is well-understood (2-line removal in `setup.typoscript`), but shipping it without addressing the underlying coverage gap would just queue up the next #790-equivalent.

Sequence:

1. **This PR** — bring CI/composer to v14.3 LTS explicitly (small, independently valuable, makes #790 reproducible against the current LTS)
2. **PR2** — add a `core-only` E2E variant (advisory) that runs against minimal install, no Bootstrap, no FSC site set
3. **PR3+** — fix everything `core-only` surfaces (including #790) with regression assertions; flip variant to blocking
4. **Later** — add `fsc-site-set` variant

Strategy details on issue: [#790#issuecomment-4318433276](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/790#issuecomment-4318433276).

## Test plan

- [x] `composer validate --strict --no-check-publish` passes
- [x] `php -l ext_emconf.php` passes
- [x] YAML syntax check on `ci.yml` passes
- [ ] CI matrix runs green (will appear here after push)
- [ ] DDEV `install-v14` works end-to-end with new metapackage approach (smoke test post-merge)

Refs: #790