### PR TITLE
refactor: drop unused parameters from private link DTO builders

### DIFF
--- a/Classes/Service/ImageResolverService.php
+++ b/Classes/Service/ImageResolverService.php
@@ -197,10 +197,10 @@ class ImageResolverService
             $link = null;
 
             if ($linkAttributes !== null) {
-                $link = $this->buildLinkDto($linkAttributes, $attributes, $systemImage, $conf, $request);
+                $link = $this->buildLinkDto($linkAttributes, $attributes, $request);
             } elseif ($this->isPopupAttributeSet($attributes)) {
                 // Auto-generate popup link for standalone images with zoom attributes
-                $link = $this->buildPopupLinkDto($systemImage, $attributes, $conf, $request);
+                $link = $this->buildPopupLinkDto($systemImage, $request);
             }
 
             return new ImageRenderingDto(
@@ -692,8 +692,6 @@ class ImageResolverService
      *
      * @param array<string,string>   $linkAttributes  Link attributes
      * @param array<string,string>   $imageAttributes Image attributes
-     * @param File                   $systemImage     System image file
-     * @param array<string,mixed>    $conf            TypoScript configuration
      * @param ServerRequestInterface $request         Current request
      *
      * @return LinkDto|null Link DTO or null
@@ -701,8 +699,6 @@ class ImageResolverService
     private function buildLinkDto(
         array $linkAttributes,
         array $imageAttributes,
-        File $systemImage,
-        array $conf,
         ServerRequestInterface $request,
     ): ?LinkDto {
         // Trim once at the boundary so the validated URL and the URL emitted
@@ -746,16 +742,12 @@ class ImageResolverService
      * when zoom/clickenlarge attributes are present but no explicit link.
      *
      * @param File                   $systemImage System image file
-     * @param array<string,string>   $attributes  Image attributes
-     * @param array<string,mixed>    $conf        TypoScript configuration
      * @param ServerRequestInterface $request     Current request
      *
      * @return LinkDto|null Popup link DTO or null
      */
     private function buildPopupLinkDto(
         File $systemImage,
-        array $attributes,
-        array $conf,
         ServerRequestInterface $request,
     ): ?LinkDto {
         // Get the full-size original image URL for popup


### PR DESCRIPTION
## Summary

Drops 4 unused parameters from two private methods in `Classes/Service/ImageResolverService.php`:

- `buildLinkDto()` — removed `File $systemImage` and `array $conf` (never referenced in body)
- `buildPopupLinkDto()` — removed `array $attributes` and `array $conf` (never referenced in body)

Both call sites inside the same file were updated to drop the corresponding arguments. Behavior is unchanged.

## Why

These were the only 4 of 12 SonarCloud `php:S1172` (unused parameters) findings on this repo that were genuine cleanup. The other 8 occurrences are required by TYPO3 framework contracts (e.g. `#[AsAllowedCallable]` callbacks, DataHandler hooks) where the signature is dictated by the framework, and are already marked won't-fix in Sonar.

## Test plan

- [x] grep verified all 4 params are absent from method bodies (only present in signatures)
- [x] `composer ci:test:php:phpstan` — no errors (catches missed callers)
- [x] `composer ci:test:php:unit` — 830 tests, 1874 assertions, all green
- [x] `composer ci:test:php:cgl` — clean
- [ ] CI matrix (PHP 8.2/8.3/8.4 x TYPO3 13/14) green