### PR TITLE
fix: support v14 link browser FormEngineLinkBrowserSetLinkEvent contract

### DIFF
--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -1354,18 +1354,25 @@ function openLinkBrowser(editor, currentValue) {
         // element. v14 also no longer auto-dismisses the modal, so we have to
         // call Modal.dismiss() ourselves. Keep the v13 hidden-input listener
         // for backwards compatibility.
+        //
+        // Treat any string value as a confirmed selection — including:
+        //   - the same value as currentValue (user reopened to confirm)
+        //   - an empty string (user invoked "remove link" in the browser)
+        // The user explicitly clicked something to fire this event; don't
+        // gate on equality with the prior value.
         const v14LinkSetEventName = 'typo3:form-engine:link-browser:set-link';
         const v14EventHandler = function(event) {
             const linkValue = event.value;
-            if (linkValue && linkValue !== currentValue) {
-                modal.removeEventListener(v14LinkSetEventName, v14EventHandler);
-                hiddenInput.removeEventListener('change', changeHandler);
-                const linkData = parseTypoLink(linkValue);
-                // resolvePromise FIRST so settled=true before typo3-modal-hidden
-                // handler runs (otherwise it would call rejectPromise()).
-                resolvePromise(linkData);
-                Modal.dismiss();
+            if (typeof linkValue !== 'string') {
+                return;
             }
+            modal.removeEventListener(v14LinkSetEventName, v14EventHandler);
+            hiddenInput.removeEventListener('change', changeHandler);
+            const linkData = parseTypoLink(linkValue);
+            // resolvePromise FIRST so settled=true before typo3-modal-hidden
+            // handler runs (otherwise it would call rejectPromise()).
+            resolvePromise(linkData);
+            Modal.dismiss();
         };
         modal.addEventListener(v14LinkSetEventName, v14EventHandler);
 

--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -1345,6 +1345,30 @@ function openLinkBrowser(editor, currentValue) {
             size: Modal.sizes.large
         });
 
+        // TYPO3 v14: form-engine-link-browser-adapter no longer writes to the
+        // hidden form input or dispatches a 'change' event (the v13 contract
+        // above). Instead it dispatches a `FormEngineLinkBrowserSetLinkEvent`
+        // (event name "typo3:form-engine:link-browser:set-link") on the iframe
+        // element with the typoLink string in `event.value`. The event has
+        // bubbles+composed, so it bubbles from the iframe up to the modal
+        // element. v14 also no longer auto-dismisses the modal, so we have to
+        // call Modal.dismiss() ourselves. Keep the v13 hidden-input listener
+        // for backwards compatibility.
+        const v14LinkSetEventName = 'typo3:form-engine:link-browser:set-link';
+        const v14EventHandler = function(event) {
+            const linkValue = event.value;
+            if (linkValue && linkValue !== currentValue) {
+                modal.removeEventListener(v14LinkSetEventName, v14EventHandler);
+                hiddenInput.removeEventListener('change', changeHandler);
+                const linkData = parseTypoLink(linkValue);
+                // resolvePromise FIRST so settled=true before typo3-modal-hidden
+                // handler runs (otherwise it would call rejectPromise()).
+                resolvePromise(linkData);
+                Modal.dismiss();
+            }
+        };
+        modal.addEventListener(v14LinkSetEventName, v14EventHandler);
+
         // Handle modal close without selection
         modal.addEventListener('typo3-modal-hidden', function() {
             // Clean up hidden form from the target document


### PR DESCRIPTION
## Summary

TYPO3 v14 introduced a breaking change in [`form-engine-link-browser-adapter.js`](https://github.com/TYPO3/typo3/blob/v14.3.0/typo3/sysext/backend/Resources/Public/JavaScript/form-engine-link-browser-adapter.js):

| | v13 contract | v14 contract |
|---|---|---|
| How URL is communicated | Sets value on hidden form input + dispatches `change` event | Dispatches `FormEngineLinkBrowserSetLinkEvent` on `window.frameElement` with `event.value` |
| Modal dismissal | Adapter calls `Modal.dismiss()` itself | Adapter does **not** dismiss — caller must |
| Event class | n/a | [`@typo3/backend/event/form-engine-link-browser-set-link-event.js`](https://github.com/TYPO3/typo3/blob/v14.3.0/typo3/sysext/backend/Resources/Public/JavaScript/event/form-engine-link-browser-set-link-event.js) |

Our `openLinkBrowser()` in `Resources/Public/JavaScript/Plugins/typo3image.js` only listened for the v13 contract. On v14 the `change` event never fires, the promise never resolves, and the link browser modal sits open. When the user finally closes it manually, `typo3-modal-hidden`'s no-selection branch runs and the image dialog's `#rteckeditorimage-linkHref` stays empty.

## Fix

Add a v14-compatible listener on the modal element. The `FormEngineLinkBrowserSetLinkEvent` has `bubbles: true, composed: true`, so it bubbles from `window.frameElement` (the iframe in the modal's outer document) up to the modal element. Listening on the modal scopes cleanly to the current link-browser session.

Subtleties:
- Resolve the promise **before** calling `Modal.dismiss()` so the existing `typo3-modal-hidden` handler sees `settled = true` and doesn't reject the promise.
- Keep the v13 hidden-input listener intact — both paths coexist; only the contract matching the running TYPO3 version actually fires.

## Why it surfaced now

Surfaced by the variant matrix introduced in [#794](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/794). Before #794, E2E ran only against TYPO3 v13 in CI, so the v14-only contract change never triggered. The variant expansion to `(^13.4.21, ^14.3) × (fsc, core-only, bootstrap)` exposed it.

Affected specs (all v14, all variants):
- `tests/image-dialog-link-browser.spec.ts:66` — page tree node click
- `tests/link-browser-all-types.spec.ts:122` — URL tab
- `tests/link-browser-all-types.spec.ts:167` — Email tab
- `tests/link-browser-all-types.spec.ts:214` — Phone tab

All four hit the same code path: open link browser → make a selection → resulting URL never makes it back to `#rteckeditorimage-linkHref`.

## Test plan

- [x] Verified v13/v14 adapter source diff in vendored TYPO3 (v14 single-line minified module dispatches `FormEngineLinkBrowserSetLinkEvent`; v13 single-line module sets form value + change event).
- [x] Verified the consumer at `typo3image.js:597` correctly writes `linkData.href` to `#rteckeditorimage-linkHref` once `openLinkBrowser` resolves — so fixing the promise resolution is sufficient, no further changes needed downstream.
- [ ] CI: 4 affected specs pass on v14 fsc/core-only/bootstrap; v13 specs unchanged.

## Refs

- Closes part of the PR3a/PR3b/PR3d sequence following [#794](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/794) (variant matrix), [#796](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/796) (#790 fix) and [#797](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/797) (PR3a locator fix).
- Related: [#718](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/718) — same area (link browser integration), different contract change.