### PR TITLE
docs: align release process with tag-first flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- FOR AI AGENTS - Human readability is a side effect, not a goal -->
 <!-- Managed by agent: keep sections and order; edit content, not structure -->
-<!-- Last updated: 2026-03-26 | Last verified: 2026-03-26 -->
+<!-- Last updated: 2026-05-05 | Last verified: 2026-05-05 -->
 
 # AGENTS.md — TYPO3_12 Branch
 
@@ -106,7 +106,7 @@ Build/            -> PHPStan, PHPUnit configs, CI tooling
 
 ## Release Process
 
-See [RELEASE.md](RELEASE.md): bump `ext_emconf.php` via PR → merge → `gh release create vX.Y.Z --target TYPO3_12 --title "vX.Y.Z" --notes "..."` → verify Packagist + TER.
+See [RELEASE.md](RELEASE.md): bump `ext_emconf.php` via PR → merge → **signed tag** `vX.Y.Z` + push → **GitHub Release** from that tag (web UI; do not use `gh release create` to create the tag) → optional `gh release edit --notes-file` → verify Packagist + TER.
 
 ## Index of scoped AGENTS.md
 

--- a/README.md
+++ b/README.md
@@ -148,4 +148,4 @@ editor:
 
 - developed on [GitHub](https://github.com/netresearch/t3x-rte_ckeditor_image)
 - [composer repository](https://packagist.org/packages/netresearch/rte-ckeditor-image)
-- new version will automatically be uploaded to TER via Github Action when creating a new Github release
+- new version is uploaded to TER via GitHub Action when a **GitHub Release** is **published** for an existing version tag (see [RELEASE.md](RELEASE.md))

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,15 +52,15 @@ gh pr merge <number> --merge --delete-branch
 
 ### 4. Tag, then publish the GitHub Release
 
-**Do not use `gh release create` from the CLI** to mint a new tag. GitHub immutable releases and tag handling make CLI `gh release create` error-prone; this repository uses a **tag-first** flow.
+**Do not use `gh release create` from the CLI** to mint a tag in one step with the release. That pattern is easy to get wrong (wrong target commit, duplicate tags, or conflicting release metadata). This repository uses a **tag-first** flow: tag the correct commit locally, push the tag, then attach the GitHub Release to that tag.
 
-1. **Update local `TYPO3_12` / `main`** to the merged bump commit (version in `ext_emconf.php` must match the tag).
+1. **Update local clone** to the merged bump commit on the **same branch you released from** (`TYPO3_12` or `main`; version in `ext_emconf.php` must match the tag).
 
 2. **Create a signed annotated tag** on that commit:
 
 ```bash
-git checkout TYPO3_12   # or main
-git pull origin TYPO3_12
+git checkout <branch>          # e.g. TYPO3_12 or main
+git pull origin <branch>
 git tag -s vX.Y.Z -m "vX.Y.Z"
 git push origin vX.Y.Z
 ```
@@ -72,7 +72,7 @@ git push origin vX.Y.Z
    `gh release edit vX.Y.Z --notes-file release-notes.md`  
    (Do **not** delete or recreate the tag or re-run a full `gh release create` for the same version.)
 
-5. **TER re-publish only if needed:** use **Actions** → *Publish new extension version to TER* → *workflow_dispatch* and the version string (see workflow inputs). Normal releases should not need this.
+5. **TER re-publish only if needed:** use **Actions** → *Publish new extension version to TER* → *workflow_dispatch* and the version string. The workflow accepts **`X.Y.Z`** or **`vX.Y.Z`**. Normal releases should not need this.
 
 #### Release Notes Template
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -50,13 +50,29 @@ Wait for CI to pass (build matrix: PHP 8.1/8.2/8.3/8.4 on TYPO3_12, PHP 8.2–8.
 gh pr merge <number> --merge --delete-branch
 ```
 
-### 4. Create GitHub Release
+### 4. Tag, then publish the GitHub Release
+
+**Do not use `gh release create` from the CLI** to mint a new tag. GitHub immutable releases and tag handling make CLI `gh release create` error-prone; this repository uses a **tag-first** flow.
+
+1. **Update local `TYPO3_12` / `main`** to the merged bump commit (version in `ext_emconf.php` must match the tag).
+
+2. **Create a signed annotated tag** on that commit:
 
 ```bash
-gh release create vX.Y.Z --target <branch> --title "vX.Y.Z" --notes-file release-notes.md
+git checkout TYPO3_12   # or main
+git pull origin TYPO3_12
+git tag -s vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
 ```
 
-Write release notes to a temporary file using the template below, then pass it with `--notes-file`. Alternatively, omit `--notes-file` to open an editor interactively.
+3. **Publish the GitHub Release from the existing tag** (web UI): Repository → **Releases** → **Draft a new release** → choose tag **`vX.Y.Z`** → paste release notes → **Publish release**.  
+   This triggers `.github/workflows/publish-to-ter.yml` (`release: published`).
+
+4. **Optional — polish notes after publish:** editing description only is allowed, e.g.  
+   `gh release edit vX.Y.Z --notes-file release-notes.md`  
+   (Do **not** delete or recreate the tag or re-run a full `gh release create` for the same version.)
+
+5. **TER re-publish only if needed:** use **Actions** → *Publish new extension version to TER* → *workflow_dispatch* and the version string (see workflow inputs). Normal releases should not need this.
 
 #### Release Notes Template
 
@@ -83,7 +99,7 @@ Always credit both **bug reporters** (from linked issues) and **code contributor
 
 ### 5. Verify Distribution
 
-After creating the GitHub release, verify availability:
+After the GitHub Release is **published**, verify availability:
 
 - **Packagist**: https://packagist.org/packages/netresearch/rte-ckeditor-image (auto-syncs via webhook)
 - **TER**: https://extensions.typo3.org/extension/rte_ckeditor_image/ (auto-syncs from GitHub tag)
@@ -109,10 +125,11 @@ The required status check for branch protection is **"Build ✓"** (the `build-s
 
 ## Checklist
 
-- [ ] All CI checks pass on the branch
+- [ ] All CI checks pass on the version-bump PR
 - [ ] `ext_emconf.php` version bumped via PR
 - [ ] PR merged to target branch
-- [ ] GitHub release created with tag `vX.Y.Z` targeting correct branch
+- [ ] Signed tag `vX.Y.Z` pushed; tag matches `ext_emconf.php`
+- [ ] GitHub **Release** published for **existing** tag `vX.Y.Z` (not `gh release create` for a new tag)
 - [ ] Release notes include bug reporters and contributors
 - [ ] Packagist shows new version
 - [ ] TER shows new version

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -101,10 +101,10 @@ Always credit both **bug reporters** (from linked issues) and **code contributor
 
 After the GitHub Release is **published**, verify availability:
 
-- **Packagist**: https://packagist.org/packages/netresearch/rte-ckeditor-image (auto-syncs via webhook)
-- **TER**: https://extensions.typo3.org/extension/rte_ckeditor_image/ (auto-syncs from GitHub tag)
+- **Packagist**: https://packagist.org/packages/netresearch/rte-ckeditor-image (syncs from new **tags** via webhook; allow a few minutes)
+- **TER**: https://extensions.typo3.org/extension/rte_ckeditor_image/ — the **Publish new extension version to TER** workflow uploads the version (runs on **`release: published`** for that tag, or via **`workflow_dispatch`**). It is not a separate “TER polls GitHub tags” integration.
 
-Both should pick up the new version within minutes.
+Allow a few minutes after the workflow succeeds before expecting the TER page to list the version.
 
 ## CI/CD Workflows
 
@@ -112,7 +112,7 @@ Both should pick up the new version within minutes.
 |----------|------|----------|---------|
 | **CI** | `.github/workflows/ci.yml` | Push + PR to `TYPO3_12` | Build matrix: lint, CGL, PHPStan, Rector, unit tests, functional tests, coverage |
 | **PR Quality Gates** | `.github/workflows/pr-quality.yml` | PR to `TYPO3_12` | Auto-approve for solo maintainer |
-| **Publish to TER** | `.github/workflows/publish-to-ter.yml` | GitHub release published | Uploads extension to TER via API |
+| **Publish to TER** | `.github/workflows/publish-to-ter.yml` | `release: published` (+ `workflow_dispatch`) | Uploads extension to TER via Tailor (`ter:publish`) |
 | **CodeQL** | `.github/workflows/codeql-analysis.yml` | Push + PR + weekly schedule | Security analysis |
 | **Add to Project** | `.github/workflows/add-to-project.yml` | Issue opened | Adds issues to project board |
 


### PR DESCRIPTION
## Summary

Updates release documentation to match the intended **tag-first** workflow:

- **`RELEASE.md`**: signed annotated tag + push; publish GitHub Release by selecting the **existing** tag in the web UI; explicitly **avoid `gh release create`** for minting tags; optional `gh release edit --notes-file` after publish; TER `workflow_dispatch` fallback.
- **`AGENTS.md`**: release one-liner + date header.
- **`README.md`**: TER upload trigger wording + link to `RELEASE.md`.

No code or version changes.