### PR TITLE
chore(release): v13.9.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Handles image insertion, processing, rendering with captions, links, popups, qua
 - **Repository**: [github.com/netresearch/t3x-rte_ckeditor_image](https://github.com/netresearch/t3x-rte_ckeditor_image)
 - **Tech Stack**: PHP ^8.2, TYPO3 ^13.4.21 || ^14.3, CKEditor 5
 - **License**: AGPL-3.0-or-later
-- **Current Version**: 13.8.0
+- **Current Version**: 13.9.0
 
 ## Architecture Overview
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [13.9.0] - 2026-04-29
+
+### Added
+
+- **Validator skips out-of-scope `<img src>` origins by default** ([#788](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/788)) — `rte_ckeditor_image:validate` now classifies `<img src>` values via a new `SrcOriginClassifier` and skips four categories the validator cannot meaningfully repair: external URLs, inline `data:` URIs, legacy `typo3conf/ext/` paths, and `/securedl/` URLs. Per-origin skip counts are reported in the CLI summary so skipped references stay visible. New `--include=external,data,legacy,securedl` flag opts categories back in (`--include=all` disables all skipping).
+
 ### Fixed
 
 - **`rel="noreferrer"` missing on figure-wrapped linked images** ([#799](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/799), [#802](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/802)) — figure-wrapped linked images go through the Fluid `Link.html` partial, which builds the `<a>` tag directly rather than via TYPO3 typolink, so `LinkFactory::addSecurityRelValues()` never ran for them. External `target="_blank"` links lacked the `rel="noreferrer"` browser security policy expects. Mirrored the typolink semantics in a new `SecurityRelComputer` service: `noreferrer` is now appended whenever the target opens a new browsing context AND the URL is absolute `http(s)` or protocol-relative (`//example.com/...`). Existing `rel` tokens from the source `<a>` are preserved (lowercased, deduplicated, normalized). Bug existed on both v13 and v14; surfaced on v14 because v14 dropped the default `config.extTarget = _blank`. New unit + E2E coverage.
 - **`<p>` tags entity-encoded in plain RTE bodytext on vanilla installs** ([#790](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/790)) — removed restrictive `lib.parseFunc_RTE.allowTags`/`denyTags` modifications from `setup.typoscript`. They were artifacts from pre-TYPO3-v13.2 (when `fluid_styled_content` provided defaults that have since moved); on current installs they made `parseFunc` `htmlspecialchars`-encode every standard tag including `<p>`. Added an E2E regression spec. Thanks [@timofo](https://github.com/timofo) for pinpointing the exact line.
+- **TYPO3 v14 link browser integration broken** ([#798](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/798)) — TYPO3 v14 replaced the v13 hidden-input + `change`-event contract of `form-engine-link-browser-adapter.js` with a `FormEngineLinkBrowserSetLinkEvent`. The image dialog's link picker silently failed on v14 because it was still polling the input value. Now subscribes to the new event while remaining backward-compatible with the v13 contract.
+- **Corrupted `<img src>` no longer round-tripped through the RTE** ([#787](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/787)) — the editor plugin used to persist literal `"undefined"` / `"null"` strings (and empty values) into bodytext when an upcast or downcast couldn't resolve a real `src`. Added a `sanitizeSrc()` guard at all six upcast sites and both downcast helpers; corrupted values are now dropped instead of saved.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1005,7 +1005,12 @@ _See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/rele
 - Update image reference index ([#45](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/45), [#62](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/62))
 - Compatibility with TYPO3 CMS 9.x
 
-[Unreleased]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.7.1...HEAD
+[Unreleased]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.9.0...HEAD
+[13.9.0]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.8.3...v13.9.0
+[13.8.3]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.8.2...v13.8.3
+[13.8.2]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.8.1...v13.8.2
+[13.8.1]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.8.0...v13.8.1
+[13.8.0]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.7.1...v13.8.0
 [13.7.1]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.6.1...v13.7.1
 [13.6.1]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.6.0...v13.6.1
 [13.6.0]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.5.0...v13.6.0

--- a/Documentation/Troubleshooting/Image-Reference-Validation.rst
+++ b/Documentation/Troubleshooting/Image-Reference-Validation.rst
@@ -125,6 +125,59 @@ database:
    ``--fix`` modifies database records directly. Always run a dry-run scan
    first and create a database backup before applying fixes in production.
 
+Skipped origins
+---------------
+
+.. versionadded:: 13.9.0
+
+Not every ``<img src>`` value can be repaired by the validator. By default the
+command classifies each ``src`` and **skips four out-of-scope categories**:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 25 60
+
+   * - Category
+     - Example
+     - Why skipped
+   * - ``external``
+     - ``https://cdn.example.com/foo.jpg``
+     - Off-site URL — not part of this TYPO3's FAL.
+   * - ``data``
+     - ``data:image/png;base64,...``
+     - Inline-encoded image, no FAL reference exists.
+   * - ``legacy``
+     - ``typo3conf/ext/some_ext/Resources/...``
+     - Pre-FAL extension path, file lives outside FAL.
+   * - ``securedl``
+     - ``/securedl/sk=.../foo.jpg``
+     - URL signed by ``EXT:naw_securedl`` / similar — the
+       on-disk path differs from the signed URL.
+
+Skips are surfaced in the CLI summary as a per-origin breakdown so they
+stay visible (added to the existing "Scanned records / Scanned images /
+Issues found" definition list):
+
+.. code-block:: text
+
+    Skipped (out of scope)
+    16 total (12 external, 3 data, 1 legacy)
+
+Use ``--include`` to opt one or more categories back in if your environment
+needs them validated:
+
+.. code-block:: bash
+
+   # Re-include external URLs (the validator will then flag them as
+   # mismatches against FAL) — useful when migrating off a CDN.
+   bin/typo3 rte_ckeditor_image:validate --include=external
+
+   # Re-include multiple categories at once
+   bin/typo3 rte_ckeditor_image:validate --include=external,legacy
+
+   # Disable all skipping (validate every <img src> regardless of origin)
+   bin/typo3 rte_ckeditor_image:validate --include=all
+
 Limit to a specific table
 --------------------------
 

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,7 +20,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email'   => 'sebastian.koschel@netresearch.de, sebastian.mendel@netresearch.de, rico.sonntag@netresearch.de',
     'author_company' => 'Netresearch DTT GmbH',
     'state'          => 'stable',
-    'version'        => '13.8.3',
+    'version'        => '13.9.0',
     'constraints'    => [
         'depends' => [
             // ext_emconf does not support disjoint ranges. The supported


### PR DESCRIPTION
## Summary

Release bump to **v13.9.0** — bumps `ext_emconf.php`, finalizes the `[Unreleased]` section of `CHANGELOG.md`, and refreshes user-facing docs to cover the new validator behavior.

Compare: [`v13.8.3...release/v13.9.0`](https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.8.3...release/v13.9.0)

### Highlights since [v13.8.3](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v13.8.3)

**Added**
- Validator now skips out-of-scope `<img src>` origins (external, `data:`, legacy `typo3conf/ext/`, `/securedl/`) by default; new `--include` flag opts categories back in ([#788](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/788))

**Fixed**
- `rel="noreferrer"` missing on figure-wrapped linked images ([#799](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/799), [#802](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/802))
- `<p>` tags entity-encoded in plain RTE bodytext on vanilla installs ([#790](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/790))
- TYPO3 v14 link browser `FormEngineLinkBrowserSetLinkEvent` contract ([#798](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/798))
- Corrupted `<img src>` no longer round-tripped through RTE ([#787](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/787))

**Changed**
- Pin TYPO3 v14 requirement to v14.3 LTS ([#792](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/792))

Minor bump justified by [#788](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/788) (new user-facing default behavior + new flag).

### Files touched

- `ext_emconf.php` — version `13.8.3` → `13.9.0`
- `CHANGELOG.md` — `[Unreleased]` → `[13.9.0] - 2026-04-29`; added missing entries for [#787](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/787) and [#798](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/798); promoted [#788](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/788) under **Added**
- `Documentation/Troubleshooting/Image-Reference-Validation.rst` — new "Skipped origins" subsection (`.. versionadded:: 13.9.0`) covering the default-skip categories, per-origin breakdown in the CLI summary, and `--include` opt-in flag
- `AGENTS.md` — bump stale `Current Version: 13.8.0` (never updated through 13.8.1/2/3) → `13.9.0`

`README.md`, `Documentation/Settings.cfg` (uses `version = main`) and `Documentation/Index.rst` (uses `:Version: |release|`) need no edits.

## Test plan

- [x] Pre-commit hooks pass (lint, php-cs-fixer, phpstan)
- [x] Latest CI green on `main` (47/47 required checks pass)
- [ ] CI green on this PR
- [ ] After merge: tag `v13.9.0` (signed) and push to trigger release workflow

## Related issues

Triggers release workflow on tag push (archive, SBOM, cosign, attestations, TER publish, announcement discussion).
