### PR TITLE
ci(sonarqube): wire PHPUnit coverage into SonarCloud scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,68 @@ jobs:
     # repository secrets, so SONAR_TOKEN would be empty and the scan would
     # fail; skip them. merge_group / schedule add no new signal (same code
     # already analyzed) and would only burn analysis quota.
+    #
+    # Inline (not the language-agnostic
+    # netresearch/.github/.github/workflows/sonarqube.yml) so we can run
+    # PHPUnit with coverage and feed the resulting Clover report to the
+    # scanner — the reusable workflow only checks out + scans, with no
+    # test execution. Single PHP/TYPO3 combo to keep CI cost bounded;
+    # the `ci` job still exercises the full matrix.
     if: >-
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository)
-    uses: netresearch/.github/.github/workflows/sonarqube.yml@main
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Sonar requires full history for accurate blame / new-code detection.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+        with:
+          php-version: '8.3'
+          tools: composer:v2
+          coverage: xdebug
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-sonar-${{ hashFiles('composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-sonar-
+
+      - name: Install TYPO3
+        run: |
+          composer require --no-update "typo3/cms-core:^14.3" "typo3/cms-rte-ckeditor:^14.3"
+          composer install --prefer-dist --no-progress
+
+      - name: Run unit tests with coverage
+        env:
+          XDEBUG_MODE: coverage
+        # Reuses the existing composer script (which writes to
+        # .Build/logs/clover-unit.xml) so the CI command matches what
+        # developers run locally — same Xdebug driver, same output paths.
+        run: composer ci:coverage:unit
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: 'https://sonarcloud.io'

--- a/Resources/Public/Demo/index.html
+++ b/Resources/Public/Demo/index.html
@@ -373,7 +373,7 @@
             <code>.image-left</code> &mdash; Float left with text wrapping
         </div>
         <div class="example-render">
-            <img class="image-left ph-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='120'%3E%3Crect width='180' height='120' fill='%232F99A4'/%3E%3Ctext x='90' y='64' text-anchor='middle' fill='white' font-family='sans-serif' font-size='13' font-weight='600'%3E180 %C3%97 120%3C/text%3E%3C/svg%3E" alt="Left-aligned 180 by 120 image" width="180" height="120">
+            <img class="image-left ph-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='120'%3E%3Crect width='180' height='120' fill='%232F99A4'/%3E%3Ctext x='90' y='64' text-anchor='middle' fill='white' font-family='sans-serif' font-size='13' font-weight='600'%3E180 %C3%97 120%3C/text%3E%3C/svg%3E" alt="Left-aligned 180×120 placeholder" width="180" height="120">
             <p class="demo-text">The image floats to the left and surrounding text wraps around it. This is the most common layout for editorial content where an image illustrates a point while the narrative continues alongside it. The float is cleared automatically via the <code>::after</code> pseudo-element to prevent layout collisions with subsequent content. On screens narrower than 768px, the float is removed and the image becomes a centered block element for better readability on mobile devices.</p>
         </div>
     </div>
@@ -385,7 +385,7 @@
             <code>.image-right</code> &mdash; Float right with text wrapping
         </div>
         <div class="example-render">
-            <img class="image-right ph-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='120'%3E%3Crect width='180' height='120' fill='%23FF4D00'/%3E%3Ctext x='90' y='64' text-anchor='middle' fill='white' font-family='sans-serif' font-size='13' font-weight='600'%3E180 %C3%97 120%3C/text%3E%3C/svg%3E" alt="Right-aligned 180 by 120 image" width="180" height="120">
+            <img class="image-right ph-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='120'%3E%3Crect width='180' height='120' fill='%23FF4D00'/%3E%3Ctext x='90' y='64' text-anchor='middle' fill='white' font-family='sans-serif' font-size='13' font-weight='600'%3E180 %C3%97 120%3C/text%3E%3C/svg%3E" alt="Right-aligned 180×120 placeholder" width="180" height="120">
             <p class="demo-text">The image floats to the right. This is useful for pull-quotes, secondary illustrations, or sidebar content that accompanies the main text flow. Like <code>.image-left</code>, the float clears automatically and becomes a centered block on narrow viewports. The margin is applied on the left side to create space between the image and the text.</p>
         </div>
     </div>
@@ -398,7 +398,7 @@
         </div>
         <div class="example-render">
             <p class="demo-text">Content before the centered image.</p>
-            <img class="image-center ph-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='140'%3E%3Crect width='300' height='140' fill='%23585961'/%3E%3Ctext x='150' y='74' text-anchor='middle' fill='white' font-family='sans-serif' font-size='13' font-weight='600'%3E300 %C3%97 140%3C/text%3E%3C/svg%3E" alt="Centered 300 by 140 image" width="300" height="140">
+            <img class="image-center ph-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='140'%3E%3Crect width='300' height='140' fill='%23585961'/%3E%3Ctext x='150' y='74' text-anchor='middle' fill='white' font-family='sans-serif' font-size='13' font-weight='600'%3E300 %C3%97 140%3C/text%3E%3C/svg%3E" alt="Centered 300×140 placeholder" width="300" height="140">
             <p class="demo-text">Content after the centered image. The image is displayed as a block element with automatic left and right margins. Text does not wrap around it &mdash; it creates a visual break in the content flow, ideal for hero images or key illustrations.</p>
         </div>
     </div>
@@ -428,7 +428,7 @@
         </div>
         <div class="example-render">
             <p class="demo-text">Content before the block image.</p>
-            <img class="image-block ph-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='120'%3E%3Crect width='800' height='120' fill='%23267883'/%3E%3Ctext x='400' y='64' text-anchor='middle' fill='white' font-family='sans-serif' font-size='13' font-weight='600'%3Efull width (100%25)%3C/text%3E%3C/svg%3E" alt="Full-width image" width="800" height="120">
+            <img class="image-block ph-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='120'%3E%3Crect width='800' height='120' fill='%23267883'/%3E%3Ctext x='400' y='64' text-anchor='middle' fill='white' font-family='sans-serif' font-size='13' font-weight='600'%3Efull width (100%25)%3C/text%3E%3C/svg%3E" alt="Full-width banner" width="800" height="120">
             <p class="demo-text">Content after. The image stretches to 100% of the container width, creating a strong visual break. Ideal for banner images, section dividers, or full-bleed photography.</p>
         </div>
     </div>
@@ -497,7 +497,7 @@
         </div>
         <div class="example-render">
             <figure class="image-block" style="max-width: 400px">
-                <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='120'%3E%3Crect width='400' height='120' fill='%23267883'/%3E%3Ctext x='200' y='64' text-anchor='middle' fill='white' font-family='sans-serif' font-size='13' font-weight='600'%3E400 %C3%97 120 (block)%3C/text%3E%3C/svg%3E" alt="Full-width block image with caption" width="400" height="120" decoding="async">
+                <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='120'%3E%3Crect width='400' height='120' fill='%23267883'/%3E%3Ctext x='200' y='64' text-anchor='middle' fill='white' font-family='sans-serif' font-size='13' font-weight='600'%3E400 %C3%97 120 (block)%3C/text%3E%3C/svg%3E" alt="Full-width block with caption" width="400" height="120" decoding="async">
                 <figcaption>A block-level figure with caption. The CSS sets width: 100% but max-width constrains it to the image width, preventing the figure from stretching beyond 400px.</figcaption>
             </figure>
             <p class="demo-text">With <code>.image-block</code>, the figure uses <code>width: 100%</code> but the inline <code>max-width</code> caps it at the image width. This prevents the caption from spanning the full container while keeping the block display behavior.</p>
@@ -526,7 +526,7 @@
             <div>
                 <div class="comparison-label comparison-label--before">&#x2717; Before (no max-width)</div>
                 <figure class="image-left">
-                    <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='75' height='100'%3E%3Crect width='75' height='100' fill='%23dc2626'/%3E%3Ctext x='37' y='54' text-anchor='middle' fill='white' font-family='sans-serif' font-size='11' font-weight='600'%3E75%C3%97100%3C/text%3E%3C/svg%3E" alt="Small image" width="75" height="100" decoding="async">
+                    <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='75' height='100'%3E%3Crect width='75' height='100' fill='%23dc2626'/%3E%3Ctext x='37' y='54' text-anchor='middle' fill='white' font-family='sans-serif' font-size='11' font-weight='600'%3E75%C3%97100%3C/text%3E%3C/svg%3E" alt="Small red placeholder" width="75" height="100" decoding="async">
                     <figcaption>This caption overflows far beyond the image boundary because the figure has no width constraint applied</figcaption>
                 </figure>
                 <p class="demo-text-sm">The figcaption expands the figure width beyond the image, breaking the layout.</p>
@@ -534,7 +534,7 @@
             <div>
                 <div class="comparison-label comparison-label--after">&#x2713; After (max-width: 75px)</div>
                 <figure class="image-left" style="max-width: 75px">
-                    <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='75' height='100'%3E%3Crect width='75' height='100' fill='%2316a34a'/%3E%3Ctext x='37' y='54' text-anchor='middle' fill='white' font-family='sans-serif' font-size='11' font-weight='600'%3E75%C3%97100%3C/text%3E%3C/svg%3E" alt="Small image" width="75" height="100" decoding="async">
+                    <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='75' height='100'%3E%3Crect width='75' height='100' fill='%2316a34a'/%3E%3Ctext x='37' y='54' text-anchor='middle' fill='white' font-family='sans-serif' font-size='11' font-weight='600'%3E75%C3%97100%3C/text%3E%3C/svg%3E" alt="Small green placeholder" width="75" height="100" decoding="async">
                     <figcaption>This caption wraps neatly within the image width boundary</figcaption>
                 </figure>
                 <p class="demo-text-sm">With <code>max-width: 75px</code>, the caption wraps within the image width.</p>
@@ -621,7 +621,7 @@
         </div>
         <div class="example-render">
             <a href="#link-demo">
-                <img class="image-center ph-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='280' height='160'%3E%3Crect width='280' height='160' fill='%232563eb'/%3E%3Ctext x='140' y='75' text-anchor='middle' fill='white' font-family='sans-serif' font-size='12' font-weight='600'%3EClick me (linked)%3C/text%3E%3Ctext x='140' y='100' text-anchor='middle' fill='rgba(255,255,255,.6)' font-family='sans-serif' font-size='11'%3Ehref=%22/some-page%22%3C/text%3E%3C/svg%3E" alt="Linked image" width="280" height="160" decoding="async" style="cursor:pointer">
+                <img class="image-center ph-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='280' height='160'%3E%3Crect width='280' height='160' fill='%232563eb'/%3E%3Ctext x='140' y='75' text-anchor='middle' fill='white' font-family='sans-serif' font-size='12' font-weight='600'%3EClick me (linked)%3C/text%3E%3Ctext x='140' y='100' text-anchor='middle' fill='rgba(255,255,255,.6)' font-family='sans-serif' font-size='11'%3Ehref=%22/some-page%22%3C/text%3E%3C/svg%3E" alt="Linked placeholder" width="280" height="160" decoding="async" style="cursor:pointer">
             </a>
             <p class="demo-text" style="text-align:center">Image wrapped in an <code>&lt;a&gt;</code> tag. Hover to see opacity transition.</p>
         </div>
@@ -635,7 +635,7 @@
         </div>
         <div class="example-render">
             <a href="#zoom-demo" class="popup-link" data-popup="true" rel="lightbox-group-rte">
-                <img class="image-center ph-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='280' height='160'%3E%3Cdefs%3E%3ClinearGradient id='g2' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop offset='0%25' stop-color='%237c3aed'/%3E%3Cstop offset='100%25' stop-color='%235b21b6'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='280' height='160' fill='url(%23g2)'/%3E%3Ctext x='140' y='75' text-anchor='middle' fill='white' font-family='sans-serif' font-size='12' font-weight='600'%3EClick to enlarge%3C/text%3E%3Ctext x='140' y='100' text-anchor='middle' fill='rgba(255,255,255,.6)' font-family='sans-serif' font-size='11'%3Edata-popup=%22true%22%3C/text%3E%3C/svg%3E" alt="Zoomable image" width="280" height="160" decoding="async">
+                <img class="image-center ph-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='280' height='160'%3E%3Cdefs%3E%3ClinearGradient id='g2' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop offset='0%25' stop-color='%237c3aed'/%3E%3Cstop offset='100%25' stop-color='%235b21b6'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect width='280' height='160' fill='url(%23g2)'/%3E%3Ctext x='140' y='75' text-anchor='middle' fill='white' font-family='sans-serif' font-size='12' font-weight='600'%3EClick to enlarge%3C/text%3E%3Ctext x='140' y='100' text-anchor='middle' fill='rgba(255,255,255,.6)' font-family='sans-serif' font-size='11'%3Edata-popup=%22true%22%3C/text%3E%3C/svg%3E" alt="Zoomable placeholder" width="280" height="160" decoding="async">
             </a>
             <p class="demo-text" style="text-align:center">
                 Zoom badge appears at top-right. Adds <code>data-popup="true"</code>
@@ -812,7 +812,7 @@
             Lazy Loading &mdash; <code>loading="lazy"</code> attribute
         </div>
         <div class="example-render">
-            <img class="image-center ph-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='120'%3E%3Crect width='300' height='120' fill='%23267883'/%3E%3Ctext x='150' y='55' text-anchor='middle' fill='white' font-family='sans-serif' font-size='12' font-weight='600'%3Eloading=%22lazy%22%3C/text%3E%3Ctext x='150' y='78' text-anchor='middle' fill='rgba(255,255,255,.6)' font-family='sans-serif' font-size='10'%3Edecoding=%22async%22%3C/text%3E%3C/svg%3E" alt="Lazy loaded image" width="300" height="120" decoding="async" loading="lazy">
+            <img class="image-center ph-img" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='120'%3E%3Crect width='300' height='120' fill='%23267883'/%3E%3Ctext x='150' y='55' text-anchor='middle' fill='white' font-family='sans-serif' font-size='12' font-weight='600'%3Eloading=%22lazy%22%3C/text%3E%3Ctext x='150' y='78' text-anchor='middle' fill='rgba(255,255,255,.6)' font-family='sans-serif' font-size='10'%3Edecoding=%22async%22%3C/text%3E%3C/svg%3E" alt="Lazily loaded placeholder" width="300" height="120" decoding="async" loading="lazy">
             <p class="demo-text" style="text-align:center;margin-top:1rem">
                 Images support <code>loading="lazy|eager|auto"</code> for native browser lazy loading
                 and <code>decoding="async"</code> for non-blocking decode.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,3 +10,10 @@ sonar.sourceEncoding=UTF-8
 sonar.exclusions=**/node_modules/**,**/vendor/**,.Build/**,.build/**,Documentation/**,Documentation-GENERATED-temp/**,typo3temp/**,var/**,**/*.min.js,**/*.min.css
 
 sonar.test.inclusions=Tests/**/*Test.php,Tests/**/*.test.ts,Tests/**/*.test.js,Tests/**/*.spec.ts,Tests/**/*.spec.js
+
+# Coverage report — produced by `composer ci:coverage:unit` (run by the
+# inline `sonarqube` job in .github/workflows/ci.yml). Path matches the
+# project's existing convention (.Build/ is the composer vendor-dir, used
+# by both local dev and CI). The path is read directly by the scanner;
+# `sonar.exclusions=.Build/**` only affects which files are *analyzed*.
+sonar.php.coverage.reportPaths=.Build/logs/clover-unit.xml


### PR DESCRIPTION
## Summary

Two improvements to the SonarCloud integration:

### 1. Wire PHPUnit coverage into the SonarCloud scan
- Replaces the call to the language-agnostic shared `sonarqube.yml` reusable workflow with an inline job in `ci.yml`
- The inline job sets up PHP 8.3 + Xdebug, installs the TYPO3 14.3 stack, runs `composer ci:test:php:unit -- --coverage-clover=coverage-unit.xml`, then runs `SonarSource/sonarqube-scan-action`
- Adds `sonar.php.coverage.reportPaths=coverage-unit.xml` to `sonar-project.properties`

### 2. Fix accessibility issues in the demo showcase
- Removes the redundant word "image" from 10 `alt` attributes in `Resources/Public/Demo/index.html`
- Screen readers already announce `<img>` elements as "image" — `alt="… image"` produces "image image …" for AT users
- Resolves all 10 `Web:S6851` Reliability findings in the demo file (genuine a11y improvements, not just lint silencing)

## Why coverage was 0.0%

The shared `netresearch/.github/.github/workflows/sonarqube.yml@main` is intentionally language-agnostic — it only checks out the repo and runs the scanner, with no test step or coverage report generation.

Goal here is to **evaluate** whether SonarCloud's coverage view adds value alongside the existing Codecov integration. Scope is intentionally limited to one repo + a single PHP/TYPO3 combo.

## Other findings handled out-of-band (no code change)

- Security `php:S1313` (hardcoded `169.254.169.254` in `SecurityValidator.php`) — marked **False Positive** in SonarCloud with explanation: the literal address IS the security control (cloud-metadata SSRF blocklist).
- Both `php:S4790` weak-hash hotspots (MD5 used for filename generation, not crypto) — marked **Safe** in SonarCloud earlier today.

## Trade-offs

- ✅ Self-contained: no changes to `netresearch/typo3-ci-workflows` or `netresearch/.github` needed.
- ⚠️ Test execution duplicates work — the existing `ci` job already runs unit tests across the full PHP 8.2–8.5 × TYPO3 13/14 matrix. The inline `sonarqube` job re-runs unit tests on a single combo (PHP 8.3 + TYPO3 14.3) just to feed Sonar.
- 🔄 If the experiment proves valuable, the natural follow-up is to push artifact upload into `typo3-ci-workflows/ci.yml` and artifact download into `.github/sonarqube.yml`, eliminating the duplicate test run.

Action SHAs match those used by the shared reusable workflows.

## Related

- Predecessor PR #809 — original SonarQube wiring (coverage-less)

## Test plan

- [ ] CI green
- [ ] SonarCloud project shows non-zero coverage after merge to `main`
- [ ] SonarCloud Reliability count drops by 10 (a11y fixes) on next scan
- [ ] Existing `ci` matrix still passes