### PR TITLE
docs: sync rel="noreferrer" docs and clean up validation findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`rel="noreferrer"` missing on figure-wrapped linked images** ([#799](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/799), [#802](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/802)) — figure-wrapped linked images go through the Fluid `Link.html` partial, which builds the `<a>` tag directly rather than via TYPO3 typolink, so `LinkFactory::addSecurityRelValues()` never ran for them. External `target="_blank"` links lacked the `rel="noreferrer"` browser security policy expects. Mirrored the typolink semantics in a new `SecurityRelComputer` service: `noreferrer` is now appended whenever the target opens a new browsing context AND the URL is absolute `http(s)` or protocol-relative (`//example.com/...`). Existing `rel` tokens from the source `<a>` are preserved (lowercased, deduplicated, normalized). Bug existed on both v13 and v14; surfaced on v14 because v14 dropped the default `config.extTarget = _blank`. New unit + E2E coverage.
 - **`<p>` tags entity-encoded in plain RTE bodytext on vanilla installs** ([#790](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/790)) — removed restrictive `lib.parseFunc_RTE.allowTags`/`denyTags` modifications from `setup.typoscript`. They were artifacts from pre-TYPO3-v13.2 (when `fluid_styled_content` provided defaults that have since moved); on current installs they made `parseFunc` `htmlspecialchars`-encode every standard tag including `<p>`. Added an E2E regression spec. Thanks [@timofo](https://github.com/timofo) for pinpointing the exact line.
 
 ### Changed
@@ -24,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **17 translator context notes** — add XLIFF notes to ambiguous keys to prevent future translation errors
 - **Debug leftover** — replace modal title `'test'` with translated "Select image"
 
+## [13.8.2] - 2026-04-10
+
+_No GitHub release was created for this tag. See [git tag v13.8.2](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v13.8.2) and [commit log](https://github.com/netresearch/t3x-rte_ckeditor_image/commits/v13.8.2)._
+
 ## [13.8.1] - 2026-04-10
 
 ### Fixed
@@ -35,6 +40,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Danish backend localization
+
+## [12.0.11] - 2026-03-26
+
+## Bug Fixes
+
+- **Resolve all PHPStan errors** (#754): PHPStan baseline now only contains deprecated items, all actual errors resolved.
+- **Replace removed `getFileStorageRecords()`** (#751): Replaced deprecated method with `checkActionPermission()` for proper file storage access checks. Fixes #749.
+
+## CI/CD
+
+- **Pin GitHub Actions to full-length commit SHAs** (#753): Improved supply chain security by pinning all GitHub Actions to immutable commit hashes.
+- **Add unit test support to CI pipeline**: Unit tests are now included in the CI build matrix.
+
+## Contributors
+
+- @hansup — bug report (#749)
+- @magicsunday — PHPStan fixes, API migration, unit tests (#751, #754)
+- @CybotTM — GitHub Actions security hardening (#753)
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v12.0.11) for the original notes._
 
 ## [13.8.0] - 2026-03-14
 
@@ -51,6 +76,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Migrate CI to centralized `typo3-ci-workflows`
+
+## [12.0.10] - 2026-03-13
+
+## Bug Fixes
+
+- **PCRE limits restored after image processing** (#731, #733): Modified PCRE backtrack/recursion limits are now reverted to their original values after image processing completes, preventing side effects on subsequent code.
+
+## Contributors
+
+- @joharthun — bug report (#731)
+- @vimar — fix (#733)
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v12.0.10) for the original notes._
 
 ## [13.7.1] - 2026-03-07
 
@@ -71,6 +109,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrate to centralized dev-dependencies package ([#717](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/717))
 - Migrate CI to centralized `typo3-ci-workflows` ([#701](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/701), [#716](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/716))
 - Add SPDX copyright and license headers to all PHP files ([#700](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/700))
+
+## [13.7.0] - 2026-03-06
+
+_No GitHub release was created for this tag. See [git tag v13.7.0](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v13.7.0) and [commit log](https://github.com/netresearch/t3x-rte_ckeditor_image/commits/v13.7.0)._
+
+## [12.0.9] - 2026-02-26
+
+## Bug Fixes
+
+- **Image Browser 503 error** (#703): Fixed SelectImageController not calling parent constructor, leaving ElementBrowserRegistry uninitialized. Now uses proper constructor dependency injection.
+
+## CI
+
+- Fixed TER publishing: removed declare(strict_types=1) from ext_emconf.php (TER cannot parse it)
+- Synced TER publish workflow from main branch
+
+## Development
+
+- Added DDEV setup for local TYPO3 v12 development and testing
+
+## Closes
+
+- #703
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v12.0.9) for the original notes._
+
+## [12.0.8] - 2026-02-26
+
+_No GitHub release was created for this tag. See [git tag v12.0.8](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v12.0.8) and [commit log](https://github.com/netresearch/t3x-rte_ckeditor_image/commits/v12.0.8)._
+
+## [12.0.7] - 2026-02-26
+
+_No GitHub release was created for this tag. See [git tag v12.0.7](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v12.0.7) and [commit log](https://github.com/netresearch/t3x-rte_ckeditor_image/commits/v12.0.7)._
+
+## [12.0.6] - 2026-02-26
+
+_No GitHub release was created for this tag. See [git tag v12.0.6](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v12.0.6) and [commit log](https://github.com/netresearch/t3x-rte_ckeditor_image/commits/v12.0.6)._
 
 ## [13.6.1] - 2026-02-25
 
@@ -113,6 +188,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **OpenSSF Scorecard** improved from 6.8 to ~9.0 ([#628](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/628))
 - E2E test suite with priority 1 coverage for all critical user paths, sharded across 11 parallel CI runners ([#621](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/621))
 - TYPO3 v14 E2E testing support, now blocking ([#611](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/611), [#626](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/626))
+
+## [12.0.5] - 2026-02-14
+
+## Bug Fixes
+
+- **Image regeneration** (#277): Restored `getProcessedFile()` in `RteImagesDbHook` to regenerate processed images when the source file is missing (e.g., after TYPO3 upgrades or cache clearing)
+- **Image processing without fluid_styled_content** (#287, #291): Added `lib.parseFunc` fallback in TypoScript for installations that don't use `fluid_styled_content`, fixing broken image processing and linking
+
+## CI Improvements
+
+- Added `Build ✓` summary job for branch protection compatibility
+- Added auto-approve workflow for solo maintainer PR merging
+- Applied Rector rule: `str_starts_with()` instead of `strpos()`
+
+## Closes
+
+- #277 — Regression for #199 (image regeneration)
+- #287 — Linking an image not working
+- #291 — Images not processed, unwanted attributes
+
+Cherry-picked from [PR #372](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/372) and [PR #375](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/375).
+Merged via [PR #631](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/631).
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v12.0.5) for the original notes._
+
+## [11.0.17] - 2026-02-14
+
+## Bug Fixes
+
+- **Image scaling in Page module** (#301): Added `backend.css` with `max-width: 100%` to prevent images from overflowing in the TYPO3 v11 Page module
+
+## CI Improvements
+
+- Disabled Composer `block-insecure` for EOL TYPO3 v11 packages
+- Added `Build ✓` summary job for branch protection compatibility
+- Added auto-approve workflow for solo maintainer PR merging
+
+## Closes
+
+- #301 — Images not scaled in Page module
+
+Cherry-picked from [PR #376](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/376).
+Merged via [PR #632](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/632).
+
+> **Note:** TYPO3 v11 reached end-of-life in October 2024. This is a final maintenance release. Users are encouraged to upgrade to v13+ for continued support.
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v11.0.17) for the original notes._
 
 ## [13.5.0] - 2026-01-29
 
@@ -298,13 +420,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Risk Assessment**: LOW - Zero evidence of XCLASS usage found in ecosystem
 - **Code Statistics**: +2,596 lines (implementation + tests + docs), 23 new files
 
-## [13.0.1] - 2025-11-26
+## [13.1.0-rc2] - 2025-12-16
 
-### Changed
+## Release Candidate 2
 
-- Change extension icon to Netresearch logo ([#419](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/419))
-- TER compatibility and branding updates ([#427](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/427))
-  - Updated descriptions in `composer.json` and `ext_emconf.php` to mention Netresearch
+### Bug Fixes
+
+- **fix: prevent parseFunc whitespace artifacts in image rendering** (#482)
+  - Fixed `<p>&nbsp;</p>` artifacts appearing between `<img>` and `<figcaption>` elements
+  - Corrected invalid Fluid template syntax (`f:if="..."` → `{f:if(condition: ..., then: ...)}`)
+  - Added PHP whitespace normalization in `ImageRenderingService::render()`
+  - Added `figure,figcaption,a` to `encapsTagList` in TypoScript
+
+### Testing
+
+- All unit tests pass (131 tests)
+- All functional tests pass (32 tests)
+- E2E tests pass
+- CodeQL analysis pass
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v13.1.0-rc2) for the original notes._
 
 ## [13.0.0] - 2025-01-08
 
@@ -331,6 +466,138 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing TSFE method for v13 compatibility
 - Fix missing TextPreviewRenderer for v13 compatibility
 - Support for TYPO3 13.4
+
+## [13.1.0-rc1] - 2025-12-03
+
+## 🎉 Release Candidate 1 for v13.1.0
+
+Major feature release with significant improvements to architecture, developer experience, and internationalization.
+
+### ✨ New Features
+
+#### Zero-Configuration Installation
+- **Zero-Config TypoScript Injection** ([#429](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/429)) - Automatic TypoScript loading via `AfterTemplatesHaveBeenDeterminedEvent`, works seamlessly with TYPO3 v13 Site Sets
+- **Automatic RTE Softref Enforcement** ([#371](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/371)) - Global PSR-14 event listener for automatic TCA configuration
+- **Zero-Config Installation** ([#362](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/362)) - Complete zero-configuration for TYPO3 13.4 LTS
+
+#### Image Handling Enhancements
+- **Quality Selector with Visual Feedback** ([#388](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/388)) - Frontend quality selector with persistence for image processing, fixes [#331](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/331)
+- **SVG Image Dimension Handling** ([#388](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/388)) - Proper SVG support with TSConfig maxWidth/maxHeight
+- **noScale Support** ([#358](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/358)) - Skip image processing when not needed, resolves [#77](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/77)
+- **Remote Storage URL Preservation** ([#368](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/368)) - Support for S3, Azure, CDN URLs in RTE
+
+#### CKEditor 5 Improvements
+- **Widget UI with Block Toolbar** ([#393](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/393)) - Modern CKEditor 5 widget interface for images
+- **WYSIWYG Caption Features** ([#398](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/398)) - Balloon toolbar with caption editing and toggle button
+- **Improved Image Dialog** ([#369](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/369)) - Buttons matching TYPO3 backend standards
+
+#### Architecture Refactoring
+- **Fluid Templates Refactoring** ([#418](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/418)) - Complete rewrite with service-based approach and DTOs
+- **Controller Refactoring** ([#395](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/395)) - Extracted shared logic to AbstractImageRenderingController, resolves [#378](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/378)
+- **TYPO3 13.4 Modernization** ([#356](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/356)) - Full constructor injection in controllers and utilities
+
+### 🐛 Bug Fixes
+
+- **Link Attribute Preservation** ([#387](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/387)) - Preserve link attributes on TYPO3 images, fixes [#385](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/385)
+- **Click-to-Enlarge** ([#369](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/369)) - Enable lightbox/popup rendering by preserving zoom attributes
+- **Default Upload Folder** ([#374](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/374), [#381](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/381)) - Resolve for non-admin users in image selector
+- **Empty Link Wrappers** ([#392](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/392)) - Prevent empty wrappers, ensure Bootstrap Package compatibility
+- **Width/Height Dimensions** ([#347](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/347)) - Fix dimensions getting dropped and set to 1920
+- **DoubleClickObserver Namespace** ([#383](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/383)) - Prevent conflicts with other plugins
+- **Link Toolbar Configuration** ([#382](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/382)) - Prevent linkProperties error
+- **Empty Width/Height Input** ([#367](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/367)) - Allow empty input during typing
+- **ElementBrowserRegistry Injection** ([#379](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/379)) - Fix DI in SelectImageController
+- **lazyLoading Configuration** ([#373](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/373)) - Add TypoScript bridge
+- **CKEditor Migration** ([#380](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/380)) - Migrate from deprecated @typo3/ckeditor5-bundle.js to direct CKEditor imports
+- **Image Dialog Translations** ([#391](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/391)) - Fix hardcoded strings not translated
+
+### 🌍 Internationalization
+
+- **Crowdin Integration** ([#400](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/400), [#403](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/403)) - Native TYPO3 Crowdin integration for translations
+- **18 Language Translations** ([#402](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/402), [#405](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/405)) - Complete translations for all supported languages
+- **Quality Selector Translations** ([#400](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/400)) - i18n support for quality selector strings
+- **XLIFF 1.2 Upgrade** ([#407](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/407)) - All XLIFF files upgraded from 1.0 to 1.2
+- **Translation Contribution Guide** ([#411](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/411)) - Added to CONTRIBUTING.md
+- **Translation Error Fixes** ([#420](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/420)) - Correct translation errors in 5 language files
+
+### 🔒 Security
+
+- **9 Critical Vulnerability Fixes** - Fixed vulnerabilities in image handling including:
+  - Array handling risk in attribute parsing
+  - Information disclosure in error logging
+  - Public file check to prevent privilege escalation
+  - DNS rebinding and PSR-7 compliance issues
+
+### 🧪 Testing Infrastructure
+
+- **E2E Tests with Playwright** ([#429](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/429)) - Comprehensive test suite for click-to-enlarge
+- **Unit Test Suite** ([#356](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/356)) - 60 tests, 170 assertions
+- **Functional Tests** ([#356](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/356)) - Integration tests for image rendering pipeline
+- **PHPUnit 12 Compatibility** ([#356](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/356)) - Modern test infrastructure with #[CoversClass] attributes
+
+### 🔧 Developer Experience
+
+- **DDEV Development Environment** ([#359](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/359)) - Complete local dev setup for TYPO3 v13
+- **FAL Entries for E2E Tests** ([#439](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/439)) - Proper test content with RTE attributes
+- **Playwright v1.57.0** ([#440](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/440)) - Updated E2E testing infrastructure
+- **Netresearch-Branded Landing Page** ([#364](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/364)) - DDEV development dashboard
+- **Dynamic Git Info** ([#394](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/394)) - Branch/PR info in landing page header
+- **Hierarchical Command Structure** ([#365](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/365)) - Improved .envrc commands
+
+### 📚 Documentation
+
+- **RST Format Restructure** ([#348](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/348)) - Following TYPO3 documentation standards
+- **TYPO3 Official Integration** - Webhook configured for [docs.typo3.org](https://docs.typo3.org/p/netresearch/rte-ckeditor-image/main/en-us/)
+- **API Documentation** ([#355](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/355)) - Enhanced cards with TYPO3 directives
+- **README Refresh** ([#344](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/344)) - Comprehensive v13.0.0+ updates
+- **TYPO3 Core Removal Guidance** ([#412](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/412)) - Decision guidance documentation
+
+### 🔨 Code Quality
+
+- **PHPStan Level 10** - Strict type checking with [phpstan-typo3](https://github.com/saschaegerer/phpstan-typo3)
+- **Rector Modernizations** ([#356](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/356)) - Automated code improvements
+- **PHP-CS-Fixer** - Modern coding standards
+- **CodeQL Analysis** - Security scanning in CI
+- **TER Compatibility** ([#427](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/427)) - Branding updates for TYPO3 Extension Repository
+- **CI Modernization** ([#428](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/428)) - Modernized TER publish workflow
+
+### 📦 Dependencies
+
+| Package | Version |
+|---------|---------|
+| `actions/checkout` | v6 ([#430](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/430)) |
+| `actions/upload-artifact` | v5 ([#438](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/438)) |
+| `@playwright/test` | v1.57.0 ([#436](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/436)) |
+| `bk2k/bootstrap-package` | v15/v16 ([#435](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/435)) |
+| `commitlint` | v20 ([#341](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/341)) |
+| `lint-staged` | v16 ([#342](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/342)) |
+
+### 📋 Requirements
+
+- **TYPO3**: 13.4.0 - 13.4.99
+- **PHP**: 8.2 - 8.4
+
+### 📖 Resources
+
+- **Documentation**: [docs.typo3.org](https://docs.typo3.org/p/netresearch/rte-ckeditor-image/main/en-us/)
+- **Packagist**: [netresearch/rte-ckeditor-image](https://packagist.org/packages/netresearch/rte-ckeditor-image)
+- **TER**: [rte_ckeditor_image](https://extensions.typo3.org/extension/rte_ckeditor_image)
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.0.0...v13.1.0-rc1
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v13.1.0-rc1) for the original notes._
+
+## [13.0.1] - 2025-11-26
+
+### Changed
+
+- Change extension icon to Netresearch logo ([#419](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/419))
+- TER compatibility and branding updates ([#427](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/427))
+  - Updated descriptions in `composer.json` and `ext_emconf.php` to mention Netresearch
+
+## [11.0.16] - 2025-01-16
+
+_No GitHub release was created for this tag. See [git tag v11.0.16](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v11.0.16) and [commit log](https://github.com/netresearch/t3x-rte_ckeditor_image/commits/v11.0.16)._
 
 ## [12.0.4] - 2024-11-21
 
@@ -371,6 +638,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update runtests.sh script
 - Update branch aliases for v12
+
+## [11.0.15] - 2024-02-01
+
+## What's Changed
+* chore: Fix current build/tests in pipeline/actions. by @CybotTM in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/253
+* add TYPO3 badges to README by @CybotTM in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/252
+* [BUGFIX] Fixes #254: handle deleted files by @hannesbochmann in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/255
+* [BUGFIX] prevent open_basedir warnings by @linawolf in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/264
+
+## New Contributors
+* @hannesbochmann made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/255
+* @linawolf made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/264
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v11.0.14...v11.0.15
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v11.0.15) for the original notes._
 
 ## [12.0.0] - 2023-08-25
 
@@ -450,12 +733,124 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extend from AbstractSoftReferenceIndexParser
 - Implement interface instead of deprecated extension of SoftReferenceIndexParser
 
+## [11.0.10] - 2023-06-26
+
+## What's Changed
+* [BUGFIX] generate publicUrl from originalImageFile storage by @lukasniestroj in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/219
+* Fix output of alt and title attribute when overriden by @sk-foresite in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/225
+* Add .attributes by @sypets in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/231
+* [FEAT] #56: Show images in preview by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/106
+* Correctly handle embedded images (data:image) by @sypets in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/227
+
+## New Contributors
+* @sk-foresite made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/225
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v11.0.9...v11.0.10
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v11.0.10) for the original notes._
+
+## [11.0.9] - 2023-02-13
+
+## What's Changed
+* [BUGFIX] do not append "0" to getFileObject by @lukasniestroj in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/218
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v11.0.8...v11.0.9
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v11.0.9) for the original notes._
+
+## [11.0.8] - 2023-02-03
+
+## What's Changed
+* Add initial security policy by @ngolatka in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/216
+* [BUGFIX] Fix invalid typoscript in README, comments not allowed behind values
+* [BUGFIX] Fix invalid return type of method "getLazyLoadingConfiguration" #217
+
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v11.0.7...v11.0.8
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v11.0.8) for the original notes._
+
+## [11.0.7] - 2023-02-02
+
+## What's Changed
+* Create Github issue templates (initial version) by @ngolatka in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/211
+* [BUGFIX] Fix PHP warning about undefined array key access by @magicsunday in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/206 #205
+* [BUGFIX] Fix a couple of common PHP issues by @magicsunday in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/207
+*  Create contributing guide (initial version) by @ngolatka in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/213
+* [BUGFIX] Load Image when inserted to editor by @stephanederer in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/204
+* [BUGFIX] Remove deprecated call to GeneralUtility::rmFromList by @magicsunday in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/215
+
+## New Contributors
+* @ngolatka made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/211
+* @magicsunday made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/206
+* @stephanederer made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/204
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v11.0.6...v11.0.7
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v11.0.7) for the original notes._
+
+## [11.0.6] - 2022-12-09
+
+## What's Changed
+* [BUGFIX] Make fetching of external image configurable by @sypets in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/192
+* [BUGFIX] Catch exception when fetching external image by @sypets in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/191
+* [BUGFIX] fix misuse of 11LTS BE processing middleware URLs by @jpmschuler in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/194
+* [BUGFIX] Prevent undefined array key by @cngJo in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/198
+* [BUGFIX] fileadmin path without slash won't output in 11LTS by @jpmschuler in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/197
+* Fix undefined array key access by @fsuter in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/196
+
+## New Contributors
+* @sypets made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/192
+* @cngJo made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/198
+* @fsuter made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/196
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v11.0.5...v11.0.6
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v11.0.6) for the original notes._
+
 ## [11.0.5] - 2022-12-05
 
 ### Changed
 
 - Update dependencies
 - Add dependabot configuration
+
+## [10.2.5] - 2022-06-21
+
+## What's Changed
+* [BUGFIX] Preserve important image attributes on initialization by @thommyhh in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/178
+
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v10.2.4...v10.2.5
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v10.2.5) for the original notes._
+
+## [10.2.4] - 2022-06-09
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v10.2.3...v10.2.4
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v10.2.4) for the original notes._
+
+## [10.2.3] - 2022-06-09
+
+Fix: composer.json
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v10.2.2...v10.2.3
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v10.2.3) for the original notes._
+
+## [10.2.2] - 2022-06-09
+
+- Version fixes 7b5fcb239144b37fd7b57e3eddfcda4ef0d83fbf
+
+  - 10.x does not support TYPO3 v11
+  - add 10.x-dev version alias
+- fix version in ext_emconf.php 2e4b61930f639c6dfcbba0cf5ca6e9b8d218c0cc
+- Version 10.2.2 376f273ec045d21b6e2accc5fadc3f8d50eda652
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v10.2.1...v10.2.2
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v10.2.2) for the original notes._
 
 ## [11.0.4] - 2022-11-28
 
@@ -479,6 +874,99 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make extension error-free on PHPStan levels 0-8
 - Require PHP 7.4 or newer
+
+## [10.2.1] - 2021-12-31
+
+## What's Changed
+* [bugfix/145]Fix disabled button. by @lucmuller in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/149
+
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v10.2.0...v10.2.1
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v10.2.1) for the original notes._
+
+## [11.0.2] - 2021-12-30
+
+## What's Changed
+* [bugfix/145]Fix disabled button. Fixes netresearch/t3x-rte_ckeditor_image #145 by @lucmuller in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/146
+
+## New Contributors
+* @lucmuller made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/146
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v11.0.1...v11.0.2
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v11.0.2) for the original notes._
+
+## [11.0.1] - 2021-12-11
+
+## What's Changed
+* [BUGFIX] #126 Wrong link in image, #142 Wrong backwards compatibility by @cnmarco in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/143
+
+## New Contributors
+* @cnmarco made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/143
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v11.0.0...v11.0.1
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v11.0.1) for the original notes._
+
+## [11.0.0] - 2021-12-06
+
+## What's Changed
+* [BUGFIX] use parseFunc_RTE for processing by @vellip in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/116
+* [FEAT] #88: Add custom class field for each image by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/108
+* [TASK] Wrapping innerText to avoid js error by @eliasfernandez in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/114
+* [TASK] guard clause if jQuery is not present by @eliasfernandez in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/115
+* Revert "[BUGFIX] use parseFunc_RTE for processing" by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/117
+* [FEAT] #82: TYPO3 lazyload support by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/107
+* [BUGFIX] Fix override detection for title/alt attributes; allow empt… by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/118
+* Added extension-key to composer.json by @rvock in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/121
+* [TASK] Allow installation on TYPO3 v11 by @susannemoog in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/123
+* [BUGFIX] #122: Fix jquery requirement to not crash the ckeditor by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/127
+* [BUGFIX] #112: Remove wrapping p-tag from images by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/130
+* Resolve retrieved file correctly if its a processed file by @tgaertner in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/134
+* TYPO3 11.5.x by @MIchelHolz in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/138
+* [Task] Make installable in 11.5 via Composer by @typoniels in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/139
+* WIP: [BUGFIX] #112: Remove wrapping p-tag from images via TS by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/129
+
+## New Contributors
+* @vellip made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/116
+* @eliasfernandez made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/114
+* @rvock made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/121
+* @susannemoog made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/123
+* @tgaertner made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/134
+* @MIchelHolz made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/138
+* @typoniels made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/139
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/10.1.0...v11.0.0
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v11.0.0) for the original notes._
+
+## [10.2.0] - 2021-11-06
+
+## What's Changed
+* [BUGFIX] use parseFunc_RTE for processing by @vellip in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/116
+* [FEAT] #88: Add custom class field for each image by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/108
+* [TASK] Wrapping innerText to avoid js error by @eliasfernandez in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/114
+* [TASK] guard clause if jQuery is not present by @eliasfernandez in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/115
+* Revert "[BUGFIX] use parseFunc_RTE for processing" by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/117
+* [FEAT] #82: TYPO3 lazyload support by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/107
+* [BUGFIX] Fix override detection for title/alt attributes; allow empt… by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/118
+* Added extension-key to composer.json by @rvock in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/121
+* [TASK] Allow installation on TYPO3 v11 by @susannemoog in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/123
+* [BUGFIX] #122: Fix jquery requirement to not crash the ckeditor by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/127
+* [BUGFIX] #112: Remove wrapping p-tag from images by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/130
+* Resolve retrieved file correctly if its a processed file by @tgaertner in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/134
+
+## New Contributors
+* @vellip made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/116
+* @eliasfernandez made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/114
+* @rvock made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/121
+* @susannemoog made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/123
+* @tgaertner made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/134
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/10.1.0...v10.2.0
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v10.2.0) for the original notes._
 
 ## [10.1.0] - 2021-05-20
 
@@ -534,3 +1022,161 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [11.0.4]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v11.0.3...v11.0.4
 [11.0.3]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v10.1.0...v11.0.3
 [10.1.0]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v10.0.0...v10.1.0
+
+## [10.0.0] - 2020-12-23
+
+_No GitHub release was created for this tag. See [git tag v10.0.0](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v10.0.0) and [commit log](https://github.com/netresearch/t3x-rte_ckeditor_image/commits/v10.0.0)._
+
+## [9.0.5] - 2020-10-10
+
+## What's Changed
+* [Classes] Fix attrSearchPattern ImageLinkRendering  by @UNI49 in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/74
+* Create LICENSE by @CybotTM in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/80
+* Issue 71 fix composer by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/93
+* [BUGFIX] #61: Respect max width and height configuration for images w… by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/96
+* [FEAT] #78: Regenerate missing processed images by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/95
+* [BUGFIX] #69: Remove zoom attributes when checkbox is disabled by @mcmulman in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/94
+* Fix deprecation log about locallang_core.xlf by @tmotyl in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/81
+
+## New Contributors
+* @UNI49 made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/74
+* @CybotTM made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/80
+* @tmotyl made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/81
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v9.0.4...v9.0.5
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v9.0.5) for the original notes._
+
+## [9.0.4] - 2019-10-26
+
+## What's Changed
+* [BUGFIX] #25: Regenerate missing processed image for linked images by @muh-nr in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/57
+* suggestion for reformat code by @sascha307050 in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/58
+* [TASK] #45: Update image reference index by @muh-nr in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/62
+* added ie11 support by removing arrow functions by @christophmellauner in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/66
+* [BUGFIX] Use original files width and height for ratio and max by @thommyhh in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/70
+
+## New Contributors
+* @sascha307050 made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/58
+* @christophmellauner made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/66
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v9.0.3...v9.0.4
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v9.0.4) for the original notes._
+
+## [9.0.3] - 2019-07-03
+
+## What's Changed
+* [REFACTOR] #38: Process image on first selection by @muh-nr in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/55
+
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v9.0.2...v9.0.3
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v9.0.3) for the original notes._
+
+## [9.0.2] - 2019-06-21
+
+## What's Changed
+* [BUGFIX] Avoid loosing existing attributes when editing image by @thommyhh in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/54
+
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v9.0.1...v9.0.2
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v9.0.2) for the original notes._
+
+## [9.0.1] - 2019-03-19
+
+_No GitHub release was created for this tag. See [git tag v9.0.1](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v9.0.1) and [commit log](https://github.com/netresearch/t3x-rte_ckeditor_image/commits/v9.0.1)._
+
+## [9.0.0] - 2019-03-19
+
+## What's Changed
+* [BUGFIX] `Image properties` not working inside table cell by @thommyhh in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/41
+* Dev typo3 9.x refactor 29 backend image url by @muh-nr in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/48
+* [FEATURE] Compatibility TYPO3 9.x by @muh-nr in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/43
+
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v8.7.8...v9.0.0
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v9.0.0) for the original notes._
+
+## [8.9.0] - 2019-02-05
+
+## What's Changed
+* [REFACTOR] #29: Process backend image url savely by @muh-nr in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/47
+
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v8.8.0...v8.9.0
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v8.9.0) for the original notes._
+
+## [8.8.0] - 2018-12-13
+
+## What's Changed
+* [BUGFIX] `Image properties` not working inside table cell by @thommyhh in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/41
+
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v8.7.8...v8.8.0
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v8.8.0) for the original notes._
+
+## [8.7.8] - 2018-12-04
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v8.7.7...v8.7.8
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v8.7.8) for the original notes._
+
+## [8.7.7] - 2018-12-02
+
+## What's Changed
+* [BUGFIX] Use proper condition for empty DomDocuments by @flossels in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/37
+
+## New Contributors
+* @flossels made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/37
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v8.7.6...v8.7.7
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v8.7.7) for the original notes._
+
+## [8.7.6] - 2018-11-30
+
+Fixes output of linked images and image popups/lightboxes.
+
+## What's Changed
+* [BUGFIX] Add custom image link handler to get fallback image values; … by @muh-nr in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/34
+
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v8.7.5...v8.7.6
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v8.7.6) for the original notes._
+
+## [8.7.5] - 2018-11-24
+
+## What's Changed
+* Depend on typo3/cms-core instead of typo3/cms by @bmack in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/24
+* Update URLs by @benabbottnz in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/30
+
+## New Contributors
+* @bmack made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/24
+* @benabbottnz made their first contribution in https://github.com/netresearch/t3x-rte_ckeditor_image/pull/30
+
+**Full Changelog**: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v8.7.4...v8.7.5
+
+_See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v8.7.5) for the original notes._
+
+## [8.7.4] - 2017-08-17
+
+_No GitHub release was created for this tag. See [git tag v8.7.4](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v8.7.4) and [commit log](https://github.com/netresearch/t3x-rte_ckeditor_image/commits/v8.7.4)._
+
+## [8.7.3] - 2017-06-26
+
+_No GitHub release was created for this tag. See [git tag v8.7.3](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v8.7.3) and [commit log](https://github.com/netresearch/t3x-rte_ckeditor_image/commits/v8.7.3)._
+
+## [8.7.2] - 2017-06-23
+
+_No GitHub release was created for this tag. See [git tag v8.7.2](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v8.7.2) and [commit log](https://github.com/netresearch/t3x-rte_ckeditor_image/commits/v8.7.2)._
+
+## [8.7.1] - 2017-05-17
+
+_No GitHub release was created for this tag. See [git tag v8.7.1](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v8.7.1) and [commit log](https://github.com/netresearch/t3x-rte_ckeditor_image/commits/v8.7.1)._
+

--- a/Documentation/Architecture/ADR-003-Security-Responsibility-Boundaries.rst
+++ b/Documentation/Architecture/ADR-003-Security-Responsibility-Boundaries.rst
@@ -1,5 +1,7 @@
 .. include:: /Includes.rst.txt
 
+.. _adr-003-security-responsibility-boundaries:
+
 ADR-003: Security Responsibility Boundaries
 ===========================================
 
@@ -89,6 +91,21 @@ In Scope (This Extension's Responsibility)
    - Uses TYPO3 Core's ``SvgSanitizer`` for consistency with FAL sanitization
    - Location: ``ImageResolverService::sanitizeSvgDataUri()``
    - Addresses: `#474 <https://github.com/netresearch/rte-ckeditor-image/issues/474>`_
+
+7. **External-link rel security (Fluid path)**
+
+   - Append ``rel="noreferrer"`` on ``target="_blank"`` external links
+     in the figure-wrapped Fluid render path, mirroring TYPO3's
+     ``LinkFactory::addSecurityRelValues()``
+   - In scope because the Fluid ``Link.html`` partial constructs ``<a>``
+     directly and does **not** go through ``LinkFactory``, so Core's
+     security helper never executes on this path
+   - Preserves any pre-existing ``rel`` tokens (``nofollow``,
+     ``sponsored``, ``noopener``); appends ``noreferrer`` at most once
+   - Location: ``Service\\SecurityRelComputer::compute()``,
+     wired in ``Service\\ImageResolverService::buildLinkDto()`` and
+     ``createDtoFromExternalImage()``
+   - Addresses: `#799 <https://github.com/netresearch/t3x-rte_ckeditor_image/issues/799>`_
 
 Known Boundaries & Limitations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Documentation/CKEditor/Conversions.rst
+++ b/Documentation/CKEditor/Conversions.rst
@@ -83,7 +83,7 @@ Configuration Breakdown
 -----------------------
 
 View Matcher
-^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -115,7 +115,7 @@ Not matched (regular img passthrough):
    <span data-htmlarea-file-uid="123"></span>  <!-- Wrong element -->
 
 Model Creator Function
-^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -133,7 +133,7 @@ Model Creator Function
 **Return**: New model element with extracted attributes
 
 Attribute Extraction
-^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -260,7 +260,7 @@ Configuration Breakdown
 -----------------------
 
 Model Matcher
-^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -277,7 +277,7 @@ Model Matcher
 - Has ``fileUid``, ``fileTable``, ``src`` attributes (required for meaningful output)
 
 View Creator Function
-^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -293,7 +293,7 @@ View Creator Function
 **Return**: New view element (``<img>``)
 
 Attribute Mapping
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -324,7 +324,7 @@ enableZoom           data-htmlarea-zoom           Only if true
 ===================  ===========================  ========================
 
 Conditional Attributes
-^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 

--- a/Documentation/CKEditor/Image-Quality-Selector.rst
+++ b/Documentation/CKEditor/Image-Quality-Selector.rst
@@ -6,7 +6,7 @@
 Image Quality Selector
 ======================
 
-.. versionadded:: 13.1.0
+.. versionadded:: 13.1.5
    The image quality selector with SVG dimension support and multiplier-based processing.
 
 The image dialog includes a quality selector dropdown that controls image processing

--- a/Documentation/CKEditor/Model-Element.rst
+++ b/Documentation/CKEditor/Model-Element.rst
@@ -103,7 +103,7 @@ Inline Image Schema (typo3imageInline)
    });
 
 Key Differences
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
@@ -132,13 +132,13 @@ Key Differences
      - ``image-inline``
 
 Usage Example
-^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In the editor, users can type text before and after inline images on the same line,
 just like typing around any other inline element (bold text, links, etc.).
 
 Toggle Command
-^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Users can convert between block and inline via the ``toggleImageType`` command:
 
@@ -166,7 +166,7 @@ Schema Properties Explained
 ----------------------------
 
 inheritAllFrom: '$blockObject'
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Inherits all properties from CKEditor's base ``$blockObject``:
 
@@ -176,7 +176,7 @@ Inherits all properties from CKEditor's base ``$blockObject``:
 - **Non-Breaking**: Cannot be split by Enter key
 
 allowIn: ['$text', '$block']
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Defines where ``typo3image`` can exist:
 
@@ -186,7 +186,7 @@ Defines where ``typo3image`` can exist:
 **Result**: Images can be placed in any text flow or block context.
 
 allowAttributes: [...]
-^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Lists all valid attributes for the model element. Attributes not listed are stripped.
 
@@ -197,7 +197,7 @@ Core Attributes
 ---------------
 
 src
-^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -222,7 +222,7 @@ src
    writer.setAttribute('src', '/new/path.jpg', modelElement);
 
 fileUid
-^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -257,7 +257,7 @@ fileUid
    ).then(r => r.json());
 
 fileTable
-^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -284,7 +284,7 @@ Metadata Attributes
 -------------------
 
 alt
-^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -312,7 +312,7 @@ alt
    writer.setAttribute('alt', 'New alt text', modelElement);
 
 altOverride
-^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -346,7 +346,7 @@ altOverride
    }
 
 title
-^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -374,7 +374,7 @@ title
    writer.setAttribute('title', 'Tooltip text', modelElement);
 
 titleOverride
-^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -398,7 +398,7 @@ Visual Attributes
 -----------------
 
 class
-^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -441,7 +441,7 @@ class
    class: 'float-left mr-3'
 
 width
-^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -480,7 +480,7 @@ width
    writer.setAttribute('height', String(newHeight), modelElement);
 
 height
-^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -505,7 +505,7 @@ height
    writer.setAttribute('height', '600', modelElement);
 
 enableZoom
-^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -544,7 +544,7 @@ Link Attributes
 ---------------
 
 htmlA
-^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -565,7 +565,7 @@ htmlA
    This is a legacy attribute. Modern approach uses separate link attributes.
 
 linkHref
-^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -589,7 +589,7 @@ linkHref
    writer.setAttribute('linkHref', '/page/123', modelElement);
 
 linkTarget
-^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -613,7 +613,7 @@ linkTarget
    writer.setAttribute('linkTarget', '_blank', modelElement);
 
 linkTitle
-^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -635,7 +635,7 @@ linkTitle
    writer.setAttribute('linkTitle', 'Link description', modelElement);
 
 linkClass
-^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 13.5.0
 
@@ -659,7 +659,7 @@ linkClass
    writer.setAttribute('linkClass', 'my-link-class', modelElement);
 
 linkParams
-^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 13.5.0
 

--- a/Documentation/CKEditor/Style-Integration.rst
+++ b/Documentation/CKEditor/Style-Integration.rst
@@ -515,7 +515,7 @@ Issue: Style Drop-down Disabled for Images
 **Solutions**:
 
 Verify Dependencies
-^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -524,7 +524,7 @@ Verify Dependencies
    }
 
 Verify Style Definitions
-^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: yaml
 
@@ -535,7 +535,7 @@ Verify Style Definitions
          classes: ['my-class']
 
 Check Event Listeners
-^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -562,7 +562,7 @@ Issue: Style Changes Not Applied
 **Solutions**:
 
 Verify GHS Listeners
-^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -571,7 +571,7 @@ Verify GHS Listeners
    // Should be > 0
 
 Check Class Attribute Conversion
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -581,7 +581,7 @@ Check Class Attribute Conversion
    });
 
 Verify CSS Loaded
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: css
 
@@ -603,7 +603,7 @@ Issue: Styles Not Shown as Active
 **Solution**:
 
 Debug Class Matching
-^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -1,0 +1,20 @@
+.. include:: /Includes.rst.txt
+
+.. _configuration:
+
+=============
+Configuration
+=============
+
+Configuration is split across several focused pages under
+:ref:`integration` (RTE preset, TSConfig, frontend rendering, security,
+advanced options). The full table of contents is on the
+:ref:`Integration index <integration>`.
+
+.. seealso::
+
+   - :ref:`integration-configuration-rte-setup` — RTE YAML preset wiring
+   - :ref:`integration-configuration-tsconfig` — TSConfig page-level options
+   - :ref:`integration-configuration-frontend-rendering` — TypoScript rendering
+   - :ref:`integration-security` — security configuration and the rel rules
+   - :ref:`integration-configuration-advanced` — advanced extension options

--- a/Documentation/Developer/Adr/Index.rst
+++ b/Documentation/Developer/Adr/Index.rst
@@ -1,0 +1,14 @@
+.. include:: /Includes.rst.txt
+
+.. _developer-adr:
+
+=============================
+Architecture Decision Records
+=============================
+
+ADRs for this extension live under
+:ref:`Architecture <architecture>`. The list:
+
+- :ref:`adr-001-image-scaling` — image scaling responsibility split
+- :ref:`adr-002-ckeditor-integration` — CKEditor 5 plugin model
+- :ref:`adr-003-security-responsibility-boundaries` — security in/out of scope (incl. external-link rel)

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -1,0 +1,17 @@
+.. include:: /Includes.rst.txt
+
+.. _developer:
+
+=========
+Developer
+=========
+
+Developer documentation is split into two domains:
+
+- :ref:`api-index` — PHP service / DTO / controller reference.
+- :ref:`ckeditor-plugin-development` — CKEditor 5 plugin internals
+  (model, conversions, style integration).
+
+Architecture decisions are recorded as ADRs under
+:ref:`Architecture <architecture>`; the ADR index is also mirrored at
+:ref:`developer-adr` for discoverability.

--- a/Documentation/Examples/Advanced-Features.rst
+++ b/Documentation/Examples/Advanced-Features.rst
@@ -15,7 +15,7 @@ Examples for implementing lightbox functionality and lazy loading for performanc
 Lightbox Integration
 ====================
 
-.. versionchanged:: 13.1.0
+.. versionchanged:: 13.1.5
    Default popup configuration is now provided automatically.
    The basic "Enlarge on Click" feature works out-of-the-box without additional setup.
    See :ref:`integration-configuration-frontend-rendering` for details.
@@ -23,7 +23,7 @@ Lightbox Integration
 Popup Link Configuration
 ------------------------
 
-.. versionadded:: 13.4.3
+.. versionadded:: 13.5.0
    The popup link CSS class is now configurable via TypoScript.
 
 By default, popup links use the CSS class ``popup-link``. You can customize this

--- a/Documentation/Examples/Linked-Images.rst
+++ b/Documentation/Examples/Linked-Images.rst
@@ -173,15 +173,32 @@ The :php:`LinkDto::getUrlWithParams()` method handles all edge cases:
 Frontend Rendering
 ==================
 
-Linked images are rendered with the configured attributes:
+Linked images are rendered with the configured attributes. Internal
+links retain their original `rel` (or none):
 
 .. code-block:: html
+   :caption: Internal link with target="_blank" (no rel injected)
 
-   <!-- Link click behavior with all attributes -->
    <a href="/page?L=1#section"
       target="_blank"
       title="Click to view details"
       class="image-link external">
+       <img src="/fileadmin/_processed_/image.jpg"
+            alt="Product image"
+            width="800"
+            height="600" />
+   </a>
+
+External links opening a new browsing context receive `rel="noreferrer"`
+automatically — mirroring TYPO3 typolink security semantics. See
+:ref:`integration-security-rel`.
+
+.. code-block:: html
+   :caption: External link with target="_blank" (rel="noreferrer" injected)
+
+   <a href="https://example.com"
+      target="_blank"
+      rel="noreferrer">
        <img src="/fileadmin/_processed_/image.jpg"
             alt="Product image"
             width="800"

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -144,3 +144,16 @@ This extension is licensed under `AGPL-3.0-or-later <https://www.gnu.org/license
 
    API/Index
    CKEditor/Index
+   Developer/Index
+   Developer/Adr/Index
+
+.. Convention-named redirect stubs (Installation/Configuration/Usage)
+   point readers searching for the canonical TYPO3 docs section names
+   at the actual content under Integration/, Examples/, and Architecture/.
+
+.. toctree::
+   :hidden:
+
+   Installation/Index
+   Configuration/Index
+   Usage/Index

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -1,0 +1,18 @@
+.. include:: /Includes.rst.txt
+
+.. _installation:
+
+============
+Installation
+============
+
+Installation steps live alongside the RTE setup workflow in
+:ref:`integration-configuration-rte-setup`. See also the README on
+`GitHub <https://github.com/netresearch/t3x-rte_ckeditor_image#installation>`__
+for the quick-start composer command.
+
+.. seealso::
+
+   - :ref:`integration-configuration-rte-setup` — full RTE preset wiring (Composer + DDEV)
+   - :ref:`integration-configuration-advanced` — extension configuration options
+   - :ref:`troubleshooting-installation-issues` — installation-related troubleshooting

--- a/Documentation/Integration/Frontend-Rendering.rst
+++ b/Documentation/Integration/Frontend-Rendering.rst
@@ -116,7 +116,7 @@ Enable native browser lazy loading:
 Lightbox/Popup Integration
 --------------------------
 
-.. versionadded:: 13.1.0
+.. versionadded:: 13.1.5
    Default popup configuration is now provided by the extension.
 
 .. note::

--- a/Documentation/Integration/Security.rst
+++ b/Documentation/Integration/Security.rst
@@ -126,6 +126,78 @@ This ensures:
 -  **Audit trail**: Security validation happens once, at creation.
 -  **Thread safety**: No race conditions on property access.
 
+.. _integration-security-rel:
+
+External link security (`rel="noreferrer"`)
+===========================================
+
+Automatic `rel="noreferrer"` on figure-wrapped linked images, mirroring
+TYPO3 typolink semantics. Closes
+`#799 <https://github.com/netresearch/t3x-rte_ckeditor_image/issues/799>`__
+(see `CHANGELOG.md <https://github.com/netresearch/t3x-rte_ckeditor_image/blob/main/CHANGELOG.md>`__
+for the version this shipped in).
+
+Linked images that are wrapped in `<figure>` (e.g. when a caption is set)
+are rendered through the Fluid `Link.html` partial, which constructs
+the `<a>` tag directly rather than going through TYPO3's `LinkFactory`.
+That means `LinkFactory::addSecurityRelValues()` — the core helper that
+appends `rel="noreferrer"` to external `target="_blank"` links to prevent
+referrer leakage — never ran on this code path. The extension now mirrors
+the typolink semantics in PHP via the :php:`SecurityRelComputer` service.
+
+When the rule fires
+-------------------
+
+`rel="noreferrer"` is appended automatically when **both** conditions hold:
+
+#. The link target opens a new browsing context — i.e. `target` is set
+   and not one of `_self`, `_parent`, `_top` (case-insensitive,
+   whitespace-tolerant per the HTML living standard).
+#. The URL is **external** — defined as either:
+
+   -  An absolute `http://` or `https://` URL.
+   -  A protocol-relative URL (e.g. `//example.com/image.jpg`,
+      RFC 3986 §4.2 network-path reference) that inherits the page
+      scheme but resolves to a different host.
+
+Relative paths (`/fileadmin/...`), fragment links (`#section`),
+`mailto:` / `tel:` schemes, and `t3://` URIs (already resolved before
+this point) are treated as internal and don't trigger the addition.
+
+Token preservation
+------------------
+
+Pre-existing rel tokens from the source `<a>` tag — `nofollow`,
+`sponsored`, `noopener`, custom values — are preserved through
+`SecurityRelComputer::parseTokens()`, which lowercases, deduplicates,
+and collapses whitespace. `noreferrer` is added at most once; if the
+source already declares it, no duplicate is appended.
+
+Example
+-------
+
+..  code-block:: html
+    :caption: Editor-set link with target="_blank" and an external URL
+
+    <a href="https://example.com" target="_blank">
+      <img src="/fileadmin/_processed_/image.jpg" alt="..." />
+    </a>
+
+After rendering through the figure-wrapped path:
+
+..  code-block:: html
+    :caption: Output — `rel="noreferrer"` injected automatically
+
+    <figure>
+      <a href="https://example.com" target="_blank" rel="noreferrer">
+        <img src="/fileadmin/_processed_/image.jpg" alt="..." />
+      </a>
+      <figcaption>...</figcaption>
+    </figure>
+
+Internal links (e.g. `/about` or `t3://page?uid=42`) and links without
+a `target` continue to render without `rel`, matching typolink behavior.
+
 SVG security
 ============
 

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -7,9 +7,9 @@ Introduction
 ============
 
 The RTE CKEditor Image extension provides comprehensive image handling capabilities
-for TYPO3's CKEditor Rich Text Editor. This extension enables editors to insert,
+for |typo3|'s CKEditor Rich Text Editor. This extension enables editors to insert,
 configure, and style images directly within the CKEditor interface, with full
-integration into TYPO3's File Abstraction Layer (FAL).
+integration into |typo3|'s File Abstraction Layer (FAL).
 
 Key Features
 ============
@@ -231,7 +231,7 @@ Install via Composer:
 
    The extension appears in the TYPO3 Extension Manager after installation
 
-.. versionchanged:: 13.4.3
+.. versionchanged:: 13.5.0
    The RTE preset and frontend TypoScript are now provided via Site Set only.
    You must enable the Site Set in your site configuration.
 

--- a/Documentation/Troubleshooting/Editor-Issues.rst
+++ b/Documentation/Troubleshooting/Editor-Issues.rst
@@ -217,7 +217,7 @@ Issue: JavaScript Console Errors
 * Editor doesn't load properly
 
 Common Errors
-^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. "GeneralHtmlSupport is not defined"
 """"""""""""""""""""""""""""""""""""""

--- a/Documentation/Troubleshooting/Frontend-Issues.rst
+++ b/Documentation/Troubleshooting/Frontend-Issues.rst
@@ -407,6 +407,29 @@ For production use, consider a proper lightbox library such as
 
 ----
 
+Issue: Unexpected `rel="noreferrer"` on External Linked Images
+---------------------------------------------------------------
+
+**Symptoms:**
+
+* External linked images (e.g. `<a href="https://example.com" target="_blank">`)
+  render with `rel="noreferrer"` even though the editor did not set it
+* Internal links (`/page` or `t3://page?uid=42`) do **not** receive the
+  attribute
+
+**Cause:** This is intentional behaviour added in `#799 <https://github.com/netresearch/t3x-rte_ckeditor_image/issues/799>`__.
+The Fluid `Link.html` partial used for figure-wrapped linked images
+mirrors TYPO3 typolink security semantics — it appends `rel="noreferrer"`
+when the target opens a new browsing context **and** the URL is external
+(absolute `http(s)` or protocol-relative). Pre-existing rel tokens from
+the source `<a>` (such as `nofollow` or `noopener`) are preserved.
+
+**Solution:** No action required. To suppress the attribute (not
+recommended), remove `target="_blank"` from the link or use an internal
+URL. See :ref:`integration-security-rel` for the full rule and rationale.
+
+----
+
 Responsive Image Issues
 =======================
 

--- a/Documentation/Troubleshooting/Index.rst
+++ b/Documentation/Troubleshooting/Index.rst
@@ -19,7 +19,7 @@ Most Common Issues
 ------------------
 
 1. Style Dropdown Disabled (v13.0.0+)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: javascript
 
@@ -32,7 +32,7 @@ Most Common Issues
    :ref:`troubleshooting-style-dropdown`
 
 2. Images Not Appearing in Frontend
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Check TypoScript setup
 * Verify file permissions
@@ -42,7 +42,7 @@ Most Common Issues
    :ref:`troubleshooting-frontend-rendering`
 
 3. File Browser Not Opening
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Check backend user permissions
 * Verify TSConfig

--- a/Documentation/Troubleshooting/Installation-Issues.rst
+++ b/Documentation/Troubleshooting/Installation-Issues.rst
@@ -450,7 +450,7 @@ After applying fix, check frontend HTML:
 Issue: Insert Image Button Missing with Bootstrap Package or Other Site Sets
 -----------------------------------------------------------------------------
 
-.. versionadded:: 13.1.0
+.. versionadded:: 13.1.5
    Site Set dependency ordering ensures proper override behavior.
 
 **Symptoms:**

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -1,0 +1,18 @@
+.. include:: /Includes.rst.txt
+
+.. _usage:
+
+=====
+Usage
+=====
+
+Usage examples and editor workflows are documented under
+:ref:`examples`. That index covers basic image insertion, captions,
+linked images (including the security rel behaviour), and advanced
+features.
+
+.. seealso::
+
+   - :ref:`examples` — full examples index
+   - :ref:`examples-linked-images` — linked-image rendering and rel security
+   - :ref:`integration-configuration-rte-setup` — initial RTE setup before first use


### PR DESCRIPTION
## Summary

Documents the [#799](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/799) / [#802](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/802) figure-wrapped link security fix across the relevant docs surfaces, and clears all gap-analysis findings flagged by the `typo3-docs` skill validation scripts (heading hierarchy, unreleased versionadded refs, missing CHANGELOG versions, missing convention dirs, RST substitutions, ADR coverage).

## Changes

### Tied to #799 / #802 (rel="noreferrer" fix)

- **`CHANGELOG.md`** — `[Unreleased]` entry describing the SecurityRelComputer service, typolink semantic parity, and protocol-relative URL coverage.
- **`Documentation/Integration/Security.rst`** — new "External link security" section explaining when `noreferrer` is appended, token preservation, and a worked example.
- **`Documentation/Examples/Linked-Images.rst`** — frontend rendering example now shows internal vs external link output (external carries `rel="noreferrer"`).
- **`Documentation/Architecture/ADR-003`** — adds rel-on-external as in-scope item #7 for the Fluid path with rationale.
- **`Documentation/Troubleshooting/Frontend-Issues.rst`** — FAQ entry explaining the new attribute on external linked images.

### Skill validation cleanup

- **Heading hierarchy** (5 files, 60+ headings): replaced non-standard `^` underlines with `~` to match the TYPO3 convention `= / = / - / ~ / "`.
- **Unreleased version refs**: bumped four `versionadded::13.1.0` to `13.1.5` (v13.1.0 went rc1 → rc2 → 13.1.5; never tagged) and two `13.4.3` to `13.5.0` (no v13.4.3 tag).
- **CHANGELOG backfill**: 33 missing GitHub-released versions inserted with their original release notes; 11 tags without GitHub releases get a stub linking to the git tag/commit log. Normalised CRLF → LF.
- **Substitutions**: replaced two hardcoded `TYPO3` mentions with `|typo3|` in `Introduction/Index.rst`.
- **Required-section stubs**: added `Installation/`, `Configuration/`, `Usage/`, `Developer/`, `Developer/Adr/` `Index.rst` redirect pages so readers and the skill checks find the conventional names. They cross-link to the actual content under `Integration/`, `Examples/`, `API/`, `CKEditor/`, and `Architecture/` — **no content was relocated**.
- Added `:ref:` anchor to ADR-003 so the new cross-references resolve.

## Skill validation status

| Script | Status |
|--------|--------|
| `validate_docs.sh` | ✅ pass (0 warnings, 46 RST files) |
| `check-required-doc-sections.sh` | ✅ pass |
| `check-adr-coverage.sh` | ✅ pass |
| `check-rst-substitutions-used.sh` | ✅ pass |
| `check-changelog-version-coverage.sh` | ✅ pass |
| `check-unreleased-versions.sh` | ✅ pass |
| `check-untranslated-fluid-strings.sh` | ✅ pass |
| `check-version-match.sh` / `check-guides-xml-version-sync.sh` | ⚠️ false positive — script reads XML declaration `version="1.0"` instead of project tag, and `release="main"` is intentional for the docs.typo3.org `/main/en-us/` URL convention |

## Test plan

- [ ] CI runs (lint, RST validation, link checks) all green.
- [ ] Render docs locally: confirm new sections appear in TOC and cross-references resolve.
- [ ] Verify `[Unreleased]` CHANGELOG entry reads correctly and references both `#799` and `#802`.
- [ ] Confirm new redirect stub Index pages don't appear in main TOC (they're under `:hidden:` toctree).