### PR TITLE
ci(sonarqube): wire up shared SonarQube workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,14 @@ jobs:
       pull-requests: write
 
   sonarqube:
-    # Sonar covers push to main + every PR. merge_group / schedule add no
-    # signal (same code already analyzed) and would burn analysis quota.
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    # Sonar covers push to main + same-repo PRs. Fork PRs do not receive
+    # repository secrets, so SONAR_TOKEN would be empty and the scan would
+    # fail; skip them. merge_group / schedule add no new signal (same code
+    # already analyzed) and would only burn analysis quota.
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     uses: netresearch/.github/.github/workflows/sonarqube.yml@main
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,13 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+
+  sonarqube:
+    # Sonar covers push to main + every PR. merge_group / schedule add no
+    # signal (same code already analyzed) and would burn analysis quota.
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/sonarqube.yml@main
+    permissions:
+      contents: read
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.projectKey=netresearch_t3x-rte_ckeditor_image
+sonar.organization=netresearch
+
+sonar.sources=Classes,Configuration,Resources/Public,ext_emconf.php,ext_localconf.php
+sonar.tests=Tests
+
+sonar.sourceEncoding=UTF-8
+
+# Generated, vendored, or third-party content excluded from analysis.
+sonar.exclusions=**/node_modules/**,**/vendor/**,.Build/**,.build/**,Documentation/**,Documentation-GENERATED-temp/**,typo3temp/**,var/**,**/*.min.js,**/*.min.css
+
+sonar.test.inclusions=Tests/**/*Test.php,Tests/**/*.test.ts,Tests/**/*.test.js,Tests/**/*.spec.ts,Tests/**/*.spec.js


### PR DESCRIPTION
## Summary

- Adds a `sonarqube` job to `ci.yml` that consumes the new reusable workflow [`netresearch/.github/.github/workflows/sonarqube.yml@main`](https://github.com/netresearch/.github/pull/104).
- Adds `sonar-project.properties` with the project key (`netresearch_t3x-rte_ckeditor_image`), source/test paths, and exclusions for vendor / build / generated content.
- Job is gated to `push` and `pull_request`; `merge_group` and the weekly `schedule` add no signal (same code already analyzed) and would only consume Sonar analysis quota.

## Dependency

This PR uses `@main` of `netresearch/.github`, so it depends on:

- netresearch/.github#104 — must be merged **before** this can run successfully.

## Configuration

- **`SONAR_TOKEN`** is forwarded from the org-level secret (already provisioned for `ALL` repos).
- **`SONAR_HOST_URL`** is intentionally omitted so the scan targets SonarCloud (default).
- A SonarCloud project must exist at `netresearch_t3x-rte_ckeditor_image` (under the `netresearch` organization). If the project hasn't been onboarded yet, the first scan will fail with `Project not found` — onboard the repo via the SonarCloud UI, then re-run.

## Test plan

- [ ] netresearch/.github#104 lands on `main`.
- [ ] CI on this PR shows a `sonarqube` job that runs to completion.
- [ ] SonarCloud receives the analysis (visible at https://sonarcloud.io/project/overview?id=netresearch_t3x-rte_ckeditor_image).
- [ ] PR decoration appears via the SonarCloud GitHub App (no extra workflow permissions needed).