### PR TITLE
fix(js): restore allowedExtensions wiring into bparams[3] (#821)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`allowedExtensions` YAML preset silently ignored** ([#821](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/821), [#822](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/822)) — the v12 / CKEditor 5 rewrite ([`1cfe7a7`](https://github.com/netresearch/t3x-rte_ckeditor_image/commit/1cfe7a7)) hardcoded the FileBrowser's `bparams[3]` slot to the empty string, so the documented `editor.externalPlugins.typo3image.allowedExtensions` option was overridden by the controller's fallback to `$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']`. JS now threads the configured value through; admin-misconfigured non-string values emit a `console.warn` instead of silently falling back. New module `select-image-bparams.js` (matches the helper-extraction pattern from #813) with Vitest unit coverage and a Playwright regression spec asserting the iframe URL.
+
 ## [13.9.0] - 2026-04-29
 
 ### Added

--- a/Resources/Public/JavaScript/Plugins/select-image-bparams.js
+++ b/Resources/Public/JavaScript/Plugins/select-image-bparams.js
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Build the 4-element `bparams` array passed to the FileBrowser via the
+ * `&bparams=<a>|<b>|<c>|<d>` query parameter. The fourth slot carries the
+ * comma-separated list of allowed file extensions; an empty value triggers
+ * the server-side fallback to
+ * `$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']` in
+ * `SelectImageController`.
+ *
+ * Wiring `allowedExtensions` (configured via the YAML key
+ * `editor.externalPlugins.typo3image.allowedExtensions`) into bparams[3]
+ * makes the documented configuration effective again — the CKEditor 5
+ * rewrite had dropped this line, silently overriding admins' choices with
+ * the global GFX default.
+ *
+ * The `|`-joined output is consumed verbatim by TYPO3's ElementBrowser
+ * (cf. `AbstractElementBrowser::getBParamDataAttributes`); the raw
+ * separator is the established backend convention, so callers should join
+ * with `bparams.join('|')` and not URL-encode (PSR-7 would decode `%7C`
+ * back to `|` before `explode('|', ...)`, defeating any encoding).
+ *
+ * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/821
+ *
+ * @param {string|undefined|null} allowedExtensions - Comma-separated list,
+ *   e.g. `"jpg,jpeg,png,webp"`. The contract is a string; `null` and
+ *   `undefined` are tolerated for callers that read the YAML preset
+ *   directly. Any other falsy value (`''`, `0`, `false`, `NaN`) is
+ *   defensively coerced to the empty string so the server-side default
+ *   always applies, never `undefined`/`'null'` substrings in the URL.
+ * @return {string[]} 4-element array suitable for `bparams.join('|')`.
+ */
+export function buildSelectImageBparams(allowedExtensions) {
+    let slot = '';
+    if (typeof allowedExtensions === 'string') {
+        slot = allowedExtensions;
+    } else if (allowedExtensions !== undefined && allowedExtensions !== null) {
+        // Surface admin misconfiguration without aborting the editor: e.g. a
+        // YAML preset that yields an array (`allowedExtensions: [jpg, png]`)
+        // would otherwise silently fall back to GFX.imagefile_ext.
+        // eslint-disable-next-line no-console
+        console.warn(
+            'rte_ckeditor_image: typo3image.allowedExtensions ignored — expected string, got '
+            + (typeof allowedExtensions)
+        );
+    }
+    return ['', '', '', slot];
+}

--- a/Resources/Public/JavaScript/Plugins/typo3image.js
+++ b/Resources/Public/JavaScript/Plugins/typo3image.js
@@ -19,6 +19,7 @@ import { DomEventObserver } from '@ckeditor/ckeditor5-engine';
 import { toWidget, toWidgetEditable, WidgetToolbarRepository } from '@ckeditor/ckeditor5-widget';
 import { default as Modal } from '@typo3/backend/modal.js';
 import { sanitizeSrc } from './sanitize-src.js';
+import { buildSelectImageBparams } from './select-image-bparams.js';
 // Internal callers reference parseTypoLink (l.1149, l.1189) and
 // encodeTypoLink (l.595); parseTypoLinkParts is only used by external
 // consumers via the re-export below (Sonar S1128 if imported here).
@@ -1016,14 +1017,10 @@ function selectImage(editor) {
     const promise = new Promise(function(resolve) {
         resolvePromise = resolve;
     });
-    const bparams = [
-        '',
-        '',
-        '',
-        '',
-    ];
+    const typo3imageConfig = editor.config.get('typo3image');
+    const bparams = buildSelectImageBparams(typo3imageConfig.allowedExtensions);
 
-    const contentUrl = `${editor.config.get('typo3image').routeUrl}&bparams=${bparams.join('|')}`;
+    const contentUrl = `${typo3imageConfig.routeUrl}&bparams=${bparams.join('|')}`;
 
     Modal.advanced({
         type: Modal.types.iframe,

--- a/Tests/E2E/tests/regression-821-allowed-extensions.spec.ts
+++ b/Tests/E2E/tests/regression-821-allowed-extensions.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect } from '@playwright/test';
+import {
+  BACKEND_PASSWORD,
+  loginToBackend,
+  navigateToContentEdit,
+  waitForCKEditor,
+  getModuleFrame,
+  requireCondition,
+} from './helpers/typo3-backend';
+
+/**
+ * Regression test for https://github.com/netresearch/t3x-rte_ckeditor_image/issues/821
+ *
+ * Bug: selectImage() in Resources/Public/JavaScript/Plugins/typo3image.js built
+ * a 4-element bparams array of empty strings. Slot [3] is the FileBrowser's
+ * allowedExtensions filter — the controller (SelectImageController::mainAction)
+ * only honours it when the JS sends a non-empty value, otherwise it overwrites
+ * with $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']. The user's
+ * documented `editor.externalPlugins.typo3image.allowedExtensions` setting was
+ * therefore silently ignored.
+ *
+ * Root cause: bparams[3] hardcoded to '' (introduced in commit 1cfe7a7).
+ * Fix: read editor.config.get('typo3image').allowedExtensions and place it in
+ * bparams[3] when set, falling back to '' so the controller's default kicks in.
+ *
+ * Strategy
+ * --------
+ * Rather than ship a new YAML preset, the spec injects the configuration into
+ * the live CKEditor instance with `editor.config.set('typo3image', ...)`
+ * before clicking the image-insert button. This keeps the regression test
+ * self-contained inside `Tests/E2E/` and avoids changing any production YAML
+ * file that real installations consume. The TYPO3 RteConfig→CKEditor bridge
+ * is unchanged: `externalPlugins.typo3image.route` already surfaces as
+ * `editor.config.get('typo3image').routeUrl` today, so the same path is what
+ * we exercise — just primed with a known value.
+ *
+ * The most surgical assertion is the iframe URL of the file-selection modal:
+ * `Modal.advanced({ type: 'iframe', content: contentUrl })` makes `contentUrl`
+ * the iframe's `src`, and `contentUrl = routeUrl + '&bparams=' + bparams.join('|')`.
+ * If bparams[3] carries our configured value, the bug is fixed.
+ */
+
+/**
+ * Read-only spec — only opens the file-browser modal, never saves. Safe to
+ * share CE 33 with image-insertion.spec.ts (also read-only on this CE).
+ */
+const CE_ID = 33;
+
+const TEST_ALLOWED_EXTENSIONS = 'jpg,jpeg,png,gif,svg,webp';
+
+/**
+ * Extract the bparams query parameter from a TYPO3 file-browser URL and
+ * return it as the 4-element `|`-separated slot array.
+ *
+ * The URL is built by typo3image.js as:
+ *   {routeUrl}&bparams={a}|{b}|{c}|{d}
+ * where {d} (slot [3]) carries the allowedExtensions filter. The TYPO3
+ * ElementBrowser convention uses a raw `|`-joined value (no URL-encoding),
+ * so `URL.searchParams.get('bparams').split('|')` recovers the slots.
+ */
+function getBparamsSlots(url: string): string[] {
+  // `URL` requires an absolute URL, so prefix relative URLs with a placeholder.
+  const absolute = /^https?:\/\//i.test(url) ? url : `https://placeholder.invalid${url}`;
+  const parsed = new URL(absolute);
+  const bparams = parsed.searchParams.get('bparams');
+  expect(bparams, `bparams query parameter missing in URL: ${url}`).not.toBeNull();
+  return (bparams as string).split('|');
+}
+
+test.describe('Regression #821: allowedExtensions reaches FileBrowser', () => {
+  test.beforeEach(() => {
+    requireCondition(!!BACKEND_PASSWORD, 'TYPO3_BACKEND_PASSWORD must be configured');
+  });
+
+  test('iframe URL carries configured allowedExtensions in bparams[3]', async ({ page }) => {
+    await loginToBackend(page);
+    await navigateToContentEdit(page, CE_ID);
+    await waitForCKEditor(page);
+
+    const frame = getModuleFrame(page);
+
+    // Inject the allowedExtensions setting into the CKEditor instance just
+    // like a real YAML preset would (`editor.externalPlugins.typo3image.allowedExtensions`
+    // is forwarded by TYPO3 RteConfig as `editor.config.typo3image.allowedExtensions`).
+    // The CKEditor `Config` class exposes `set()` / `get()` for plugin-namespaced
+    // values; setting it after editor init is supported because `typo3image` is
+    // a custom (non-builtin) namespace and is read on demand inside selectImage().
+    await frame.locator('.ck-editor__editable').first().evaluate((el, ext) => {
+      const editor = (el as any).ckeditorInstance;
+      if (!editor || typeof editor.config?.get !== 'function' || typeof editor.config?.set !== 'function') {
+        throw new Error('CKEditor instance with config.get/set not found on .ck-editor__editable');
+      }
+      const current = editor.config.get('typo3image') || {};
+      editor.config.set('typo3image', { ...current, allowedExtensions: ext });
+
+      // Sanity-check the round-trip — fail loudly here so a CKEditor API
+      // change cannot silently neuter the assertion below.
+      const verify = editor.config.get('typo3image');
+      if (!verify || verify.allowedExtensions !== ext) {
+        throw new Error(
+          `editor.config.set did not retain allowedExtensions; got: ${JSON.stringify(verify)}`
+        );
+      }
+    }, TEST_ALLOWED_EXTENSIONS);
+
+    // Click the CKEditor image insert button to open the file-selection modal.
+    // The modal is created via Modal.advanced({ type: 'iframe', content: contentUrl }),
+    // so the contentUrl becomes the iframe's src attribute.
+    const imageButton = frame.locator(
+      '.ck-toolbar button[data-cke-tooltip-text*="image" i], ' +
+      '.ck-toolbar button[data-cke-tooltip-text*="Image" i]'
+    ).first();
+
+    requireCondition(
+      await imageButton.count() > 0,
+      'Image insert button not found in CKEditor toolbar'
+    );
+
+    await imageButton.click();
+
+    // Wait for the modal and its iframe.
+    const modal = page.locator('.t3js-modal').first();
+    await expect(modal).toBeVisible({ timeout: 10000 });
+
+    const iframeLocator = page.locator('.t3js-modal iframe').first();
+    await expect(iframeLocator).toBeVisible({ timeout: 10000 });
+
+    // Read the iframe src directly. We don't need to wait for the iframe
+    // content to finish loading — the URL is set synchronously when the
+    // modal opens.
+    const iframeSrc = await iframeLocator.getAttribute('src');
+    expect(iframeSrc, 'iframe src must be set by Modal.advanced({ content: contentUrl })').toBeTruthy();
+    expect(iframeSrc, 'iframe src must point to the rteckeditorimage_wizard_select_image route')
+      .toContain('selectimage');
+
+    const slots = getBparamsSlots(iframeSrc as string);
+
+    // Sanity check: bparams should always have at least 4 segments.
+    expect(
+      slots.length,
+      `bparams should split into >=4 segments, got ${slots.length}: ${slots.join(' | ')}`
+    ).toBeGreaterThanOrEqual(4);
+
+    // *** The regression assertion for #821 ***
+    // Slot [3] must carry the configured allowedExtensions value.
+    // Before the fix, bparams[3] was hardcoded to '' so this was the empty
+    // string and the controller fell back to GFX.imagefile_ext (and the
+    // documented allowedExtensions setting was silently ignored).
+    expect(
+      slots[3],
+      `bparams[3] must carry the configured allowedExtensions value (#821). ` +
+      `Got "${slots[3]}" — expected "${TEST_ALLOWED_EXTENSIONS}". ` +
+      `Full bparams: "${slots.join('|')}". Full src: "${iframeSrc}".`
+    ).toBe(TEST_ALLOWED_EXTENSIONS);
+  });
+});

--- a/Tests/JavaScript/tests/select-image-bparams.test.js
+++ b/Tests/JavaScript/tests/select-image-bparams.test.js
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for `buildSelectImageBparams`, the helper that builds the
+ * `bparams` query value passed to the TYPO3 FileBrowser when `selectImage()`
+ * opens its iframe modal.
+ *
+ * Issue #821: The CKEditor 5 plugin was hardcoding all four `bparams` slots
+ * to empty strings, dropping the user-configured `allowedExtensions` value
+ * (YAML: `editor.externalPlugins.typo3image.allowedExtensions`). The server
+ * then fell back to `$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']`
+ * for the FileBrowser's `allowedFileExtensions`, silently ignoring the
+ * documented configuration option.
+ *
+ * Pre-CKE5 (commit 1cfe7a7), the legacy plugin set
+ * `bparams[3] = editor.config.typo3image.allowedExtensions || ''`. The CKE5
+ * rewrite dropped that line — these tests lock the contract back in.
+ *
+ * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/821
+ * @see Resources/Public/JavaScript/Plugins/select-image-bparams.js
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+    buildSelectImageBparams,
+} from '../../../Resources/Public/JavaScript/Plugins/select-image-bparams.js';
+
+describe('buildSelectImageBparams (issue #821)', () => {
+
+    describe('contract: 4-element array shape', () => {
+        it('returns exactly 4 elements', () => {
+            const result = buildSelectImageBparams('jpg,png');
+            expect(result).toHaveLength(4);
+        });
+
+        it('keeps the first three slots as empty strings', () => {
+            const result = buildSelectImageBparams('jpg,png');
+            expect(result[0]).toBe('');
+            expect(result[1]).toBe('');
+            expect(result[2]).toBe('');
+        });
+    });
+
+    describe('contract: bparams[3] carries allowedExtensions', () => {
+        it('places the allowedExtensions string into bparams[3]', () => {
+            const result = buildSelectImageBparams('jpg,jpeg,png,webp');
+            expect(result[3]).toBe('jpg,jpeg,png,webp');
+        });
+
+        it('preserves a single-extension list verbatim', () => {
+            const result = buildSelectImageBparams('svg');
+            expect(result[3]).toBe('svg');
+        });
+
+        it('preserves whitespace and casing inside the list (server validates, JS does not normalize)', () => {
+            const result = buildSelectImageBparams('JPG, PNG');
+            expect(result[3]).toBe('JPG, PNG');
+        });
+    });
+
+    describe('contract: empty bparams[3] for null/undefined/empty-string (preserves server fallback)', () => {
+        let warnSpy;
+
+        beforeEach(() => {
+            warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            warnSpy.mockRestore();
+        });
+
+        it('emits empty string for undefined input (no warning)', () => {
+            const result = buildSelectImageBparams(undefined);
+            expect(result[3]).toBe('');
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        it('emits empty string for null input (no warning)', () => {
+            const result = buildSelectImageBparams(null);
+            expect(result[3]).toBe('');
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        it('emits empty string for empty-string input (no warning)', () => {
+            const result = buildSelectImageBparams('');
+            expect(result[3]).toBe('');
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('diagnostic: warns and falls back when admin config is non-string', () => {
+        let warnSpy;
+
+        beforeEach(() => {
+            warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            warnSpy.mockRestore();
+        });
+
+        it('warns and emits empty bparams[3] for an array (typical YAML mishap)', () => {
+            const result = buildSelectImageBparams(['jpg', 'png']);
+            expect(result[3]).toBe('');
+            expect(warnSpy).toHaveBeenCalledOnce();
+            expect(warnSpy.mock.calls[0][0]).toMatch(/typo3image\.allowedExtensions ignored/);
+            expect(warnSpy.mock.calls[0][0]).toMatch(/got object/);
+        });
+
+        it('warns for boolean false (defensive against unexpected types)', () => {
+            const result = buildSelectImageBparams(false);
+            expect(result[3]).toBe('');
+            expect(warnSpy).toHaveBeenCalledOnce();
+            expect(warnSpy.mock.calls[0][0]).toMatch(/got boolean/);
+        });
+
+        it('warns for numeric 0 (defensive against unexpected types)', () => {
+            const result = buildSelectImageBparams(0);
+            expect(result[3]).toBe('');
+            expect(warnSpy).toHaveBeenCalledOnce();
+            expect(warnSpy.mock.calls[0][0]).toMatch(/got number/);
+        });
+    });
+
+    describe('regression: issue #821 — allowedExtensions reaches FileBrowser', () => {
+        /**
+         * BEFORE the fix, `selectImage()` used a hardcoded
+         *   const bparams = ['', '', '', ''];
+         * which discarded the user's `allowedExtensions` config. The server's
+         * `SelectImageController` then replaced the empty 4th slot with
+         * `$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']`, silently
+         * overriding the documented YAML option.
+         *
+         * AFTER the fix, the helper threads `allowedExtensions` through to
+         * bparams[3], so an admin who configures `allowedExtensions: "jpg,png"`
+         * actually sees only those extensions in the file browser.
+         */
+        it('forwards the configured allowedExtensions into bparams[3] (NOT empty)', () => {
+            const configured = 'jpg,jpeg,png';
+            const result = buildSelectImageBparams(configured);
+
+            // The bug: bparams[3] was always '' regardless of input.
+            expect(result[3]).not.toBe('');
+            expect(result[3]).toBe(configured);
+        });
+
+        it('does NOT mangle the list with separators or sorting', () => {
+            // Order matters: the FileBrowser receives the list verbatim and
+            // matches case-insensitively by simple substring on the comma list.
+            const configured = 'png,jpg,gif';
+            const result = buildSelectImageBparams(configured);
+            expect(result[3]).toBe('png,jpg,gif');
+        });
+    });
+});
+
+describe('round-trip with bparams.join("|") (TYPO3 ElementBrowser convention)', () => {
+    /**
+     * The ElementBrowser bparams contract uses a raw `|`-joined query
+     * value (cf. AbstractElementBrowser::getBParamDataAttributes); PSR-7
+     * decodes once before `explode('|', ...)`, so URL-encoding the slots
+     * would not survive the server-side parse anyway. Lock the join
+     * behaviour here so a future refactor cannot silently break it.
+     */
+    it('joins to "|||jpg,png" when only allowedExtensions is set', () => {
+        const result = buildSelectImageBparams('jpg,png').join('|');
+        expect(result).toBe('|||jpg,png');
+    });
+
+    it('joins to "|||" when allowedExtensions is empty', () => {
+        const result = buildSelectImageBparams('').join('|');
+        expect(result).toBe('|||');
+    });
+});


### PR DESCRIPTION
## Summary

Fixes [#821](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/821) — the documented `editor.externalPlugins.typo3image.allowedExtensions` YAML option silently has no effect since the v12 / CKEditor 5 rewrite.

**Root cause**: commit [`1cfe7a7`](https://github.com/netresearch/t3x-rte_ckeditor_image/commit/1cfe7a7) (TYPO3 v12 Support, Nov 2023) replaced `typo3image.js` end-to-end and dropped the line:

```js
bparams[3] = editor.config.typo3image.allowedExtensions || '';   // pre-CKE5
```

In current `main`, `selectImage()` hardcodes `const bparams = ['', '', '', '']`. The empty 4th slot triggers the controller's fallback in `Classes/Controller/SelectImageController.php:111-124` which overwrites it with `$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']`, so the user's preset is silently ignored.

**Fix**: surgical restore of the wiring via a small pure helper `buildSelectImageBparams(allowedExtensions)`. Falsy input still emits an empty 4th slot, so admins who don't set the option keep getting the GFX default — no behaviour change for them.

Documentation already advertises the option (`Documentation/Integration/RTE-Setup.rst:98`, `Advanced-Configuration.rst:383`, `Security.rst:242`), so no docs update is required — this just makes the docs accurate again.

## Tests (TDD)

- **Unit (Vitest)** — `Tests/JavaScript/tests/select-image-bparams.test.js`, 14 cases across 5 describe blocks: 4-element-array contract, slot-3 forwarding, falsy-input fallback, pipe-join round-trip, and an explicit `regression: issue #821 — allowedExtensions reaches FileBrowser` block. Local run: `Test Files 4 passed (4) | Tests 122 passed (122)`.
- **E2E (Playwright)** — `Tests/E2E/tests/regression-821-allowed-extensions.spec.ts`. Read-only spec (CE 33, shared with `image-insertion.spec.ts`): primes `editor.config.set('typo3image', { allowedExtensions: 'jpg,jpeg,png,gif,svg,webp' })` on the live CKEditor instance, opens the file-browser modal, and asserts `iframe.src`'s `bparams.split('|')[3]` equals the configured value. Pre-fix this would be `''`.

No production YAML/PHP/PHP-config touched. Server-side fallback for empty `bparams[3]` is left intact.

## Test plan

- [x] Pre-commit hooks pass (PHP lint / CGL / PHPStan — JS-only diff)
- [x] Vitest green locally (14 new + 108 existing)
- [ ] CI — Vitest + functional + E2E across the matrix
- [ ] Manual verification on a TYPO3 12/13 instance with `allowedExtensions: "jpg,png"`

## Related issues

Fixes #821