### PR TITLE
chore: release v13.9.1 (+ SonarCloud lcov fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,12 +172,20 @@ jobs:
         # picked up via `sonar.javascript.lcov.reportPaths` in
         # sonar-project.properties. Coverage is bounded — only files
         # importable without the CKEditor module graph (typolink-parser,
-        # sanitize-src) get instrumented; typo3image.js itself can't be
-        # loaded by vitest.
+        # sanitize-src, select-image-bparams) get instrumented;
+        # typo3image.js itself can't be loaded by vitest.
+        #
+        # Vitest's v8 provider emits SF paths relative to the cwd
+        # (Tests/JavaScript), so they read as "../../Resources/...".
+        # SonarCloud's scanner anchors SF lines to the project root and
+        # otherwise warns "Could not resolve N file paths" → 0% coverage.
+        # Strip the "../../" prefix so SF reads "Resources/..." (project
+        # root-relative) and the scanner can match it to sonar.sources.
         run: |
           cd Tests/JavaScript
           npm ci --silent
           npm test -- --coverage
+          sed -i 's|^SF:\.\./\.\./|SF:|g' coverage/lcov.info
 
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [13.9.1] - 2026-05-07
+
 ### Fixed
 
 - **`allowedExtensions` YAML preset silently ignored** ([#821](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/821), [#822](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/822)) — the documented `editor.externalPlugins.typo3image.allowedExtensions` YAML option was overridden by the controller's fallback to `$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']`, a regression introduced by the CKEditor 5 rewrite ([`1cfe7a7`](https://github.com/netresearch/t3x-rte_ckeditor_image/commit/1cfe7a7)). The configured value is now threaded through; admin-misconfigured non-string values emit a `console.warn` instead of silently falling back. Thanks [@mmunz](https://github.com/mmunz) for the report and the precise root-cause analysis pointing at the regression.
@@ -1009,7 +1011,8 @@ _See [GitHub release](https://github.com/netresearch/t3x-rte_ckeditor_image/rele
 - Update image reference index ([#45](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/45), [#62](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/62))
 - Compatibility with TYPO3 CMS 9.x
 
-[Unreleased]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.9.0...HEAD
+[Unreleased]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.9.1...HEAD
+[13.9.1]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.9.0...v13.9.1
 [13.9.0]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.8.3...v13.9.0
 [13.8.3]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.8.2...v13.8.3
 [13.8.2]: https://github.com/netresearch/t3x-rte_ckeditor_image/compare/v13.8.1...v13.8.2

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,7 +20,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email'   => 'sebastian.koschel@netresearch.de, sebastian.mendel@netresearch.de, rico.sonntag@netresearch.de',
     'author_company' => 'Netresearch DTT GmbH',
     'state'          => 'stable',
-    'version'        => '13.9.0',
+    'version'        => '13.9.1',
     'constraints'    => [
         'depends' => [
             // ext_emconf does not support disjoint ranges. The supported


### PR DESCRIPTION
## Summary

Patch release v13.9.1 plus a CI plumbing fix.

### Commit 1 — `ci(sonarqube): rewrite vitest lcov SF paths to project-root`

Vitest's v8 coverage provider emits `SF:../../Resources/...` paths relative to `Tests/JavaScript/`. SonarCloud's scanner anchors `SF` lines to the project root and warns *"Could not resolve N file paths in lcov.info"* → reports 0% coverage on new code, breaking the SonarCloud Quality Gate (currently failing on `main` HEAD; surfaced first on [#822](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/822) which added `select-image-bparams.js`). One-line `sed` strips the `../../` prefix in CI before the SonarQube scan step. Local `npm test -- --coverage` is unaffected.

### Commit 2 — `chore: bump version to 13.9.1`

Patch bump. Sole user-visible change since v13.9.0 is the fix from [#822](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/822) (`allowedExtensions` wiring, fixes [#821](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/821)). Audit of the 11 PRs merged since v13.9.0 (2026-04-29):

| PR | Type | User-visible? |
|---|---|---|
| #822 / #824 | fix + docs follow-up | ✅ — the only entry in `[Unreleased]` |
| #813 / #819 | refactor — code quality, no behavior change | ❌ |
| #820 / #814 / #812 / #811 / #810 / #809 / #808 | deps + CI plumbing | ❌ |

Patch is the correct semver bump — no features, no API changes, no behavior shifts.

`CHANGELOG.md`'s `[Unreleased]` entry moves under a new `## [13.9.1] - 2026-05-07` heading.

## Release flow after merge

Per project memory + `RELEASE.md`:
1. Merge this PR via merge queue
2. `git tag -s v13.9.1 -m "v13.9.1" && git push origin v13.9.1`
3. `release.yml` workflow handles archive, SBOM, cosign, attestations, TER publish, announcement discussion automatically

## Test plan

- [x] Both commits signed (Ed25519, info@sebastianmendel.de) + DCO Signed-off-by
- [x] CI green expected (no production code changes)
- [ ] After merge: SonarCloud Quality Gate green on next PR with new JS files (validation that the lcov fix works)

## Related

- Closes [#821](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/821) (transitive via [#822](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/822) merge — re-stating here for release-notes generation)