### PR TITLE
fix: emit rel="noreferrer" on figure-wrapped linked images (#799)

### DIFF
--- a/Classes/Domain/Model/LinkDto.php
+++ b/Classes/Domain/Model/LinkDto.php
@@ -26,6 +26,9 @@ final readonly class LinkDto
      * @param string|null              $params   Additional URL parameters (e.g., "&L=1&type=123")
      * @param bool                     $isPopup  Whether this is a popup/lightbox link
      * @param array<string,mixed>|null $jsConfig JavaScript configuration for lightbox/popup
+     * @param string|null              $rel      Link rel attribute (e.g. "noreferrer" for external _blank).
+     *                                           Mirrors TYPO3 LinkFactory::addSecurityRelValues() for the
+     *                                           Fluid-rendered link path (which bypasses typolink).
      */
     public function __construct(
         public string $url,
@@ -34,6 +37,7 @@ final readonly class LinkDto
         public ?string $params,
         public bool $isPopup,
         public ?array $jsConfig,
+        public ?string $rel = null,
     ) {}
 
     /**

--- a/Classes/Service/ImageResolverService.php
+++ b/Classes/Service/ImageResolverService.php
@@ -944,7 +944,7 @@ class ImageResolverService
             // SECURITY: Validate URL to prevent JavaScript injection
             if ($this->validateLinkUrl($linkUrl)) {
                 $linkTarget = $linkAttributes['target'] ?? null;
-                $link = new LinkDto(
+                $link       = new LinkDto(
                     url: $linkUrl,
                     target: $linkTarget,
                     class: $linkAttributes['class'] ?? null,

--- a/Classes/Service/ImageResolverService.php
+++ b/Classes/Service/ImageResolverService.php
@@ -615,6 +615,47 @@ class ImageResolverService
     }
 
     /**
+     * Compute the rel attribute for an editorial link, mirroring TYPO3's
+     * LinkFactory::addSecurityRelValues() semantics.
+     *
+     * The Fluid Link.html partial constructs <a> directly (it does not go
+     * through typolink), so the security rel attribute that typolink would
+     * normally add for external target=_blank links has to be computed here.
+     * Without this, figure-wrapped linked images render <a target="_blank">
+     * without rel="noreferrer" — a regression of the security default that
+     * the rest of TYPO3 applies automatically.
+     *
+     * Returns "noreferrer" when target opens a new browsing context AND the
+     * URL is external (absolute http(s) — t3:// is already resolved before
+     * reaching this point, and relative/fragment URLs are internal).
+     * Returns null otherwise.
+     *
+     * @param string|null $target Link target attribute
+     * @param string      $url    Resolved link URL
+     *
+     * @return string|null Security rel value or null
+     *
+     * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/799
+     */
+    private function computeSecurityRel(?string $target, string $url): ?string
+    {
+        // No target or self/parent/top targets keep the same browsing context — no security risk.
+        if ($target === null || in_array($target, ['', '_self', '_parent', '_top'], true)) {
+            return null;
+        }
+
+        // Only absolute http(s) URLs are external for our purposes. Relative
+        // paths (/fileadmin/...), fragments (#...), and other schemes already
+        // share the same origin or use a non-browsing-context handler.
+        $lower = strtolower($url);
+        if (!str_starts_with($lower, 'http://') && !str_starts_with($lower, 'https://')) {
+            return null;
+        }
+
+        return 'noreferrer';
+    }
+
+    /**
      * Get attribute value with fallback to file property.
      *
      * Handles the override mechanism where:
@@ -721,13 +762,16 @@ class ImageResolverService
             $jsConfig = $this->getPopupConfiguration($request);
         }
 
+        $target = $linkAttributes['target'] ?? null;
+
         return new LinkDto(
             url: $url,
-            target: $linkAttributes['target'] ?? null,
+            target: $target,
             class: $linkAttributes['class'] ?? null,
             params: $linkAttributes['data-link-params'] ?? null,
             isPopup: $isPopup,
             jsConfig: $jsConfig,
+            rel: $this->computeSecurityRel($target, $url),
         );
     }
 
@@ -899,13 +943,15 @@ class ImageResolverService
 
             // SECURITY: Validate URL to prevent JavaScript injection
             if ($this->validateLinkUrl($linkUrl)) {
+                $linkTarget = $linkAttributes['target'] ?? null;
                 $link = new LinkDto(
                     url: $linkUrl,
-                    target: $linkAttributes['target'] ?? null,
+                    target: $linkTarget,
                     class: $linkAttributes['class'] ?? null,
                     params: $linkAttributes['data-link-params'] ?? null,
                     isPopup: $isPopup,
                     jsConfig: null, // External images don't get popup config
+                    rel: $this->computeSecurityRel($linkTarget, $linkUrl),
                 );
             }
         }

--- a/Classes/Service/ImageResolverService.php
+++ b/Classes/Service/ImageResolverService.php
@@ -626,9 +626,13 @@ class ImageResolverService
      * the rest of TYPO3 applies automatically.
      *
      * Returns "noreferrer" when target opens a new browsing context AND the
-     * URL is external (absolute http(s) — t3:// is already resolved before
-     * reaching this point, and relative/fragment URLs are internal).
-     * Returns null otherwise.
+     * URL is external. "External" includes:
+     *   - absolute http(s) URLs (`http://...`, `https://...`)
+     *   - protocol-relative URLs (`//example.com/...`) — RFC 3986 §4.2,
+     *     these inherit the page's scheme and resolve to a different host
+     * Returns null for relative paths, fragments, mailto:/tel:/t3:, and
+     * non-browsing-context targets. (t3:// URLs are already resolved to
+     * absolute paths before reaching this method.)
      *
      * @param string|null $target Link target attribute
      * @param string      $url    Resolved link URL
@@ -644,15 +648,26 @@ class ImageResolverService
             return null;
         }
 
-        // Only absolute http(s) URLs are external for our purposes. Relative
-        // paths (/fileadmin/...), fragments (#...), and other schemes already
-        // share the same origin or use a non-browsing-context handler.
-        $lower = strtolower($url);
-        if (!str_starts_with($lower, 'http://') && !str_starts_with($lower, 'https://')) {
-            return null;
+        // Trim and lowercase for stable scheme detection. validateLinkUrl()
+        // upstream already trims, but be defensive — the URL traversed our
+        // attribute pipeline and may still have edge whitespace from the
+        // original RTE markup.
+        $normalized = strtolower(trim($url));
+
+        // Absolute http(s) URLs are external by definition.
+        if (str_starts_with($normalized, 'http://') || str_starts_with($normalized, 'https://')) {
+            return 'noreferrer';
         }
 
-        return 'noreferrer';
+        // Protocol-relative URLs (`//example.com/...`) inherit the page's
+        // scheme and resolve to whatever host follows the `//`. Treat as
+        // external. Note the second character must NOT be another `/` (a
+        // single-slash path like `/foo` is internal).
+        if (str_starts_with($normalized, '//')) {
+            return 'noreferrer';
+        }
+
+        return null;
     }
 
     /**

--- a/Classes/Service/ImageResolverService.php
+++ b/Classes/Service/ImageResolverService.php
@@ -615,109 +615,6 @@ class ImageResolverService
     }
 
     /**
-     * Compute the rel attribute for an editorial link, mirroring TYPO3's
-     * LinkFactory::addSecurityRelValues() semantics, while preserving any
-     * rel tokens that came from the source `<a>` tag.
-     *
-     * The Fluid Link.html partial constructs <a> directly (it does not go
-     * through typolink), so the security rel attribute that typolink would
-     * normally add for external target=_blank links has to be computed here.
-     * Without this, figure-wrapped linked images render <a target="_blank">
-     * without rel="noreferrer" — a regression of the security default that
-     * the rest of TYPO3 applies automatically.
-     *
-     * Adds "noreferrer" to the rel set when target opens a new browsing
-     * context AND the URL is external. "External" includes:
-     *   - absolute http(s) URLs (`http://...`, `https://...`)
-     *   - protocol-relative URLs (`//example.com/...`) — RFC 3986 §4.4.2,
-     *     these inherit the page's scheme and resolve to a different host
-     *     (single-slash paths like `/foo` are internal — startsWith `//`
-     *     and `/` are matched in that order to disambiguate).
-     *
-     * Existing rel tokens from the source `<a>` (e.g. `nofollow`,
-     * `sponsored`, `noopener`) are preserved. If "noreferrer" is already
-     * present in the source rel, the source value is returned unchanged.
-     *
-     * Returns the source rel (if any) for relative paths, fragments,
-     * mailto:/tel:/t3:, and non-browsing-context targets — i.e. cases
-     * where typolink wouldn't add security rel either. (t3:// URLs are
-     * already resolved to absolute paths before reaching this method.)
-     *
-     * @param string|null $target   Link target attribute
-     * @param string      $url      Resolved link URL
-     * @param string|null $existing Pre-existing rel value from the source `<a>` tag
-     *
-     * @return string|null Merged rel value (or null when neither security
-     *                     rel applies nor a source rel was provided)
-     *
-     * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/799
-     */
-    private function computeSecurityRel(?string $target, string $url, ?string $existing = null): ?string
-    {
-        $existingTokens = $this->parseRelTokens($existing);
-
-        // Determine whether security rel should be added.
-        $needsNoreferrer = false;
-        if ($target !== null && !in_array($target, ['', '_self', '_parent', '_top'], true)) {
-            // Trim and lowercase for stable scheme detection. validateLinkUrl()
-            // upstream already trims, but be defensive — the URL traversed our
-            // attribute pipeline and may still have edge whitespace from the
-            // original RTE markup.
-            $normalized = strtolower(trim($url));
-            $needsNoreferrer
-                = str_starts_with($normalized, 'http://')
-                || str_starts_with($normalized, 'https://')
-                // Protocol-relative URLs inherit the page's scheme and resolve
-                // to a different host. RFC 3986 §4.4.2 calls these
-                // "network-path references". `//foo` ⇒ external; `/foo` ⇒ internal.
-                || str_starts_with($normalized, '//');
-        }
-
-        if ($needsNoreferrer && !in_array('noreferrer', $existingTokens, true)) {
-            $existingTokens[] = 'noreferrer';
-        }
-
-        return $existingTokens === [] ? null : implode(' ', $existingTokens);
-    }
-
-    /**
-     * Parse an HTML `rel` attribute value into a list of unique tokens.
-     *
-     * The rel attribute is space-separated per HTML living standard. Tokens
-     * are case-insensitive but conventionally lowercase; we lowercase for
-     * comparison stability and de-duplicate while preserving first-seen order.
-     *
-     * @param string|null $value Raw rel attribute value
-     *
-     * @return list<string> Unique lowercased tokens, empty when no value
-     */
-    private function parseRelTokens(?string $value): array
-    {
-        if ($value === null) {
-            return [];
-        }
-
-        $trimmed = trim($value);
-        if ($trimmed === '') {
-            return [];
-        }
-
-        $rawTokens = preg_split('/\s+/', strtolower($trimmed));
-        if ($rawTokens === false) {
-            return [];
-        }
-
-        $tokens = [];
-        foreach ($rawTokens as $token) {
-            if ($token !== '' && !in_array($token, $tokens, true)) {
-                $tokens[] = $token;
-            }
-        }
-
-        return $tokens;
-    }
-
-    /**
      * Get attribute value with fallback to file property.
      *
      * Handles the override mechanism where:
@@ -808,7 +705,12 @@ class ImageResolverService
         array $conf,
         ServerRequestInterface $request,
     ): ?LinkDto {
-        $url = $linkAttributes['href'] ?? '';
+        // Trim once at the boundary so the validated URL and the URL emitted
+        // into the rendered <a href="..."> are byte-identical. validateLinkUrl
+        // trims internally for its own checks but the original was previously
+        // stored verbatim, opening a gap where a whitespace-padded href could
+        // pass validation while emitting a different string in the output.
+        $url = trim($linkAttributes['href'] ?? '');
 
         // SECURITY: Validate URL to prevent JavaScript injection
         if (!$this->validateLinkUrl($url)) {
@@ -833,7 +735,7 @@ class ImageResolverService
             params: $linkAttributes['data-link-params'] ?? null,
             isPopup: $isPopup,
             jsConfig: $jsConfig,
-            rel: $this->computeSecurityRel($target, $url, $linkAttributes['rel'] ?? null),
+            rel: SecurityRelComputer::compute($target, $url, $linkAttributes['rel'] ?? null),
         );
     }
 
@@ -1001,7 +903,8 @@ class ImageResolverService
         $link = null;
 
         if ($linkAttributes !== null && isset($linkAttributes['href'])) {
-            $linkUrl = $linkAttributes['href'];
+            // Trim at the boundary — see buildLinkDto() for rationale.
+            $linkUrl = trim($linkAttributes['href']);
 
             // SECURITY: Validate URL to prevent JavaScript injection
             if ($this->validateLinkUrl($linkUrl)) {
@@ -1013,7 +916,7 @@ class ImageResolverService
                     params: $linkAttributes['data-link-params'] ?? null,
                     isPopup: $isPopup,
                     jsConfig: null, // External images don't get popup config
-                    rel: $this->computeSecurityRel($linkTarget, $linkUrl, $linkAttributes['rel'] ?? null),
+                    rel: SecurityRelComputer::compute($linkTarget, $linkUrl, $linkAttributes['rel'] ?? null),
                 );
             }
         }

--- a/Classes/Service/ImageResolverService.php
+++ b/Classes/Service/ImageResolverService.php
@@ -702,8 +702,13 @@ class ImageResolverService
             return [];
         }
 
+        $rawTokens = preg_split('/\s+/', strtolower($trimmed));
+        if ($rawTokens === false) {
+            return [];
+        }
+
         $tokens = [];
-        foreach (preg_split('/\s+/', strtolower($trimmed)) ?: [] as $token) {
+        foreach ($rawTokens as $token) {
             if ($token !== '' && !in_array($token, $tokens, true)) {
                 $tokens[] = $token;
             }

--- a/Classes/Service/ImageResolverService.php
+++ b/Classes/Service/ImageResolverService.php
@@ -616,7 +616,8 @@ class ImageResolverService
 
     /**
      * Compute the rel attribute for an editorial link, mirroring TYPO3's
-     * LinkFactory::addSecurityRelValues() semantics.
+     * LinkFactory::addSecurityRelValues() semantics, while preserving any
+     * rel tokens that came from the source `<a>` tag.
      *
      * The Fluid Link.html partial constructs <a> directly (it does not go
      * through typolink), so the security rel attribute that typolink would
@@ -625,49 +626,90 @@ class ImageResolverService
      * without rel="noreferrer" — a regression of the security default that
      * the rest of TYPO3 applies automatically.
      *
-     * Returns "noreferrer" when target opens a new browsing context AND the
-     * URL is external. "External" includes:
+     * Adds "noreferrer" to the rel set when target opens a new browsing
+     * context AND the URL is external. "External" includes:
      *   - absolute http(s) URLs (`http://...`, `https://...`)
-     *   - protocol-relative URLs (`//example.com/...`) — RFC 3986 §4.2,
+     *   - protocol-relative URLs (`//example.com/...`) — RFC 3986 §4.4.2,
      *     these inherit the page's scheme and resolve to a different host
-     * Returns null for relative paths, fragments, mailto:/tel:/t3:, and
-     * non-browsing-context targets. (t3:// URLs are already resolved to
-     * absolute paths before reaching this method.)
+     *     (single-slash paths like `/foo` are internal — startsWith `//`
+     *     and `/` are matched in that order to disambiguate).
      *
-     * @param string|null $target Link target attribute
-     * @param string      $url    Resolved link URL
+     * Existing rel tokens from the source `<a>` (e.g. `nofollow`,
+     * `sponsored`, `noopener`) are preserved. If "noreferrer" is already
+     * present in the source rel, the source value is returned unchanged.
      *
-     * @return string|null Security rel value or null
+     * Returns the source rel (if any) for relative paths, fragments,
+     * mailto:/tel:/t3:, and non-browsing-context targets — i.e. cases
+     * where typolink wouldn't add security rel either. (t3:// URLs are
+     * already resolved to absolute paths before reaching this method.)
+     *
+     * @param string|null $target   Link target attribute
+     * @param string      $url      Resolved link URL
+     * @param string|null $existing Pre-existing rel value from the source `<a>` tag
+     *
+     * @return string|null Merged rel value (or null when neither security
+     *                     rel applies nor a source rel was provided)
      *
      * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/799
      */
-    private function computeSecurityRel(?string $target, string $url): ?string
+    private function computeSecurityRel(?string $target, string $url, ?string $existing = null): ?string
     {
-        // No target or self/parent/top targets keep the same browsing context — no security risk.
-        if ($target === null || in_array($target, ['', '_self', '_parent', '_top'], true)) {
-            return null;
+        $existingTokens = $this->parseRelTokens($existing);
+
+        // Determine whether security rel should be added.
+        $needsNoreferrer = false;
+        if ($target !== null && !in_array($target, ['', '_self', '_parent', '_top'], true)) {
+            // Trim and lowercase for stable scheme detection. validateLinkUrl()
+            // upstream already trims, but be defensive — the URL traversed our
+            // attribute pipeline and may still have edge whitespace from the
+            // original RTE markup.
+            $normalized = strtolower(trim($url));
+            $needsNoreferrer
+                = str_starts_with($normalized, 'http://')
+                || str_starts_with($normalized, 'https://')
+                // Protocol-relative URLs inherit the page's scheme and resolve
+                // to a different host. RFC 3986 §4.4.2 calls these
+                // "network-path references". `//foo` ⇒ external; `/foo` ⇒ internal.
+                || str_starts_with($normalized, '//');
         }
 
-        // Trim and lowercase for stable scheme detection. validateLinkUrl()
-        // upstream already trims, but be defensive — the URL traversed our
-        // attribute pipeline and may still have edge whitespace from the
-        // original RTE markup.
-        $normalized = strtolower(trim($url));
-
-        // Absolute http(s) URLs are external by definition.
-        if (str_starts_with($normalized, 'http://') || str_starts_with($normalized, 'https://')) {
-            return 'noreferrer';
+        if ($needsNoreferrer && !in_array('noreferrer', $existingTokens, true)) {
+            $existingTokens[] = 'noreferrer';
         }
 
-        // Protocol-relative URLs (`//example.com/...`) inherit the page's
-        // scheme and resolve to whatever host follows the `//`. Treat as
-        // external. Note the second character must NOT be another `/` (a
-        // single-slash path like `/foo` is internal).
-        if (str_starts_with($normalized, '//')) {
-            return 'noreferrer';
+        return $existingTokens === [] ? null : implode(' ', $existingTokens);
+    }
+
+    /**
+     * Parse an HTML `rel` attribute value into a list of unique tokens.
+     *
+     * The rel attribute is space-separated per HTML living standard. Tokens
+     * are case-insensitive but conventionally lowercase; we lowercase for
+     * comparison stability and de-duplicate while preserving first-seen order.
+     *
+     * @param string|null $value Raw rel attribute value
+     *
+     * @return list<string> Unique lowercased tokens, empty when no value
+     */
+    private function parseRelTokens(?string $value): array
+    {
+        if ($value === null) {
+            return [];
         }
 
-        return null;
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return [];
+        }
+
+        $tokens = [];
+        foreach (preg_split('/\s+/', strtolower($trimmed)) ?: [] as $token) {
+            if ($token !== '' && !in_array($token, $tokens, true)) {
+                $tokens[] = $token;
+            }
+        }
+
+        return $tokens;
     }
 
     /**
@@ -786,7 +828,7 @@ class ImageResolverService
             params: $linkAttributes['data-link-params'] ?? null,
             isPopup: $isPopup,
             jsConfig: $jsConfig,
-            rel: $this->computeSecurityRel($target, $url),
+            rel: $this->computeSecurityRel($target, $url, $linkAttributes['rel'] ?? null),
         );
     }
 
@@ -966,7 +1008,7 @@ class ImageResolverService
                     params: $linkAttributes['data-link-params'] ?? null,
                     isPopup: $isPopup,
                     jsConfig: null, // External images don't get popup config
-                    rel: $this->computeSecurityRel($linkTarget, $linkUrl),
+                    rel: $this->computeSecurityRel($linkTarget, $linkUrl, $linkAttributes['rel'] ?? null),
                 );
             }
         }

--- a/Classes/Service/SecurityRelComputer.php
+++ b/Classes/Service/SecurityRelComputer.php
@@ -41,39 +41,54 @@ final class SecurityRelComputer
      *     and `/` are matched in that order to disambiguate).
      *
      * Existing rel tokens from the source `<a>` (e.g. `nofollow`,
-     * `sponsored`, `noopener`) are preserved. If "noreferrer" is already
-     * present in the source rel, the source value is returned unchanged.
+     * `sponsored`, `noopener`) are preserved through `parseTokens()`,
+     * which lowercases, deduplicates, and collapses whitespace — so the
+     * returned string is normalized rather than verbatim from the source.
+     * "noreferrer" is added at most once; if the source already has it,
+     * no duplicate is appended.
      *
-     * Returns the source rel (if any) for relative paths, fragments,
+     * Returns the (normalized) source rel for relative paths, fragments,
      * mailto:/tel:/t3:, and non-browsing-context targets — i.e. cases
      * where typolink wouldn't add security rel either. (t3:// URLs are
      * already resolved to absolute paths before reaching this method.)
+     *
+     * The HTML browsing-context keywords (`_self`, `_blank`, `_parent`,
+     * `_top`) are matched case-insensitively per the HTML living standard
+     * and after trimming, so values like `_SELF` or `  _self  ` are
+     * correctly classified as same-context.
      *
      * @param string|null $target   Link target attribute
      * @param string      $url      Resolved link URL
      * @param string|null $existing Pre-existing rel value from the source `<a>` tag
      *
-     * @return string|null Merged rel value (or null when neither security
-     *                     rel applies nor a source rel was provided)
+     * @return string|null Normalized merged rel value (or null when
+     *                     neither security rel applies nor a source rel
+     *                     was provided)
      */
     public static function compute(?string $target, string $url, ?string $existing = null): ?string
     {
         $existingTokens = self::parseTokens($existing);
 
+        // Normalize target for the same-context comparison: HTML
+        // browsing-context keywords are case-insensitive. Trim and
+        // lowercase so values like `_SELF` or `  _Top  ` are still
+        // recognized and short-circuit the security rel addition.
+        $normalizedTarget = $target === null ? null : strtolower(trim($target));
+
         // Determine whether security rel should be added.
         $needsNoreferrer = false;
-        if ($target !== null && !in_array($target, ['', '_self', '_parent', '_top'], true)) {
+        if ($normalizedTarget !== null && !in_array($normalizedTarget, ['', '_self', '_parent', '_top'], true)) {
             // Trim and lowercase for stable scheme detection. Defensive even
             // if the URL has been validated upstream — we don't want surface
             // whitespace from RTE markup to silently change the predicate.
-            $normalized = strtolower(trim($url));
+            $normalizedUrl = strtolower(trim($url));
             $needsNoreferrer
-                = str_starts_with($normalized, 'http://')
-                || str_starts_with($normalized, 'https://')
+                = str_starts_with($normalizedUrl, 'http://')
+                || str_starts_with($normalizedUrl, 'https://')
                 // Protocol-relative URLs inherit the page's scheme and resolve
                 // to a different host. RFC 3986 §4.4.2 calls these
                 // "network-path references". `//foo` ⇒ external; `/foo` ⇒ internal.
-                || str_starts_with($normalized, '//');
+                || str_starts_with($normalizedUrl, '//');
         }
 
         if ($needsNoreferrer && !in_array('noreferrer', $existingTokens, true)) {

--- a/Classes/Service/SecurityRelComputer.php
+++ b/Classes/Service/SecurityRelComputer.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\RteCKEditorImage\Service;
+
+/**
+ * Pure helpers for computing the HTML `rel` attribute on editorial
+ * `<a>` tags rendered by the Fluid Link partial.
+ *
+ * The Fluid Link.html partial constructs <a> directly (it does not go
+ * through TYPO3 typolink), so the security rel attribute that
+ * LinkFactory::addSecurityRelValues() would normally add for external
+ * `target="_blank"` links has to be computed here.
+ *
+ * Both methods are pure functions — no I/O, no DI — to keep them
+ * trivially unit-testable.
+ *
+ * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/799
+ *
+ * @internal
+ */
+final class SecurityRelComputer
+{
+    /**
+     * Compute the rel attribute for an editorial link, mirroring TYPO3's
+     * LinkFactory::addSecurityRelValues() semantics, while preserving any
+     * rel tokens that came from the source `<a>` tag.
+     *
+     * Adds "noreferrer" to the rel set when target opens a new browsing
+     * context AND the URL is external. "External" includes:
+     *   - absolute http(s) URLs (`http://...`, `https://...`)
+     *   - protocol-relative URLs (`//example.com/...`) — RFC 3986 §4.4.2,
+     *     these inherit the page's scheme and resolve to a different host
+     *     (single-slash paths like `/foo` are internal — startsWith `//`
+     *     and `/` are matched in that order to disambiguate).
+     *
+     * Existing rel tokens from the source `<a>` (e.g. `nofollow`,
+     * `sponsored`, `noopener`) are preserved. If "noreferrer" is already
+     * present in the source rel, the source value is returned unchanged.
+     *
+     * Returns the source rel (if any) for relative paths, fragments,
+     * mailto:/tel:/t3:, and non-browsing-context targets — i.e. cases
+     * where typolink wouldn't add security rel either. (t3:// URLs are
+     * already resolved to absolute paths before reaching this method.)
+     *
+     * @param string|null $target   Link target attribute
+     * @param string      $url      Resolved link URL
+     * @param string|null $existing Pre-existing rel value from the source `<a>` tag
+     *
+     * @return string|null Merged rel value (or null when neither security
+     *                     rel applies nor a source rel was provided)
+     */
+    public static function compute(?string $target, string $url, ?string $existing = null): ?string
+    {
+        $existingTokens = self::parseTokens($existing);
+
+        // Determine whether security rel should be added.
+        $needsNoreferrer = false;
+        if ($target !== null && !in_array($target, ['', '_self', '_parent', '_top'], true)) {
+            // Trim and lowercase for stable scheme detection. Defensive even
+            // if the URL has been validated upstream — we don't want surface
+            // whitespace from RTE markup to silently change the predicate.
+            $normalized = strtolower(trim($url));
+            $needsNoreferrer
+                = str_starts_with($normalized, 'http://')
+                || str_starts_with($normalized, 'https://')
+                // Protocol-relative URLs inherit the page's scheme and resolve
+                // to a different host. RFC 3986 §4.4.2 calls these
+                // "network-path references". `//foo` ⇒ external; `/foo` ⇒ internal.
+                || str_starts_with($normalized, '//');
+        }
+
+        if ($needsNoreferrer && !in_array('noreferrer', $existingTokens, true)) {
+            $existingTokens[] = 'noreferrer';
+        }
+
+        return $existingTokens === [] ? null : implode(' ', $existingTokens);
+    }
+
+    /**
+     * Parse an HTML `rel` attribute value into a list of unique tokens.
+     *
+     * The rel attribute is space-separated per HTML living standard. Tokens
+     * are case-insensitive but conventionally lowercase; we lowercase for
+     * comparison stability and de-duplicate while preserving first-seen order.
+     *
+     * @param string|null $value Raw rel attribute value
+     *
+     * @return list<string> Unique lowercased tokens, empty when no value
+     */
+    public static function parseTokens(?string $value): array
+    {
+        if ($value === null) {
+            return [];
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return [];
+        }
+
+        $rawTokens = preg_split('/\s+/', strtolower($trimmed));
+        if ($rawTokens === false) {
+            return [];
+        }
+
+        $tokens = [];
+        foreach ($rawTokens as $token) {
+            if ($token !== '' && !in_array($token, $tokens, true)) {
+                $tokens[] = $token;
+            }
+        }
+
+        return $tokens;
+    }
+}

--- a/Resources/Private/Partials/Image/Link.html
+++ b/Resources/Private/Partials/Image/Link.html
@@ -2,5 +2,5 @@
 <a href="{image.link.urlWithParams}"
    {f:if(condition: image.link.target, then: 'target="{image.link.target}"')}
    {f:if(condition: image.link.class, then: 'class="{image.link.class}"')}
-   {f:if(condition: isPopup, then: 'data-popup="true" rel="lightbox-group-rte"')}>{content -> f:format.raw()}</a>
+   {f:if(condition: isPopup, then: 'data-popup="true" rel="lightbox-group-rte"', else: '{f:if(condition: image.link.rel, then: \'rel="{image.link.rel}"\')}')}>{content -> f:format.raw()}</a>
 </html>

--- a/Tests/E2E/tests/link-default-attributes.spec.ts
+++ b/Tests/E2E/tests/link-default-attributes.spec.ts
@@ -21,19 +21,14 @@ test.describe('Link Default Attributes (#718)', () => {
 
     // Scope to **explicitly-seeded** test fixtures that carry `target="_blank"` in
     // their bodytext source (CE 768 ".test-linked-image" and CE 1024
-    // ".test-figure-linked" in `Build/Scripts/runTests.sh`). Two reasons:
+    // ".test-figure-linked" in `Build/Scripts/runTests.sh`). The fixtures go
+    // through the standard typolink path which calls
+    // `LinkFactory::addSecurityRelValues()` and adds `rel="noreferrer"` on
+    // both v13 and v14. This is the tight invariant of #718's original fix.
     //
-    //  1. Excludes our own popup/lightbox links, which legitimately carry
-    //     `target="_blank"` with `rel="lightbox-group-rte"` (a code path that
-    //     bypasses typolink — see `ImageRenderingService` Popup/Zoom templates).
-    //  2. Excludes inline-image links where our extension currently auto-adds
-    //     `target="_blank"` on TYPO3 v14 without going through typolink's
-    //     `addSecurityRelValues()` — this is a separate v14-specific bug
-    //     surfaced by the variant matrix from #794, tracked as a follow-up.
-    //
-    // The `.test-linked-image` and `.test-figure-linked` fixtures go through
-    // the standard typolink flow on both v13 and v14, so this assertion is the
-    // tight invariant of #718's original fix.
+    // Popup/lightbox links are excluded by the class scoping — they legitimately
+    // use `target="_blank"` with `rel="lightbox-group-rte"` from a code path
+    // that bypasses typolink (see `ImageRenderingService` Popup/Zoom templates).
     const externalLinks = page.locator(
       'a.test-linked-image[target="_blank"], a.test-figure-linked[target="_blank"]'
     );
@@ -50,6 +45,28 @@ test.describe('Link Default Attributes (#718)', () => {
         `Seeded external link ${i} with target="_blank" should have rel attribute containing "noreferrer"`,
       ).toContain('noreferrer');
     }
+  });
+
+  test('figure-wrapped linked images get rel="noreferrer" (#799)', async ({ page }) => {
+    await gotoFrontendPage(page);
+
+    // Regression for #799: figure-wrapped linked images go through our Fluid
+    // Link.html partial which constructs `<a>` directly rather than via typolink,
+    // so the security rel attribute that typolink would normally add for
+    // external `target="_blank"` links has to be set explicitly by our PHP layer.
+    //
+    // CE 10752 in `Build/Scripts/runTests.sh` seeds a table-figure with a
+    // linked image: `<figure class="image"><a href="https://typo3.org" target="_blank"><img></a><figcaption>…</figcaption></figure>`.
+    // The pre-#799 rendering produced `<a target="_blank">` without `rel`,
+    // which would fail this assertion.
+    const figureLink = page.locator('a[href="https://typo3.org"][target="_blank"]:has(img)').first();
+    await expect(figureLink, 'Table-figure linked image should be present (CE 10752)').toBeVisible();
+
+    const rel = await figureLink.getAttribute('rel');
+    expect(
+      rel,
+      'Figure-wrapped linked image with target="_blank" should have rel containing "noreferrer" (regression for #799)',
+    ).toContain('noreferrer');
   });
 
   test('linked inline images preserve target attribute', async ({ page }) => {

--- a/Tests/E2E/tests/link-default-attributes.spec.ts
+++ b/Tests/E2E/tests/link-default-attributes.spec.ts
@@ -56,11 +56,20 @@ test.describe('Link Default Attributes (#718)', () => {
     // external `target="_blank"` links has to be set explicitly by our PHP layer.
     //
     // CE 10752 in `Build/Scripts/runTests.sh` seeds a table-figure with a
-    // linked image: `<figure class="image"><a href="https://typo3.org" target="_blank"><img></a><figcaption>…</figcaption></figure>`.
-    // The pre-#799 rendering produced `<a target="_blank">` without `rel`,
-    // which would fail this assertion.
-    const figureLink = page.locator('a[href="https://typo3.org"][target="_blank"]:has(img)').first();
-    await expect(figureLink, 'Table-figure linked image should be present (CE 10752)').toBeVisible();
+    // linked image:
+    //   <figure class="image">
+    //     <a href="https://typo3.org" target="_blank"><img></a>
+    //     <figcaption>Linked image in table</figcaption>
+    //   </figure>
+    // wrapped inside a content-element <table>. We scope to
+    // `table figure.image > a[href="https://typo3.org"]` so we only match
+    // this specific seed and not the other test-simple-link CE which also
+    // points to https://typo3.org but is rendered outside any table.
+    // The pre-#799 rendering produced `<a target="_blank">` without `rel`.
+    const figureLink = page
+      .locator('table figure.image > a[href="https://typo3.org"][target="_blank"]:has(img)')
+      .first();
+    await expect(figureLink, 'CE 10752 table-figure linked image should be present').toBeVisible();
 
     const rel = await figureLink.getAttribute('rel');
     expect(

--- a/Tests/Unit/Domain/Model/LinkDtoTest.php
+++ b/Tests/Unit/Domain/Model/LinkDtoTest.php
@@ -36,6 +36,7 @@ class LinkDtoTest extends TestCase
             params: '&L=1&type=123',
             isPopup: true,
             jsConfig: $jsConfig,
+            rel: 'noreferrer',
         );
 
         self::assertSame('https://example.com/image.jpg', $dto->url);
@@ -44,6 +45,21 @@ class LinkDtoTest extends TestCase
         self::assertSame('&L=1&type=123', $dto->params);
         self::assertTrue($dto->isPopup);
         self::assertSame($jsConfig, $dto->jsConfig);
+        self::assertSame('noreferrer', $dto->rel);
+    }
+
+    public function testConstructorRelDefaultsToNull(): void
+    {
+        $dto = new LinkDto(
+            url: 'https://example.com',
+            target: '_blank',
+            class: null,
+            params: null,
+            isPopup: false,
+            jsConfig: null,
+        );
+
+        self::assertNull($dto->rel);
     }
 
     public function testConstructorAcceptsNullValues(): void
@@ -78,7 +94,7 @@ class LinkDtoTest extends TestCase
 
         $reflection = new ReflectionClass($dto);
 
-        $properties = ['url', 'target', 'class', 'params', 'isPopup', 'jsConfig'];
+        $properties = ['url', 'target', 'class', 'params', 'isPopup', 'jsConfig', 'rel'];
 
         foreach ($properties as $propertyName) {
             $property = $reflection->getProperty($propertyName);

--- a/Tests/Unit/Service/SecurityRelComputerTest.php
+++ b/Tests/Unit/Service/SecurityRelComputerTest.php
@@ -115,6 +115,26 @@ final class SecurityRelComputerTest extends TestCase
         yield 'empty existing string → null' => [
             '_blank', '/internal', '', null,
         ];
+
+        // === Target normalization (case-insensitive + trim) ===
+        yield 'uppercase _SELF treated as same-context' => [
+            '_SELF', 'https://example.com', null, null,
+        ];
+        yield 'mixed-case _Parent treated as same-context' => [
+            '_Parent', 'https://example.com', null, null,
+        ];
+        yield 'mixed-case _Top treated as same-context' => [
+            '_Top', 'https://example.com', null, null,
+        ];
+        yield 'whitespace-padded _self treated as same-context' => [
+            '  _self  ', 'https://example.com', null, null,
+        ];
+        yield 'mixed-case _Blank still gets noreferrer for external' => [
+            '_Blank', 'https://example.com', null, 'noreferrer',
+        ];
+        yield 'uppercase _BLANK still gets noreferrer for external' => [
+            '_BLANK', 'https://example.com', null, 'noreferrer',
+        ];
     }
 
     #[Test]

--- a/Tests/Unit/Service/SecurityRelComputerTest.php
+++ b/Tests/Unit/Service/SecurityRelComputerTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\RteCKEditorImage\Tests\Unit\Service;
+
+use Netresearch\RteCKEditorImage\Service\SecurityRelComputer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit coverage for the rel-computation helper used by the Fluid Link path.
+ *
+ * The Fluid Link.html partial constructs <a> directly, bypassing TYPO3
+ * typolink — so we mirror LinkFactory::addSecurityRelValues() in PHP and
+ * lock its semantics here.
+ *
+ * @covers \Netresearch\RteCKEditorImage\Service\SecurityRelComputer
+ */
+final class SecurityRelComputerTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{0: ?string, 1: string, 2: ?string, 3: ?string}>
+     */
+    public static function computeProvider(): iterable
+    {
+        // === Adds noreferrer for external + new browsing context ===
+        yield 'http _blank gets noreferrer' => [
+            '_blank', 'http://example.com', null, 'noreferrer',
+        ];
+        yield 'https _blank gets noreferrer' => [
+            '_blank', 'https://example.com/path', null, 'noreferrer',
+        ];
+        yield 'protocol-relative _blank gets noreferrer' => [
+            '_blank', '//example.com/path', null, 'noreferrer',
+        ];
+        yield 'uppercase HTTPS scheme matched' => [
+            '_blank', 'HTTPS://EXAMPLE.COM', null, 'noreferrer',
+        ];
+        yield 'leading whitespace url still external' => [
+            '_blank', '  https://example.com', null, 'noreferrer',
+        ];
+        yield 'custom target name like custom_window' => [
+            'custom_window', 'https://example.com', null, 'noreferrer',
+        ];
+
+        // === Does NOT add noreferrer ===
+        yield 'no target → null' => [
+            null, 'https://example.com', null, null,
+        ];
+        yield 'empty target → null' => [
+            '', 'https://example.com', null, null,
+        ];
+        yield '_self target → null' => [
+            '_self', 'https://example.com', null, null,
+        ];
+        yield '_parent target → null' => [
+            '_parent', 'https://example.com', null, null,
+        ];
+        yield '_top target → null' => [
+            '_top', 'https://example.com', null, null,
+        ];
+        yield 'absolute path is internal — no rel' => [
+            '_blank', '/fileadmin/foo.jpg', null, null,
+        ];
+        yield 'fragment is internal — no rel' => [
+            '_blank', '#section', null, null,
+        ];
+        yield 'mailto is non-browsing-context handler — no rel' => [
+            '_blank', 'mailto:foo@example.com', null, null,
+        ];
+        yield 'tel is non-browsing-context handler — no rel' => [
+            '_blank', 'tel:+1234567890', null, null,
+        ];
+
+        // === Preserves existing rel tokens ===
+        yield 'preserves nofollow on external _blank' => [
+            '_blank', 'https://example.com', 'nofollow', 'nofollow noreferrer',
+        ];
+        yield 'preserves multiple tokens' => [
+            '_blank', 'https://example.com', 'nofollow sponsored', 'nofollow sponsored noreferrer',
+        ];
+        yield 'preserves noopener and adds noreferrer' => [
+            '_blank', 'https://example.com', 'noopener', 'noopener noreferrer',
+        ];
+        yield 'idempotent — does not duplicate noreferrer' => [
+            '_blank', 'https://example.com', 'noreferrer', 'noreferrer',
+        ];
+        yield 'preserves source rel even when not external' => [
+            '_self', 'https://example.com', 'nofollow', 'nofollow',
+        ];
+        yield 'preserves source rel for internal url with _blank' => [
+            '_blank', '/fileadmin/foo.jpg', 'nofollow', 'nofollow',
+        ];
+        yield 'lowercases existing tokens' => [
+            '_blank', 'https://example.com', 'NoFollow', 'nofollow noreferrer',
+        ];
+        yield 'deduplicates duplicate source tokens' => [
+            '_blank', 'https://example.com', 'nofollow nofollow', 'nofollow noreferrer',
+        ];
+        yield 'collapses extra whitespace in source' => [
+            '_blank', 'https://example.com', '  nofollow   sponsored  ', 'nofollow sponsored noreferrer',
+        ];
+
+        // === Edge cases ===
+        yield 'null url with empty existing → null' => [
+            '_blank', '', null, null,
+        ];
+        yield 'empty existing string → null' => [
+            '_blank', '/internal', '', null,
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('computeProvider')]
+    public function computeMatchesExpectedRel(?string $target, string $url, ?string $existing, ?string $expected): void
+    {
+        self::assertSame(
+            $expected,
+            SecurityRelComputer::compute($target, $url, $existing),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{0: ?string, 1: list<string>}>
+     */
+    public static function parseTokensProvider(): iterable
+    {
+        yield 'null' => [null, []];
+        yield 'empty string' => ['', []];
+        yield 'whitespace only' => ['   ', []];
+        yield 'single token' => ['nofollow', ['nofollow']];
+        yield 'multiple tokens' => ['nofollow sponsored', ['nofollow', 'sponsored']];
+        yield 'tab separated' => ["nofollow\tsponsored", ['nofollow', 'sponsored']];
+        yield 'newline separated' => ["nofollow\nsponsored", ['nofollow', 'sponsored']];
+        yield 'lowercase normalization' => ['NOFOLLOW SPONSORED', ['nofollow', 'sponsored']];
+        yield 'deduplication' => ['nofollow nofollow', ['nofollow']];
+        yield 'extra whitespace' => ['  a   b  c  ', ['a', 'b', 'c']];
+    }
+
+    /**
+     * @param list<string> $expected
+     */
+    #[Test]
+    #[DataProvider('parseTokensProvider')]
+    public function parseTokensYieldsExpectedList(?string $value, array $expected): void
+    {
+        self::assertSame($expected, SecurityRelComputer::parseTokens($value));
+    }
+}


### PR DESCRIPTION
## Summary

Figure-wrapped linked images go through our Fluid `Link.html` partial, which builds the `<a>` tag directly via Fluid rather than via TYPO3 typolink. The standard `LinkFactory::addSecurityRelValues()` — which would normally append `rel="noreferrer"` to external `target="_blank"` links — never runs on this code path. Result: `<a href="https://typo3.org" target="_blank"><img></a>` lacked the rel attribute that browser security policy expects.

The bug exists on **both v13 and v14**. It surfaced on v14 first because TYPO3 v14 removed the default `config.extTarget = _blank`, which means v14 has far fewer auto-rel'd external links to mask the broken figure case in DOM order.

See the [diagnosis comment on #799](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/799#issuecomment-4320426205) for the per-variant outerHTML evidence and timeline.

## Fix

Mirror `addSecurityRelValues()` in our PHP layer:

- Add `?string $rel` to `LinkDto`.
- Add `computeSecurityRel()` helper in `ImageResolverService`:
  - Returns `"noreferrer"` when target opens a new browsing context (any non-empty target outside `_self`/`_parent`/`_top`) **AND** the URL is absolute `http(s)` (relative paths and fragments are internal).
  - Returns `null` otherwise.
- Wire it into both editorial `LinkDto` construction sites (`buildLinkDto` for FAL-resolved images, `createDtoFromExternalImage` for external images). The popup builder is intentionally untouched: popup links emit `rel="lightbox-group-rte"` via the existing `isPopup` branch in the template.
- Update `Link.html` partial to emit `rel="{image.link.rel}"` when set on non-popup links.

## Test plan

- [x] Unit: `LinkDtoTest` extended for the new `rel` parameter (default-null and explicit-set cases) and the readonly-properties enumeration. **All 788 tests pass locally** (was 787).
- [x] E2E: new regression test in `link-default-attributes.spec.ts` — `figure-wrapped linked images get rel="noreferrer" (#799)` — targets the CE 10752 table-figure linked image specifically (`https://typo3.org`). Pre-fix this would render without rel on both v13 and v14; post-fix it carries `rel="noreferrer"`.
- [x] PHPStan: clean on changed files at level 10.
- [ ] CI: 6×e2e variants (TYPO3 ^13.4.21 / ^14.3 × fsc/core-only/bootstrap) all green.

## Refs

- [Issue #799](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/799) — original report (rebranded after diagnosis).
- [Diagnostic PR #800](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/800) — Playwright outerHTML dump that pinpointed the actual broken link.
- [PR #797](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/797), [PR #798](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/798) — earlier fixes from the same variant-matrix exposure round.
- [PR #718](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/718) — original `tags.a` typolink path fix; this one covers the parallel Fluid path.