### PR TITLE
ci: trigger CodeQL and dependency-review on merge_group events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       actions: read
 
   dependency-review:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     uses: netresearch/.github/.github/workflows/dependency-review.yml@main
     permissions:
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   schedule:
     - cron: '0 6 * * 1'
 permissions: {}


### PR DESCRIPTION
## Summary

Required status checks defined in the [default ruleset](https://github.com/netresearch/t3x-rte_ckeditor_image/rules/9141168) — `analyze / Analyze (actions)`, `analyze / Prepare languages`, `dependency-review / Dependency Review` — only ran on \`pull_request\` events. Merge queue candidate branches (\`gh-readonly-queue/main/*\`) emit \`merge_group\` events, so those checks were never produced on the candidate, and the queue waited forever.

This was the root cause behind #802 sitting in \`AWAITING_CHECKS\` indefinitely after the BLOCKED state was cleared. The contexts had to be temporarily removed from \`required_status_checks\` to unblock #802.

## Changes

- \`.github/workflows/codeql.yml\` — add \`merge_group:\` to triggers (was missing entirely).
- \`.github/workflows/ci.yml\` — extend the \`dependency-review\` job's \`if:\` to also accept \`merge_group\` events.

\`pr-quality\` is intentionally left as \`pull_request\`-only — its \"Auto-Approve (Solo Maintainer)\" step semantically only makes sense on PR events.

## Follow-up

Once this merges, re-add to \`required_status_checks\` (will work in both contexts now):
- \`analyze / Analyze (actions)\`
- \`analyze / Prepare languages\`
- \`dependency-review / Dependency Review\`

## Test plan

- [ ] CI runs on the PR (pull_request event) — all three jobs present and green.
- [ ] After merge, the next merge queue candidate emits all three jobs as well.