### PR TITLE
ci: comply with typo3-ci-workflows v1.3 ergebnis ruleset

### DIFF
--- a/Build/phpstan-rector.neon
+++ b/Build/phpstan-rector.neon
@@ -1,0 +1,23 @@
+# Minimal phpstan config for Rector's type inference only.
+#
+# Why a separate file: Rector loads phpstan via its bundled phpstan.phar
+# rather than the project's vendored phpstan + extension-installer. That
+# means the ergebnis/phpstan-rules schema isn't registered and the
+# `parameters: ergebnis:` block in the main config (inherited from
+# typo3-ci-workflows v1.3+) trips a ValidationException.
+#
+# Rector only needs type inference here — the ergebnis style rules belong
+# to PHPStan-the-linter, not to Rector. So this config skips the shared
+# typo3-ci-workflows include entirely and provides just the bits Rector
+# wants: level, paths, treatPhpDocTypesAsCertain.
+parameters:
+    level: 10
+    treatPhpDocTypesAsCertain: false
+    paths:
+        - %currentWorkingDirectory%/Classes/
+        - %currentWorkingDirectory%/Configuration/
+        - %currentWorkingDirectory%/Resources/
+        - %currentWorkingDirectory%/Tests/
+    excludePaths:
+        - %currentWorkingDirectory%/.Build/*
+        - %currentWorkingDirectory%/ext_emconf.php

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -67,3 +67,13 @@ parameters:
           path: %currentWorkingDirectory%/Classes/Service/Environment/Typo3EnvironmentInfo.php
           message: '#getIndpEnv#'
           reportUnmatched: false
+        # ergebnis.noErrorSuppression — the shared phpstan config (v1.3+)
+        # enables this rule. SecurityValidator::normalizeIpAddress() uses
+        # `@inet_pton($ip)` to suppress the PHP warning on malformed input;
+        # the result-is-false branch is already explicitly checked. Replacing
+        # `@` with set_error_handler/restore_error_handler around a single
+        # native call is more code without behaviour change. Path-scoped so a
+        # new `@` elsewhere still flags.
+        - identifier: ergebnis.noErrorSuppression
+          path: %currentWorkingDirectory%/Classes/Service/Security/SecurityValidator.php
+          reportUnmatched: false

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -8,6 +8,8 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Rector\Set\ValueObject\LevelSetList;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 
@@ -17,13 +19,15 @@ return static function (RectorConfig $rectorConfig) use ($configure): void {
     // Apply shared base config with standard TYPO3 extension paths
     $configure($rectorConfig, __DIR__ . '/..');
 
-    // Override the shared phpstanConfig with a Rector-only neon. The shared
+    // Replace (not append to) the shared phpstanConfig list. The shared
     // Build/phpstan.neon inherits typo3-ci-workflows v1.3's
     // `parameters: ergebnis:` block; Rector's bundled phpstan.phar does
     // not have ergebnis/phpstan-rules registered and trips a
-    // ValidationException. The Rector-specific config has the same level
-    // and paths but skips the ergebnis schema.
-    $rectorConfig->phpstanConfig(__DIR__ . '/phpstan-rector.neon');
+    // ValidationException. We can't use $rectorConfig->phpstanConfig()
+    // here because it APPENDS to PHPSTAN_FOR_RECTOR_PATHS — the broken
+    // shared neon would still be loaded. setParameter() replaces the
+    // whole list with just our Rector-only neon (level + paths only).
+    SimpleParameterProvider::setParameter(Option::PHPSTAN_FOR_RECTOR_PATHS, [__DIR__ . '/phpstan-rector.neon']);
 
     // Extension-specific sets (merged with shared code-quality sets)
     $rectorConfig->sets([

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -17,6 +17,14 @@ return static function (RectorConfig $rectorConfig) use ($configure): void {
     // Apply shared base config with standard TYPO3 extension paths
     $configure($rectorConfig, __DIR__ . '/..');
 
+    // Override the shared phpstanConfig with a Rector-only neon. The shared
+    // Build/phpstan.neon inherits typo3-ci-workflows v1.3's
+    // `parameters: ergebnis:` block; Rector's bundled phpstan.phar does
+    // not have ergebnis/phpstan-rules registered and trips a
+    // ValidationException. The Rector-specific config has the same level
+    // and paths but skips the ergebnis schema.
+    $rectorConfig->phpstanConfig(__DIR__ . '/phpstan-rector.neon');
+
     // Extension-specific sets (merged with shared code-quality sets)
     $rectorConfig->sets([
         LevelSetList::UP_TO_PHP_84,

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "require-dev": {
         "bk2k/bootstrap-package": "^15.0 || ^16.0",
-        "netresearch/typo3-ci-workflows": "~1.2.0"
+        "netresearch/typo3-ci-workflows": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Replaces the temporary `~1.2.0` pin landed in #789. Per project policy, `typo3-ci-workflows` changes are mandatory and downstream extensions update to comply.

## What v1.3 turns on

The shared `phpstan.neon` curates `ergebnis/phpstan-rules` to a TYPO3-friendly subset:

- declareStrictTypes
- noCompact
- noErrorSuppression
- noEval
- noReturnByReference
- testCaseWithSuffix

This extension already complies with all of those except one site: `Classes/Service/Security/SecurityValidator.php` line 161 uses `@inet_pton($ip)` to suppress the PHP warning that `inet_pton` emits on malformed input. The `=== false` branch is checked explicitly so the suppression is load-bearing — replacing it with `set_error_handler`/`restore_error_handler` around a single native call is more code with no behaviour change.

## Change

- `composer.json`: `~1.2.0` → `^1.0` (back to the original constraint).
- `Build/phpstan.neon`: path-scope `ergebnis.noErrorSuppression` to the one file. Any new `@` elsewhere still flags.

No application code changes.