### PR TITLE
fix(database): tolerate RTE hook without backend HTTP request (#815)

### DIFF
--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -21,8 +21,6 @@ use function is_string;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
-use RuntimeException;
-
 use function strlen;
 
 use Throwable;
@@ -465,12 +463,30 @@ class RteImagesDbHook
         }
     }
 
+    /**
+     * RTE image enrichment (magic images, external fetch, etc.) requires a backend HTTP request.
+     * Scheduler/CLI and other contexts without TYPO3_REQUEST must leave HTML unchanged (#815).
+     */
+    private function isBackendRteImageProcessingContext(): bool
+    {
+        $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
+        if (!$request instanceof ServerRequestInterface) {
+            return false;
+        }
+
+        return ApplicationType::fromRequest($request)->isBackend();
+    }
+
     private function modifyRteField(string $value): string
     {
         $rteHtmlParser = new HtmlParser();
         $imgSplit      = $rteHtmlParser->splitTags('img', $value);
 
         if (count($imgSplit) === 0) {
+            return $value;
+        }
+
+        if (!$this->isBackendRteImageProcessingContext()) {
             return $value;
         }
 
@@ -556,16 +572,6 @@ class RteImagesDbHook
                     $attribArray['height'] = $imageHeight;
                 }
 
-                // Determine application type - fail secure: require backend context
-                if (!($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface) {
-                    throw new RuntimeException('Invalid request context: ServerRequest required', 1734278400);
-                }
-
-                $applicationType = ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST']);
-                if (!$applicationType->isBackend()) {
-                    throw new RuntimeException('Backend context required for image processing', 1734278401);
-                }
-
                 if ($originalImageFile instanceof File) {
                     // Build public URL to image, remove trailing slash from site URL
                     $imageFileUrl = rtrim($siteUrl, '/') . $originalImageFile->getPublicUrl();
@@ -605,7 +611,7 @@ class RteImagesDbHook
                 ) {
                     // External image from another URL: in that case, fetch image, unless
                     // the feature is disabled.
-                    // Note: Backend context is already validated above (lines 441-444).
+                    // Note: Backend context is already validated in modifyRteField() entry.
                     //
                     // SECURITY: Validate URL and get safe IP to prevent DNS rebinding attacks
                     $safeIp = $this->getSafeIpForExternalFetch($absoluteUrl);

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -32,10 +32,10 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\FileProcessingAspect;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Html\HtmlParser;
 use TYPO3\CMS\Core\Html\RteHtmlParser;
-use TYPO3\CMS\Core\Http\ApplicationType;
 use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Resource\AbstractFile;
@@ -467,6 +467,9 @@ class RteImagesDbHook
     /**
      * RTE image enrichment (magic images, external fetch, etc.) requires a backend HTTP request.
      * Scheduler/CLI and other contexts without TYPO3_REQUEST must leave HTML unchanged (#815).
+     *
+     * Reads the `applicationType` request attribute (same source as ApplicationType::fromRequest())
+     * without throwing when the attribute is missing or invalid.
      */
     private function isBackendRteImageProcessingContext(): bool
     {
@@ -475,19 +478,25 @@ class RteImagesDbHook
             return false;
         }
 
-        return ApplicationType::fromRequest($request)->isBackend();
+        $applicationType = $request->getAttribute('applicationType');
+        if (!is_int($applicationType)) {
+            return false;
+        }
+
+        return ($applicationType & SystemEnvironmentBuilder::REQUESTTYPE_BE)
+            === SystemEnvironmentBuilder::REQUESTTYPE_BE;
     }
 
     private function modifyRteField(string $value): string
     {
+        if (!$this->isBackendRteImageProcessingContext()) {
+            return $value;
+        }
+
         $rteHtmlParser = new HtmlParser();
         $imgSplit      = $rteHtmlParser->splitTags('img', $value);
 
         if (count($imgSplit) === 0) {
-            return $value;
-        }
-
-        if (!$this->isBackendRteImageProcessingContext()) {
             return $value;
         }
 

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -470,6 +470,9 @@ class RteImagesDbHook
      *
      * Reads the `applicationType` request attribute (same source as ApplicationType::fromRequest())
      * without throwing when the attribute is missing or invalid.
+     *
+     * Resolution order matches TYPO3 core ApplicationType::fromRequest(): frontend flag wins when
+     * both REQUESTTYPE_FE and REQUESTTYPE_BE bits are set.
      */
     private function isBackendRteImageProcessingContext(): bool
     {
@@ -480,6 +483,12 @@ class RteImagesDbHook
 
         $applicationType = $request->getAttribute('applicationType');
         if (!is_int($applicationType)) {
+            return false;
+        }
+
+        if (($applicationType & SystemEnvironmentBuilder::REQUESTTYPE_FE)
+            === SystemEnvironmentBuilder::REQUESTTYPE_FE
+        ) {
             return false;
         }
 

--- a/Classes/Database/RteImagesDbHook.php
+++ b/Classes/Database/RteImagesDbHook.php
@@ -21,6 +21,7 @@ use function is_string;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
+
 use function strlen;
 
 use Throwable;

--- a/Tests/Unit/Database/RteImagesDbHookTest.php
+++ b/Tests/Unit/Database/RteImagesDbHookTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the package netresearch/rte-ckeditor-image.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\RteCKEditorImage\Tests\Unit\Database;
+
+use Netresearch\RteCKEditorImage\Database\RteImagesDbHook;
+use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionClass;
+use stdClass;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Log\LogManager;
+use TYPO3\CMS\Core\Log\Logger;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Unit tests for {@see RteImagesDbHook} CLI / missing-request behaviour (#815).
+ */
+final class RteImagesDbHookTest extends UnitTestCase
+{
+    protected bool $resetSingletonInstances = true;
+
+    private RteImagesDbHook $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var ExtensionConfiguration&MockObject $extensionConfiguration */
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturnMap([
+            ['rte_ckeditor_image', 'fetchExternalImages', false],
+            ['rte_ckeditor_image', 'allowSvgImages', false],
+        ]);
+
+        $logger = $this->createMock(Logger::class);
+
+        /** @var LogManager&MockObject $logManager */
+        $logManager = $this->createMock(LogManager::class);
+        $logManager->method('getLogger')->willReturn($logger);
+
+        $this->subject = new RteImagesDbHook($extensionConfiguration, $logManager);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TYPO3_REQUEST']);
+        parent::tearDown();
+    }
+
+    /**
+     * @param array<int, mixed> $parameters
+     */
+    private function invokeModifyRteField(string $html): string
+    {
+        $reflection = new ReflectionClass(RteImagesDbHook::class);
+        $method     = $reflection->getMethod('modifyRteField');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->subject, $html);
+    }
+
+    public function testModifyRteFieldLeavesHtmlUnchangedWhenTypo3RequestIsUnset(): void
+    {
+        unset($GLOBALS['TYPO3_REQUEST']);
+
+        $html = '<p>x</p><img src="https://example.org/image.jpg" width="100" height="50" />';
+
+        $result = $this->invokeModifyRteField($html);
+
+        self::assertSame($html, $result);
+    }
+
+    public function testModifyRteFieldLeavesHtmlUnchangedWhenTypo3RequestIsNotPsrServerRequest(): void
+    {
+        $GLOBALS['TYPO3_REQUEST'] = new stdClass();
+
+        $html = '<img src="https://example.org/image.jpg" data-htmlarea-file-uid="1" />';
+
+        $result = $this->invokeModifyRteField($html);
+
+        self::assertSame($html, $result);
+    }
+}

--- a/Tests/Unit/Database/RteImagesDbHookTest.php
+++ b/Tests/Unit/Database/RteImagesDbHookTest.php
@@ -16,8 +16,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
 use stdClass;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Log\Logger;
+use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**

--- a/Tests/Unit/Database/RteImagesDbHookTest.php
+++ b/Tests/Unit/Database/RteImagesDbHookTest.php
@@ -14,6 +14,7 @@ namespace Netresearch\RteCKEditorImage\Tests\Unit\Database;
 use Netresearch\RteCKEditorImage\Database\RteImagesDbHook;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
+use RuntimeException;
 use stdClass;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Log\Logger;
@@ -27,7 +28,7 @@ final class RteImagesDbHookTest extends UnitTestCase
 {
     protected bool $resetSingletonInstances = true;
 
-    private RteImagesDbHook $subject;
+    private ?RteImagesDbHook $subject = null;
 
     protected function setUp(): void
     {
@@ -49,22 +50,34 @@ final class RteImagesDbHookTest extends UnitTestCase
         $this->subject = new RteImagesDbHook($extensionConfiguration, $logManager);
     }
 
+    private function getSubject(): RteImagesDbHook
+    {
+        $subject = $this->subject;
+        if ($subject === null) {
+            self::fail('Test subject was not initialized in setUp()');
+        }
+
+        return $subject;
+    }
+
     protected function tearDown(): void
     {
         unset($GLOBALS['TYPO3_REQUEST']);
         parent::tearDown();
     }
 
-    /**
-     * @param array<int, mixed> $parameters
-     */
     private function invokeModifyRteField(string $html): string
     {
         $reflection = new ReflectionClass(RteImagesDbHook::class);
         $method     = $reflection->getMethod('modifyRteField');
         $method->setAccessible(true);
 
-        return $method->invoke($this->subject, $html);
+        $result = $method->invoke($this->getSubject(), $html);
+        if (!is_string($result)) {
+            throw new RuntimeException('modifyRteField must return string');
+        }
+
+        return $result;
     }
 
     public function testModifyRteFieldLeavesHtmlUnchangedWhenTypo3RequestIsUnset(): void

--- a/Tests/Unit/Database/RteImagesDbHookTest.php
+++ b/Tests/Unit/Database/RteImagesDbHookTest.php
@@ -18,6 +18,7 @@ use ReflectionClass;
 use RuntimeException;
 use stdClass;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Log\Logger;
 use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -118,6 +119,31 @@ final class RteImagesDbHookTest extends UnitTestCase
         $GLOBALS['TYPO3_REQUEST'] = $request;
 
         $html = '<img src="https://example.org/image.jpg" alt="" />';
+
+        $result = $this->invokeModifyRteField($html);
+
+        self::assertSame($html, $result);
+    }
+
+    /**
+     * Frontend wins over backend when both REQUESTTYPE_FE and REQUESTTYPE_BE bits are set
+     * (same order as ApplicationType::fromRequest()).
+     */
+    public function testModifyRteFieldLeavesHtmlUnchangedWhenFrontendBitPrecedesBackend(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')
+            ->willReturnCallback(static function (string $name, mixed $default = null): mixed {
+                if ($name === 'applicationType') {
+                    return SystemEnvironmentBuilder::REQUESTTYPE_FE | SystemEnvironmentBuilder::REQUESTTYPE_BE;
+                }
+
+                return $default;
+            });
+
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+
+        $html = '<img src="https://example.org/a.jpg" width="1" height="1" alt="" />';
 
         $result = $this->invokeModifyRteField($html);
 

--- a/Tests/Unit/Database/RteImagesDbHookTest.php
+++ b/Tests/Unit/Database/RteImagesDbHookTest.php
@@ -13,6 +13,7 @@ namespace Netresearch\RteCKEditorImage\Tests\Unit\Database;
 
 use Netresearch\RteCKEditorImage\Database\RteImagesDbHook;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\ServerRequestInterface;
 use ReflectionClass;
 use RuntimeException;
 use stdClass;
@@ -96,6 +97,27 @@ final class RteImagesDbHookTest extends UnitTestCase
         $GLOBALS['TYPO3_REQUEST'] = new stdClass();
 
         $html = '<img src="https://example.org/image.jpg" data-htmlarea-file-uid="1" />';
+
+        $result = $this->invokeModifyRteField($html);
+
+        self::assertSame($html, $result);
+    }
+
+    public function testModifyRteFieldLeavesHtmlUnchangedWhenApplicationTypeAttributeIsMissing(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')
+            ->willReturnCallback(static function (string $name, mixed $default = null): mixed {
+                if ($name === 'applicationType') {
+                    return null;
+                }
+
+                return $default;
+            });
+
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+
+        $html = '<img src="https://example.org/image.jpg" alt="" />';
 
         $result = $this->invokeModifyRteField($html);
 


### PR DESCRIPTION
## Summary

- **Problem:** `RteImagesDbHook::modifyRteField()` threw `RuntimeException` when `$GLOBALS['TYPO3_REQUEST']` was missing or not a PSR-7 server request (scheduler, CLI imports such as `external_import`).
- **Change:** Introduce `isBackendRteImageProcessingContext()` and return RTE HTML unchanged before any FAL/magic-image work when there is no backend HTTP request. Removes the in-loop exceptions (same guard at entry).
- **Tests:** TDD — unit tests invoke `modifyRteField` via reflection with `<img>` HTML and assert passthrough when `TYPO3_REQUEST` is unset or not a `ServerRequestInterface`.

Resolves #815 for TYPO3 v12 / extension 12.x.

## Verification

```bash
.Build/bin/phpunit -c Build/phpunit/UnitTests.xml Tests/Unit/Database/RteImagesDbHookTest.php
```