### PR TITLE
feat(ci): add E2E setup-variant matrix (fsc, core-only, bootstrap)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,29 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  # E2E (Playwright) across TYPO3 versions x extension-setup variants.
+  # Variants exercise the extension under different sitepackage / FSC /
+  # Bootstrap-Package combinations to surface regressions that are only
+  # visible in specific configurations. See Build/Scripts/runTests.sh -X
+  # for variant definitions.
+  #
+  # Advisory mode: new variants are not yet listed in the repo's
+  # required_status_checks ruleset, so a failing variant won't block
+  # merge. Once each variant stabilizes (failures investigated/fixed),
+  # the corresponding context can be added to the ruleset to make it
+  # blocking.
+  e2e:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/e2e.yml@main
+    permissions:
+      contents: read
+    with:
+      typo3-versions: '["^13.4.21","^14.3"]'
+      typo3-packages: '["typo3/cms-core","typo3/cms-rte-ckeditor"]'
+      setup-variants: '["fsc","core-only","bootstrap"]'
+      setup-script: 'Build/Scripts/ci-e2e.sh'
+      artifact-path: 'Build/test-results/'
+      timeout-minutes: 45
+
   security:
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
     permissions:

--- a/Build/Scripts/ci-e2e.sh
+++ b/Build/Scripts/ci-e2e.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# CI wrapper for runTests.sh -s e2e.
+#
+# The reusable workflow netresearch/typo3-ci-workflows/.github/workflows/e2e.yml
+# (with `setup-script: Build/Scripts/ci-e2e.sh`) invokes this script with no
+# arguments and exposes matrix env vars: E2E_TYPO3_VERSION (e.g. "^14.3") and
+# E2E_VARIANT (e.g. "core-only"). This wrapper translates those into the
+# CLI flags that runTests.sh expects, so runTests.sh stays a CLI tool and
+# doesn't need to know about the workflow's env-var contract.
+#
+# Local invocation should call runTests.sh directly with -t/-X/-s/-p flags.
+
+set -euo pipefail
+
+# Map E2E_TYPO3_VERSION constraint to the major number runTests.sh expects via
+# `-t`. We only support v13 LTS and v14 LTS in CI; reject anything else loudly
+# rather than silently falling back to a default.
+case "${E2E_TYPO3_VERSION:-}" in
+    "^13"*|"13"*) TYPO3_MAJOR=13 ;;
+    "^14"*|"14"*) TYPO3_MAJOR=14 ;;
+    "")
+        echo "::error::ci-e2e.sh: E2E_TYPO3_VERSION env var is not set." >&2
+        echo "  This script is a CI wrapper. Run runTests.sh directly for local E2E." >&2
+        exit 1
+        ;;
+    *)
+        echo "::error::ci-e2e.sh: Unsupported E2E_TYPO3_VERSION: ${E2E_TYPO3_VERSION}" >&2
+        echo "  Expected ^13.x or ^14.x. Update the CI matrix or this wrapper." >&2
+        exit 1
+        ;;
+esac
+
+VARIANT="${E2E_VARIANT:-fsc}"
+
+# PHP 8.5 is the canonical E2E runtime per Tests/AGENTS.md ("E2E runs on
+# PHP 8.5"). Pin it here so matrix entries don't accidentally resolve to a
+# different version when scaling out.
+PHP_VERSION=8.5
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "ci-e2e.sh: TYPO3 v${TYPO3_MAJOR}, PHP ${PHP_VERSION}, variant=${VARIANT}"
+exec "${SCRIPT_DIR}/runTests.sh" \
+    -s e2e \
+    -t "${TYPO3_MAJOR}" \
+    -p "${PHP_VERSION}" \
+    -X "${VARIANT}"

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -262,6 +262,25 @@ Options:
         use
             Build/Scripts/runTests.sh -s unit -- --filter classCanBeRegistered
 
+    -X <bootstrap|core-only|fsc>
+        Only with -s e2e
+        Selects the "extension neighborhood" the E2E TYPO3 instance is set up with.
+        Different variants exercise the extension under different sitepackage / FSC /
+        Bootstrap-Package combinations to surface regressions that only manifest in
+        specific configurations (e.g. issue #790: vanilla install with no FSC site set
+        and no Bootstrap behaves differently than one with Bootstrap, where the bug
+        is masked by Bootstrap's own parseFunc_RTE config).
+
+            - core-only: minimal install — TYPO3 core only, no fluid_styled_content,
+              no Bootstrap Package. Models the fresh-install evaluator scenario.
+            - fsc      : (default) FSC site set enabled, no Bootstrap. Current
+              long-standing E2E baseline.
+            - bootstrap: FSC + Bootstrap Package. Common real-world setup.
+
+        Also reads the E2E_VARIANT env var as a fallback when -X is omitted (used
+        by ci-e2e.sh wrapper so the reusable e2e.yml workflow can pass the variant
+        through without re-translating flags).
+
     -x
         Only with -s functional|functionalDeprecated|unit|unitDeprecated|unitRandom
         Send information to host instance for test or system under test break points. This is especially
@@ -359,8 +378,13 @@ IS_CI=0
 OPTIND=1
 # Array for invalid options
 INVALID_OPTIONS=()
+# E2E setup variant — controls which sitepackage / FSC / Bootstrap-Package combo
+# the E2E TYPO3 instance is built with. Allow env override so CI can drive the
+# matrix without rewriting flags. See -X help text and ci-e2e.sh wrapper.
+E2E_VARIANT="${E2E_VARIANT:-fsc}"
+
 # Simple option parsing based on getopts (! not getopt)
-while getopts "a:b:c:s:d:i:p:e:t:xy:nhu" OPT; do
+while getopts "a:b:c:s:d:i:p:e:t:xy:nhuX:" OPT; do
     case ${OPT} in
         s)
             TEST_SUITE=${OPTARG}
@@ -403,6 +427,12 @@ while getopts "a:b:c:s:d:i:p:e:t:xy:nhu" OPT; do
             ;;
         x)
             PHP_XDEBUG_ON=1
+            ;;
+        X)
+            E2E_VARIANT=${OPTARG}
+            if ! [[ ${E2E_VARIANT} =~ ^(bootstrap|core-only|fsc)$ ]]; then
+                INVALID_OPTIONS+=("-X ${OPTARG}")
+            fi
             ;;
         y)
             PHP_XDEBUG_PORT=${OPTARG}
@@ -750,7 +780,32 @@ echo "sys_template record ensured with constants and config\n";
 DBSETUP_EOF
 
         # site-config.yaml - Site configuration
-        cat > "${E2E_SCRIPTS}/site-config.yaml" << 'SITECONFIG_EOF'
+        # Site-set dependencies match the composer-required extensions selected
+        # by E2E_VARIANT (see -X flag docs and the composer require step below).
+        # core-only intentionally lists only our own set so the bug class in
+        # #790 (vanilla install with no FSC site set) is reproduced faithfully.
+        case "${E2E_VARIANT}" in
+            core-only)
+                E2E_SITE_DEPENDENCIES='  - netresearch/rte-ckeditor-image'
+                ;;
+            fsc)
+                E2E_SITE_DEPENDENCIES='  - typo3/fluid-styled-content
+  - netresearch/rte-ckeditor-image'
+                ;;
+            bootstrap)
+                # Bootstrap Package site set name differs by major: v15 → "bootstrap-package",
+                # v16 → still "bootstrap-package/full" plus the company set.
+                # Use the universal "full" set which exists in both ranges.
+                E2E_SITE_DEPENDENCIES='  - bootstrap-package/full
+  - typo3/fluid-styled-content
+  - netresearch/rte-ckeditor-image'
+                ;;
+            *)
+                echo "::error::Unknown E2E_VARIANT for site-config: ${E2E_VARIANT}" >&2
+                exit 1
+                ;;
+        esac
+        cat > "${E2E_SCRIPTS}/site-config.yaml" << SITECONFIG_EOF
 rootPageId: 1
 base: /
 languages:
@@ -762,8 +817,7 @@ languages:
     navigationTitle: English
     flag: us
 dependencies:
-  - typo3/fluid-styled-content
-  - netresearch/rte-ckeditor-image
+${E2E_SITE_DEPENDENCIES}
 SITECONFIG_EOF
 
         # create-test-content.php - Create test image and content records
@@ -1184,7 +1238,36 @@ CONTENT_EOF
                 # Mount extension at /extension and use that path for composer
                 composer config repositories.local path /extension
                 composer require netresearch/rte-ckeditor-image:@dev --no-interaction --no-progress --no-scripts
-                composer require typo3/cms-fluid-styled-content typo3/cms-reports --no-interaction --no-progress --no-scripts
+
+                # Install variant-specific extension neighborhood. See -X flag
+                # docs in this script's header. cms-reports is included in all
+                # variants for the post-install healthcheck commands.
+                case \"${E2E_VARIANT}\" in
+                    core-only)
+                        echo \"E2E variant: core-only (no fluid_styled_content, no Bootstrap Package)\"
+                        composer require typo3/cms-reports --no-interaction --no-progress --no-scripts
+                        ;;
+                    fsc)
+                        echo \"E2E variant: fsc (fluid_styled_content site set, no Bootstrap Package)\"
+                        composer require typo3/cms-fluid-styled-content typo3/cms-reports --no-interaction --no-progress --no-scripts
+                        ;;
+                    bootstrap)
+                        echo \"E2E variant: bootstrap (FSC + Bootstrap Package)\"
+                        composer require typo3/cms-fluid-styled-content typo3/cms-reports --no-interaction --no-progress --no-scripts
+                        # Bootstrap Package versions track TYPO3 majors:
+                        # ^15.0 → TYPO3 v13, ^16.0 → TYPO3 v14
+                        # E2E_TYPO3_VERSION is expanded by the outer shell (no \\\$ escape).
+                        if [ \"${E2E_TYPO3_VERSION}\" = \"14\" ]; then
+                            composer require bk2k/bootstrap-package:'^16.0' --no-interaction --no-progress --no-scripts
+                        else
+                            composer require bk2k/bootstrap-package:'^15.0' --no-interaction --no-progress --no-scripts
+                        fi
+                        ;;
+                    *)
+                        echo \"::error::Unknown E2E_VARIANT: ${E2E_VARIANT}\" >&2
+                        exit 1
+                        ;;
+                esac
 
                 # Install extra Composer packages if specified via -c flag
                 if [ -n \"${E2E_EXTRA_PACKAGES}\" ]; then

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -512,7 +512,7 @@ IMAGE_MYSQL="docker.io/mysql:${DBMS_VERSION}"
 IMAGE_POSTGRES="docker.io/postgres:${DBMS_VERSION}-alpine"
 # E2E testing images (TYPO3 Core pattern)
 IMAGE_APACHE="ghcr.io/typo3/core-testing-apache24:1.7"
-IMAGE_PLAYWRIGHT="mcr.microsoft.com/playwright:v1.58.0-noble"
+IMAGE_PLAYWRIGHT="mcr.microsoft.com/playwright:v1.59.1-noble"
 
 # Set $1 to first mass argument, this is the optional test file or test directory to execute
 shift $((OPTIND - 1))

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -380,8 +380,13 @@ OPTIND=1
 INVALID_OPTIONS=()
 # E2E setup variant — controls which sitepackage / FSC / Bootstrap-Package combo
 # the E2E TYPO3 instance is built with. Allow env override so CI can drive the
-# matrix without rewriting flags. See -X help text and ci-e2e.sh wrapper.
+# matrix without rewriting flags (the ci-e2e.sh wrapper sets E2E_VARIANT).
+# Both the env var path and the -X CLI flag path go through the same
+# validation regex so an invalid value never silently changes setup behavior.
 E2E_VARIANT="${E2E_VARIANT:-fsc}"
+if ! [[ ${E2E_VARIANT} =~ ^(bootstrap|core-only|fsc)$ ]]; then
+    INVALID_OPTIONS+=("E2E_VARIANT=${E2E_VARIANT} (must be bootstrap|core-only|fsc)")
+fi
 
 # Simple option parsing based on getopts (! not getopt)
 while getopts "a:b:c:s:d:i:p:e:t:xy:nhuX:" OPT; do
@@ -725,21 +730,55 @@ echo "Pages record inserted\n";
 $pdo->exec("INSERT IGNORE INTO pages (uid, pid, title, slug, doktype, is_siteroot, hidden, deleted, tstamp, crdate) VALUES (2, 1, 'Error Handling Tests', '/error-handling-tests', 1, 0, 0, 0, $now, $now)");
 echo "Error handling test page (uid=2) inserted\n";
 
-// TypoScript CONSTANTS - defines default values used by setup
-// fluid_styled_content needs these constants for proper operation
-$tsConstants = <<<'TYPOSCRIPT'
+// TypoScript constants and config are split into a variant-specific
+// header (the @imports / styles.content.get definition) and a shared
+// body (page = PAGE, popup config, allowTags additions). The core-only
+// variant skips fluid_styled_content composer-side, so importing
+// EXT:fluid_styled_content TS would fail at TS-parse time — its header
+// instead inlines a minimal styles.content.get definition that mirrors
+// what fluid_styled_content normally provides.
+$variant = getenv('E2E_VARIANT') ?: 'fsc';
+
+if ($variant === 'core-only') {
+    $tsConstants = <<<'TYPOSCRIPT'
+# core-only: no fluid_styled_content constants import (extension not installed).
+styles.content.image.lazyLoading = lazy
+TYPOSCRIPT;
+
+    // Inline styles.content.get because fluid_styled_content (the usual
+    // provider) isn't installed in this variant. Shape mirrors FSC.
+    $tsConfigHeader = <<<'TYPOSCRIPT'
+styles.content.get = CONTENT
+styles.content.get {
+    table = tt_content
+    select {
+        orderBy = sorting
+        where = {#colPos}=0
+    }
+}
+
+@import 'EXT:rte_ckeditor_image/Configuration/TypoScript/ImageRendering/setup.typoscript'
+TYPOSCRIPT;
+} else {
+    // fsc and bootstrap: fluid_styled_content provides constants and the
+    // styles.content.get definition. Bootstrap layers Bootstrap Package
+    // on top via the site set; the sys_template TS is identical to fsc.
+    $tsConstants = <<<'TYPOSCRIPT'
 @import 'EXT:fluid_styled_content/Configuration/TypoScript/constants.typoscript'
 
 # Image lazy loading setting
 styles.content.image.lazyLoading = lazy
 TYPOSCRIPT;
 
-// TypoScript SETUP configuration for PAGE rendering
-// IMPORTANT: Load fluid_styled_content FIRST to define lib.parseFunc_RTE base
-// Then load our extension to add the tags.img.preUserFunc for click-to-enlarge
-$tsConfig = <<<'TYPOSCRIPT'
+    $tsConfigHeader = <<<'TYPOSCRIPT'
 @import 'EXT:fluid_styled_content/Configuration/TypoScript/setup.typoscript'
 @import 'EXT:rte_ckeditor_image/Configuration/TypoScript/ImageRendering/setup.typoscript'
+TYPOSCRIPT;
+}
+
+// Shared body across all variants — page rendering, popup, allowTags
+// additions for tags that aren't in the default whitelist.
+$tsConfigBody = <<<'TYPOSCRIPT'
 
 # Ensure lib.contentElement.settings.media.popup is set for click-to-enlarge
 # This path MUST exist for ImageRenderingController to find popup config
@@ -771,6 +810,8 @@ lib.parseFunc_RTE.allowTags := addToList(h1,h2,h3,h4,h5,h6)
 # CE 8 test data contains <table>, <ul>, <li> elements.
 lib.parseFunc_RTE.allowTags := addToList(table,thead,tbody,tr,th,td,ul,ol,li)
 TYPOSCRIPT;
+
+$tsConfig = $tsConfigHeader . $tsConfigBody;
 
 // Insert or update sys_template with BOTH constants and config
 // Use ON DUPLICATE KEY UPDATE to ensure our TypoScript is applied even if TYPO3 setup pre-created it
@@ -1226,6 +1267,7 @@ CONTENT_EOF
             -v ${E2E_COMPOSER_CACHE}:/.cache/composer \
             -w /var/www/html \
             -e COMPOSER_CACHE_DIR=/.cache/composer \
+            -e E2E_VARIANT="${E2E_VARIANT}" \
             ${IMAGE_PHP} /bin/bash -c "
                 # Disable Composer's block-insecure feature for transient upstream advisories
                 # (e.g., CVE-2025-45769 in firebase/php-jwt <7.0, a TYPO3 Core dependency)
@@ -1450,6 +1492,7 @@ HTACCESS
             -e BASE_URL=http://apache-e2e-${SUFFIX}:80 \
             -e TYPO3_BACKEND_PASSWORD="${E2E_ADMIN_PASSWORD}" \
             -e TYPO3_VERSION="${E2E_TYPO3_VERSION}" \
+            -e E2E_VARIANT="${E2E_VARIANT}" \
             -e CI=true \
             ${PLAYWRIGHT_EXTRA_ENV} \
             ${IMAGE_PLAYWRIGHT} /bin/bash -c "

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -57,7 +57,7 @@ Tests/
 | Unit tests | `composer ci:test:php:unit` | Fast, no DB needed |
 | Functional tests | `composer ci:test:php:functional` | Needs `typo3DatabaseDriver=pdo_sqlite` env var |
 | JavaScript tests | `composer ci:test:js:unit` | Runs in Tests/JavaScript/ via Vitest |
-| E2E tests | `Build/Scripts/runTests.sh -s e2e -t 13 -p 8.5` | Docker-based, TYPO3 v13 or v14 |
+| E2E tests | `Build/Scripts/runTests.sh -s e2e -t 13 -p 8.5 -X fsc` | Docker-based, TYPO3 v13 or v14, variant via `-X` |
 | Fuzz tests | `composer ci:fuzz` | 10,000 runs per target |
 | Mutation tests | `composer ci:mutation` | Infection, runs unit tests first |
 | Unit coverage | `composer ci:coverage:unit` | Outputs to `.Build/coverage-unit/` |
@@ -94,6 +94,12 @@ Tests/
 - CKEditor: bare `<p><img></p>` renders as block widget (dblclick won't open dialog). Must include surrounding text
 - `clearCookies()` before frontend navigation after backend login (session interference)
 - v14 E2E runs with `continue-on-error` (non-blocking while stabilizing)
+- E2E setup variants via `-X` flag exercise the extension under different sitepackage / FSC / Bootstrap-Package combinations:
+  - `-X fsc` (default): fluid_styled_content site set, no Bootstrap. Long-standing baseline.
+  - `-X core-only`: minimal install, neither FSC nor Bootstrap. Models the fresh-install evaluator scenario; surfaces the bug class in [#790](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/790).
+  - `-X bootstrap`: FSC + Bootstrap Package (`^15.0` for v13, `^16.0` for v14). Common real-world setup.
+- CI invokes via `Build/Scripts/ci-e2e.sh` (wrapper that translates the workflow's `E2E_VARIANT`/`E2E_TYPO3_VERSION` env vars into runTests.sh CLI flags).
+- Specs that fundamentally require a specific variant (e.g. Bootstrap lightbox CSS) should `test.skip(process.env.E2E_VARIANT === 'core-only', '...')` to keep the matrix clean.
 
 ## CI Environment
 
@@ -101,7 +107,7 @@ Tests/
 - CGL runs only on PHP 8.2 (code style is PHP version independent)
 - Coverage runs only on PHP 8.5 + TYPO3 ^14.3
 - JavaScript tests run once (not PHP/TYPO3 version dependent)
-- E2E runs after build jobs pass, on v13 (blocking) and v14 (informational)
+- E2E matrix: TYPO3 ^13.4 + ^14.3 x setup-variants `[fsc, core-only, bootstrap]` = 6 jobs. Setup variants are advisory (not in required_status_checks ruleset) until each stabilizes.
 
 ## PR Checklist
 


### PR DESCRIPTION
## Summary

Wire this repo's E2E pipeline against the matrix capability added in [`netresearch/typo3-ci-workflows#76`](https://github.com/netresearch/typo3-ci-workflows/pull/76). CI now fans Playwright E2E across TYPO3 `^13.4.21`/`^14.3` × setup variants `{fsc, core-only, bootstrap}` = 6 jobs.

| Variant | Composer require | Site-config dependencies |
|---|---|---|
| `fsc` (default) | `typo3/cms-fluid-styled-content` + `typo3/cms-reports` | `typo3/fluid-styled-content` + `netresearch/rte-ckeditor-image` |
| `core-only` (NEW) | `typo3/cms-reports` only | `netresearch/rte-ckeditor-image` only |
| `bootstrap` (NEW) | FSC + reports + `bk2k/bootstrap-package` (`^15.0` v13 / `^16.0` v14) | `bootstrap-package/full` + FSC + ours |

## Why three variants

Fresh-install evaluators (typically `core-only` or plain `fsc`) are an invisible cohort in our issue tracker — they hit a broken extension and silently move on, never reporting. The bug class in [#790](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/790) (`parseFunc_RTE.allowTags := addToList(...)` creating a restrictive whitelist once `fluid_styled_content`'s pre-v13.2 defaults disappeared) is masked entirely under the `bootstrap` variant because Bootstrap Package configures `parseFunc_RTE` itself. Coverage across all three closes the gap.

## Implementation

- **`Build/Scripts/runTests.sh`** — new `-X <bootstrap|core-only|fsc>` flag (default `fsc` for backward compat). Reads `E2E_VARIANT` env as fallback so the reusable workflow's env-var contract works without a flag-translation layer in CI YAML. Variant forks both the composer-require step and the `site-config.yaml` dependencies. Invalid `-X` values rejected via `getopts` validation.
- **`Build/Scripts/ci-e2e.sh`** (new) — thin CI wrapper translating the reusable workflow's `E2E_TYPO3_VERSION` + `E2E_VARIANT` env vars into `runTests.sh` CLI flags. Keeps `runTests.sh` a clean CLI tool; the env-bridge logic lives in one obvious place. Validates inputs loudly.
- **`.github/workflows/ci.yml`** — new `e2e:` job calling `netresearch/typo3-ci-workflows/.github/workflows/e2e.yml@main` with `setup-script: Build/Scripts/ci-e2e.sh` and the variant matrix. `timeout-minutes: 45` for the 6-job container pipeline.
- **`Tests/AGENTS.md`** — variant catalog and the `test.skip(process.env.E2E_VARIANT === 'X', '...')` pattern for specs that fundamentally require a specific neighborhood.

## Advisory mode

The new variant jobs are **not** listed in the repo's `required_status_checks` ruleset. A failing variant won't block merge while we triage the matrix output. Once each variant stabilizes, the corresponding context can be added to the ruleset to make it blocking.

## Test plan

- [x] `bash -n` syntax check passes on `runTests.sh` and `ci-e2e.sh`
- [x] `runTests.sh -h` shows the new `-X` flag
- [x] `runTests.sh -X invalid` rejects with the existing INVALID_OPTIONS error path
- [x] `ci-e2e.sh` rejects unset / unsupported `E2E_TYPO3_VERSION` clearly
- [x] `ci-e2e.sh` builds the correct `runTests.sh -s e2e -t 14 -p 8.5 -X core-only` invocation
- [ ] CI matrix runs (will appear here after push) — `fsc` variant expected to pass (current baseline); `core-only` and `bootstrap` expected to surface failures (the discovery exercise that motivates this PR)

## Follow-up

PR3+ will triage the failures this matrix surfaces, including the `parseFunc_RTE.allowTags` removal for #790 with a regression assertion in the `core-only` variant.

Refs: #790, follows #792, ci-workflows#76.