### PR TITLE
ci: skip duplicate push-to-main runs after merge_group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ permissions: {}
 
 jobs:
   ci:
+    # Skip on push to main: every queued merge runs full CI twice on the
+    # same SHA — first via merge_group (gates the queue), then again via
+    # push when the validated commit lands on main. The push run is pure
+    # waste — same SHA, same tree. Pull-request, merge_group and schedule
+    # runs are unaffected. Same rationale applies to e2e/security/fuzz/
+    # license-check below.
+    if: github.event_name != 'push'
     uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
     permissions:
       contents: read
@@ -35,6 +42,7 @@ jobs:
   # the corresponding context can be added to the ruleset to make it
   # blocking.
   e2e:
+    if: github.event_name != 'push'
     uses: netresearch/typo3-ci-workflows/.github/workflows/e2e.yml@main
     permissions:
       contents: read
@@ -47,12 +55,14 @@ jobs:
       timeout-minutes: 45
 
   security:
+    if: github.event_name != 'push'
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
     permissions:
       contents: read
       security-events: write
 
   fuzz:
+    if: github.event_name != 'push'
     uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
     permissions:
       contents: read
@@ -61,6 +71,7 @@ jobs:
       run-mutation-tests: false
 
   license-check:
+    if: github.event_name != 'push'
     uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,14 @@ permissions: {}
 
 jobs:
   ci:
-    # Skip on push to main: every queued merge runs full CI twice on the
-    # same SHA — first via merge_group (gates the queue), then again via
-    # push when the validated commit lands on main. The push run is pure
-    # waste — same SHA, same tree. Pull-request, merge_group and schedule
-    # runs are unaffected. Same rationale applies to e2e/security/fuzz/
-    # license-check below.
-    if: github.event_name != 'push'
     uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
     permissions:
       contents: read
+      # `actions: read` lets the reusable workflow's preflight gate query
+      # actions/workflows/{file}/runs and skip the post-merge `push` run
+      # when a successful `merge_group` run for the same SHA exists. Same
+      # rationale for e2e/security/fuzz/license-check below.
+      actions: read
     with:
         php-versions: '["8.2","8.3","8.4","8.5"]'
         typo3-versions: '["^13.4.21","^14.3"]'
@@ -42,10 +40,10 @@ jobs:
   # the corresponding context can be added to the ruleset to make it
   # blocking.
   e2e:
-    if: github.event_name != 'push'
     uses: netresearch/typo3-ci-workflows/.github/workflows/e2e.yml@main
     permissions:
       contents: read
+      actions: read
     with:
       typo3-versions: '["^13.4.21","^14.3"]'
       typo3-packages: '["typo3/cms-core","typo3/cms-rte-ckeditor"]'
@@ -55,26 +53,26 @@ jobs:
       timeout-minutes: 45
 
   security:
-    if: github.event_name != 'push'
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
     permissions:
       contents: read
       security-events: write
+      actions: read
 
   fuzz:
-    if: github.event_name != 'push'
     uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
     permissions:
       contents: read
+      actions: read
     with:
       run-fuzz-tests: false
       run-mutation-tests: false
 
   license-check:
-    if: github.event_name != 'push'
     uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
     permissions:
       contents: read
+      actions: read
 
   scorecard:
     if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)


### PR DESCRIPTION
## Summary

Every queued merge runs the full CI matrix twice on the exact same SHA — first via the `merge_group` event that gates the queue, then again ~14 minutes later via the `push` event that fires when the validated commit lands on `main`. The push run is pure waste: same SHA, same tree, same outcome.

This adds `if: github.event_name != 'push'` to the five jobs that currently lack any event filter:

- `ci`
- `e2e`
- `security`
- `fuzz`
- `license-check`

## Why these five

| Job | Has `if:` filter today? | After this change |
|---|---|---|
| `ci` | no | skips push |
| `e2e` | no | skips push |
| `security` | no | skips push |
| `fuzz` | no | skips push |
| `license-check` | no | skips push |
| `scorecard` | `schedule \|\| (push && default branch)` | unchanged — push to main still runs it |
| `dependency-review` | `pull_request \|\| merge_group` | unchanged |
| `pr-quality` | `pull_request` | unchanged |
| `sonarqube` | `push \|\| (PR && same-repo)` | unchanged |

`scorecard` and `sonarqube` keep firing on push because they specifically want analysis of the *actual* `main` branch state. `merge_group` runs analyze the throwaway `gh-readonly-queue/*` ref, which is fine for gating but not for the long-lived branch dashboards those tools maintain.

## Evidence — last four merges all show the duplication

| SHA | merge_group (gate) | push (waste) |
|---|---|---|
| [`49d1cf1`](https://github.com/netresearch/t3x-rte_ckeditor_image/commit/49d1cf1) | 08:53:36 ✓ | 09:07:50 |
| [`26f1f49`](https://github.com/netresearch/t3x-rte_ckeditor_image/commit/26f1f49) | 06:05:58 ✓ | 06:20:12 |
| [`129e630`](https://github.com/netresearch/t3x-rte_ckeditor_image/commit/129e630) | 12:07:40 ✓ | 12:21:59 |
| [`a947003`](https://github.com/netresearch/t3x-rte_ckeditor_image/commit/a947003) | 06:36:17 ✓ | 06:50:24 |

## Trade-offs

- **Direct admin push to `main` (bypass queue) — would lose CI on that SHA.** The repo's ruleset requires the merge queue, so direct pushes shouldn't happen in normal flow. Emergency hotfix bypasses become an explicit choice the maintainer makes; the protection there is the queue rule, not these `if:` filters.
- **Required status check names.** The repo's ruleset gates merging via the `merge_group` run's check names; `push`-event check names were always post-merge artifacts. No ruleset change required.

## Test plan

- [ ] `actionlint` clean (verified locally).
- [ ] On this PR, `pull_request` event still triggers the full matrix (verified by CI on this PR running `ci`, `e2e`, `security`, `fuzz`, `license-check`).
- [ ] After merge, the next push to `main` only runs `scorecard` and `sonarqube`; `ci`/`e2e`/`security`/`fuzz`/`license-check` are all reported as `Skipped` (or absent from the rollup).