### PR TITLE
docs(release): require --latest=false for non-default-branch releases

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,7 +52,7 @@ gh pr merge <number> --merge --delete-branch
 
 ### 4. Tag, then publish the GitHub Release
 
-**Do not use `gh release create` from the CLI** to mint a tag in one step with the release. That pattern is easy to get wrong (wrong target commit, duplicate tags, or conflicting release metadata). This repository uses a **tag-first** flow: tag the correct commit locally, push the tag, then attach the GitHub Release to that tag.
+**Never let `gh release create` mint the tag for you** (i.e. running it before the tag exists). That pattern is easy to get wrong (wrong target commit, duplicate tags, or conflicting release metadata). This repository uses a **tag-first** flow: tag the correct commit locally, push the tag, *then* attach the GitHub Release to that existing tag — either via CLI (`gh release create vX.Y.Z` reuses the existing tag) or via the web UI.
 
 1. **Update local clone** to the merged bump commit on the **same branch you released from** (`TYPO3_12` or `main`; version in `ext_emconf.php` must match the tag).
 
@@ -65,12 +65,27 @@ git tag -s vX.Y.Z -m "vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-3. **Publish the GitHub Release from the existing tag** (web UI): Repository → **Releases** → **Draft a new release** → choose tag **`vX.Y.Z`** → paste release notes → **Publish release**.  
-   This triggers `.github/workflows/publish-to-ter.yml` (`release: published`).
+3. **Publish the GitHub Release from the existing tag.** Two options — **CLI is the default for `TYPO3_12` (and any non-default branch)** because it forces the correct "Latest" flag.
+
+   **a) CLI (recommended for `TYPO3_12`):** the existing tag is reused; no new tag is created.
+
+   ```bash
+   gh release create vX.Y.Z --latest=false --title "vX.Y.Z" --notes-file release-notes.md
+   ```
+
+   > ⚠️ **`--latest=false` is mandatory for `TYPO3_12` (and any non-default branch).** GitHub assigns the "Latest" badge by **release creation timestamp**, not semver. A v12.0.X release published *after* a newer `main` release (e.g. v13.Y.Z) will steal the "Latest" badge unless `--latest=false` is passed. See [v12.0.13](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v12.0.13) for the canonical example.
+
+   For `main` releases the latest tag is also the latest by semver, so omit the flag (default `--latest=true` is correct).
+
+   **b) Web UI (alternative):** Repository → **Releases** → **Draft a new release** → choose tag **`vX.Y.Z`** → paste release notes → **Publish release**.
+
+   > ⚠️ When publishing via Web UI on `TYPO3_12` (or any non-default branch), **uncheck "Set as the latest release"**. The default is checked, which on a maintenance-branch release would steal the "Latest" badge from a newer `main` release.
+
+   Either path triggers `.github/workflows/publish-to-ter.yml` (`release: published`).
 
 4. **Optional — polish notes after publish:** editing description only is allowed, e.g.  
    `gh release edit vX.Y.Z --notes-file release-notes.md`  
-   (Do **not** delete or recreate the tag or re-run a full `gh release create` for the same version.)
+   (Do **not** delete or recreate the tag. If the "Latest" badge was incorrectly assigned, correct it via the Web UI on the appropriate release, or `gh release edit vX.Y.Z --latest=<true|false>` — this only changes release metadata, not the tag or assets.)
 
 5. **TER re-publish only if needed:** use **Actions** → *Publish new extension version to TER* → *workflow_dispatch* and the version string. The workflow accepts **`X.Y.Z`** or **`vX.Y.Z`**. Normal releases should not need this.
 
@@ -129,7 +144,7 @@ The required status check for branch protection is **"Build ✓"** (the `build-s
 - [ ] `ext_emconf.php` version bumped via PR
 - [ ] PR merged to target branch
 - [ ] Signed tag `vX.Y.Z` pushed; tag matches `ext_emconf.php`
-- [ ] GitHub **Release** published for **existing** tag `vX.Y.Z` (not `gh release create` for a new tag)
+- [ ] GitHub **Release** published for **existing** tag `vX.Y.Z` with the "Latest" badge correctly set (use `--latest=false` / uncheck "Set as the latest release" on maintenance branches like `TYPO3_12` to preserve `main`'s "Latest" badge)
 - [ ] Release notes include bug reporters and contributors
 - [ ] Packagist shows new version
 - [ ] TER shows new version


### PR DESCRIPTION
## Summary

Closes a documented landmine in `RELEASE.md` (TYPO3_12 branch): backport releases on `TYPO3_12` (or any non-default branch) MUST be marked `--latest=false`, otherwise they steal the "Latest" release badge from `main`.

## Why this matters

GitHub assigns the "Latest" release badge by **release creation timestamp**, not semver. Cutting [v12.0.13](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v12.0.13) (2026-05-07) AFTER v13.9.0 (2026-04-29) would have made v12.0.13 "Latest" — and silently demoted the supported v13 line — if the publish step hadn't been done correctly.

The current `RELEASE.md` step 3 prescribes the Web UI without warning that the "Set as the latest release" checkbox defaults to **on**. Past v12 releases (v12.0.10–v12.0.12) clearly got this right (v13.9.0 retains the "Latest" badge), so the institutional knowledge exists — but the doc lies. The just-published v12.0.13 used `gh release create --latest=false` instead. This PR aligns the doc with the actual practice.

## What changed

Single file: `RELEASE.md` (+20 / -5).

- **Step 4 ➝ sub-step 3**: Now offers two paths.
  - **a) CLI (default for `TYPO3_12`)**: `gh release create vX.Y.Z --latest=false --title "vX.Y.Z" --notes-file release-notes.md`, with a callout explaining the timestamp-vs-semver behavior and linking v12.0.13 as the canonical example.
  - **b) Web UI (alternative)**: with an explicit warning to uncheck "Set as the latest release".
- `main` releases are unaffected — the latest tag IS latest by semver, so the default `--latest=true` is correct (made explicit).
- The pre-existing "do not let `gh release create` mint the tag" rule is preserved; the CLI step here reuses the already-pushed tag from the previous sub-step.
- Checklist item updated to require `--latest=false` (CLI) or unchecked checkbox (Web UI) on `TYPO3_12`.

## Scope

- TYPO3_12 only — `main` uses the automated release workflow and is a separate concern.
- Doc-only — no code change.

## Test plan

- [x] `RELEASE.md` renders correctly (markdown lint not enforced; visually verified).
- [x] CLI command shown is exactly what was used for v12.0.13.
- [x] Cross-reference: [v12.0.13 release](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v12.0.13) is marked correctly (not "Latest"), [v13.9.0](https://github.com/netresearch/t3x-rte_ckeditor_image/releases/tag/v13.9.0) retains "Latest" badge.