### PR TITLE
docs: place template-override settings inside preUserFunc.

### DIFF
--- a/Configuration/TypoScript/ImageRendering/setup.typoscript
+++ b/Configuration/TypoScript/ImageRendering/setup.typoscript
@@ -25,17 +25,24 @@ lib.parseFunc_RTE {
         # IMPORTANT: Use the extension key "rte_ckeditor_image" (underscores) in
         # EXT: paths, NOT the Composer package name "rte-ckeditor-image" (hyphens).
         #
-        # To override, add your paths with priority > 0:
+        # To override, add your paths with priority > 0 INSIDE preUserFunc.* —
+        # TYPO3's stdWrap_preUserFunc only forwards $conf['preUserFunc.'] to the
+        # callable, so a settings.* block placed as a sibling of preUserFunc
+        # never reaches ImageRenderingService::buildTemplatePaths().
         #
-        # settings.templateRootPaths {
+        # preUserFunc.settings.templateRootPaths {
         #     10 = EXT:my_sitepackage/Resources/Private/Templates/
         # }
-        # settings.partialRootPaths {
+        # preUserFunc.settings.partialRootPaths {
         #     10 = EXT:my_sitepackage/Resources/Private/Partials/
         # }
-        # settings.layoutRootPaths {
+        # preUserFunc.settings.layoutRootPaths {
         #     10 = EXT:my_sitepackage/Resources/Private/Layouts/
         # }
+        #
+        # The same settings.* block must also be added under
+        # lib.parseFunc_RTE.externalBlocks.figure.stdWrap.preUserFunc for
+        # captioned (figure-wrapped) images.
         #
         # See Documentation/Examples/Template-Overrides.rst for details.
         #******************************************************

--- a/Configuration/TypoScript/ImageRendering/setup.typoscript
+++ b/Configuration/TypoScript/ImageRendering/setup.typoscript
@@ -25,22 +25,26 @@ lib.parseFunc_RTE {
         # IMPORTANT: Use the extension key "rte_ckeditor_image" (underscores) in
         # EXT: paths, NOT the Composer package name "rte-ckeditor-image" (hyphens).
         #
-        # To override, add your paths with priority > 0 INSIDE preUserFunc.* —
+        # To override, add your paths with priority > 0 INSIDE preUserFunc. —
         # TYPO3's stdWrap_preUserFunc only forwards $conf['preUserFunc.'] to the
-        # callable, so a settings.* block placed as a sibling of preUserFunc
+        # callable, so a settings. block placed as a sibling of preUserFunc
         # never reaches ImageRenderingService::buildTemplatePaths().
         #
-        # preUserFunc.settings.templateRootPaths {
-        #     10 = EXT:my_sitepackage/Resources/Private/Templates/
-        # }
-        # preUserFunc.settings.partialRootPaths {
-        #     10 = EXT:my_sitepackage/Resources/Private/Partials/
-        # }
-        # preUserFunc.settings.layoutRootPaths {
-        #     10 = EXT:my_sitepackage/Resources/Private/Layouts/
+        # preUserFunc {
+        #     settings {
+        #         templateRootPaths {
+        #             10 = EXT:my_sitepackage/Resources/Private/Templates/
+        #         }
+        #         partialRootPaths {
+        #             10 = EXT:my_sitepackage/Resources/Private/Partials/
+        #         }
+        #         layoutRootPaths {
+        #             10 = EXT:my_sitepackage/Resources/Private/Layouts/
+        #         }
+        #     }
         # }
         #
-        # The same settings.* block must also be added under
+        # The same settings. block must also be added under
         # lib.parseFunc_RTE.externalBlocks.figure.stdWrap.preUserFunc for
         # captioned (figure-wrapped) images.
         #

--- a/Documentation/Examples/Template-Overrides.rst
+++ b/Documentation/Examples/Template-Overrides.rst
@@ -190,7 +190,7 @@ In your site package, create the override directory:
 Step 2: Configure TypoScript
 ----------------------------
 
-Add the template path to your TypoScript setup. The ``settings.*`` block
+Add the template path to your TypoScript setup. The ``settings.`` block
 must live **inside** ``preUserFunc.`` — that is the only sub-array TYPO3
 forwards to the rendering callable (see
 :php:`ContentObjectRenderer::stdWrap_preUserFunc()`, which passes only
@@ -204,29 +204,33 @@ effect — the configuration never reaches
 
     lib.parseFunc_RTE.tags.img.preUserFunc {
         # Add your templates with higher priority (higher number = higher priority)
-        settings.templateRootPaths {
-            10 = EXT:my_sitepackage/Resources/Private/Templates/
-        }
-        settings.partialRootPaths {
-            10 = EXT:my_sitepackage/Resources/Private/Partials/
-        }
-        settings.layoutRootPaths {
-            10 = EXT:my_sitepackage/Resources/Private/Layouts/
+        settings {
+            templateRootPaths {
+                10 = EXT:my_sitepackage/Resources/Private/Templates/
+            }
+            partialRootPaths {
+                10 = EXT:my_sitepackage/Resources/Private/Partials/
+            }
+            layoutRootPaths {
+                10 = EXT:my_sitepackage/Resources/Private/Layouts/
+            }
         }
     }
 
     # Captioned images render as <figure> blocks and are processed via
     # externalBlocks.figure.stdWrap.preUserFunc (renderFigure). The same
-    # settings.* block has to be duplicated here for figure rendering.
+    # settings. block has to be duplicated here for figure rendering.
     lib.parseFunc_RTE.externalBlocks.figure.stdWrap.preUserFunc {
-        settings.templateRootPaths {
-            10 = EXT:my_sitepackage/Resources/Private/Templates/
-        }
-        settings.partialRootPaths {
-            10 = EXT:my_sitepackage/Resources/Private/Partials/
-        }
-        settings.layoutRootPaths {
-            10 = EXT:my_sitepackage/Resources/Private/Layouts/
+        settings {
+            templateRootPaths {
+                10 = EXT:my_sitepackage/Resources/Private/Templates/
+            }
+            partialRootPaths {
+                10 = EXT:my_sitepackage/Resources/Private/Partials/
+            }
+            layoutRootPaths {
+                10 = EXT:my_sitepackage/Resources/Private/Layouts/
+            }
         }
     }
 

--- a/Documentation/Examples/Template-Overrides.rst
+++ b/Documentation/Examples/Template-Overrides.rst
@@ -190,13 +190,35 @@ In your site package, create the override directory:
 Step 2: Configure TypoScript
 ----------------------------
 
-Add the template path to your TypoScript setup:
+Add the template path to your TypoScript setup. The ``settings.*`` block
+must live **inside** ``preUserFunc.`` — that is the only sub-array TYPO3
+forwards to the rendering callable (see
+:php:`ContentObjectRenderer::stdWrap_preUserFunc()`, which passes only
+``$conf['preUserFunc.']`` to the user function). Placing
+``settings.templateRootPaths`` as a sibling of ``preUserFunc`` has no
+effect — the configuration never reaches
+:php:`ImageRenderingService::buildTemplatePaths()`.
 
 ..  code-block:: typoscript
     :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
 
-    lib.parseFunc_RTE.tags.img {
+    lib.parseFunc_RTE.tags.img.preUserFunc {
         # Add your templates with higher priority (higher number = higher priority)
+        settings.templateRootPaths {
+            10 = EXT:my_sitepackage/Resources/Private/Templates/
+        }
+        settings.partialRootPaths {
+            10 = EXT:my_sitepackage/Resources/Private/Partials/
+        }
+        settings.layoutRootPaths {
+            10 = EXT:my_sitepackage/Resources/Private/Layouts/
+        }
+    }
+
+    # Captioned images render as <figure> blocks and are processed via
+    # externalBlocks.figure.stdWrap.preUserFunc (renderFigure). The same
+    # settings.* block has to be duplicated here for figure rendering.
+    lib.parseFunc_RTE.externalBlocks.figure.stdWrap.preUserFunc {
         settings.templateRootPaths {
             10 = EXT:my_sitepackage/Resources/Private/Templates/
         }
@@ -210,14 +232,11 @@ Add the template path to your TypoScript setup:
 
 ..  note::
 
-    The configuration must be placed within ``lib.parseFunc_RTE.tags.img``
-    (not directly in ``lib.parseFunc_RTE``). The same configuration can be
-    added to ``externalBlocks.figure.stdWrap`` for images wrapped in
-    ``<figure>`` blocks (captioned images). Figures are processed via
-    ``externalBlocks``, not ``tags.figure`` — placing the configuration
-    under ``tags.figure`` has no effect. Inline images wrapped in ``<a>``
-    are rendered by ``tags.img`` (recursively, inside the link wrapper), so
-    they already pick up the configuration defined under ``tags.img``.
+    Figures are processed via ``externalBlocks``, not ``tags.figure`` —
+    placing the configuration under ``tags.figure`` has no effect. Inline
+    images wrapped in ``<a>`` are rendered by ``tags.img`` (recursively,
+    inside the link wrapper), so they already pick up the configuration
+    defined under ``tags.img.preUserFunc``.
 
 Step 3: Create override templates
 ---------------------------------

--- a/Resources/AGENTS.md
+++ b/Resources/AGENTS.md
@@ -66,29 +66,33 @@ Figure wrappers are only created when there is a caption. Alignment classes with
 
 ## Template Override Mechanism
 
-Integrators can override templates via TypoScript. The `settings.*` block
+Integrators can override templates via TypoScript. The `settings.` block
 must live inside `preUserFunc.` because TYPO3 only passes
 `$conf['preUserFunc.']` to the rendering callable (see
 `ContentObjectRenderer::stdWrap_preUserFunc()`):
 
 ```typoscript
 lib.parseFunc_RTE.tags.img.preUserFunc {
-    settings.templateRootPaths {
-        10 = EXT:my_sitepackage/Resources/Private/Templates/
-    }
-    settings.partialRootPaths {
-        10 = EXT:my_sitepackage/Resources/Private/Partials/
+    settings {
+        templateRootPaths {
+            10 = EXT:my_sitepackage/Resources/Private/Templates/
+        }
+        partialRootPaths {
+            10 = EXT:my_sitepackage/Resources/Private/Partials/
+        }
     }
 }
 
 # Figures (captioned images) need the same block under the
 # externalBlocks.figure.stdWrap.preUserFunc that runs renderFigure().
 lib.parseFunc_RTE.externalBlocks.figure.stdWrap.preUserFunc {
-    settings.templateRootPaths {
-        10 = EXT:my_sitepackage/Resources/Private/Templates/
-    }
-    settings.partialRootPaths {
-        10 = EXT:my_sitepackage/Resources/Private/Partials/
+    settings {
+        templateRootPaths {
+            10 = EXT:my_sitepackage/Resources/Private/Templates/
+        }
+        partialRootPaths {
+            10 = EXT:my_sitepackage/Resources/Private/Partials/
+        }
     }
 }
 ```

--- a/Resources/AGENTS.md
+++ b/Resources/AGENTS.md
@@ -66,10 +66,24 @@ Figure wrappers are only created when there is a caption. Alignment classes with
 
 ## Template Override Mechanism
 
-Integrators can override templates via TypoScript:
+Integrators can override templates via TypoScript. The `settings.*` block
+must live inside `preUserFunc.` because TYPO3 only passes
+`$conf['preUserFunc.']` to the rendering callable (see
+`ContentObjectRenderer::stdWrap_preUserFunc()`):
 
 ```typoscript
-lib.parseFunc_RTE.tags.img {
+lib.parseFunc_RTE.tags.img.preUserFunc {
+    settings.templateRootPaths {
+        10 = EXT:my_sitepackage/Resources/Private/Templates/
+    }
+    settings.partialRootPaths {
+        10 = EXT:my_sitepackage/Resources/Private/Partials/
+    }
+}
+
+# Figures (captioned images) need the same block under the
+# externalBlocks.figure.stdWrap.preUserFunc that runs renderFigure().
+lib.parseFunc_RTE.externalBlocks.figure.stdWrap.preUserFunc {
     settings.templateRootPaths {
         10 = EXT:my_sitepackage/Resources/Private/Templates/
     }


### PR DESCRIPTION
## Summary

The current template-override documentation places `settings.templateRootPaths` as a **sibling** of `preUserFunc` under `lib.parseFunc_RTE.tags.img`, e.g. (from `Documentation/Examples/Template-Overrides.rst`):

```typoscript
lib.parseFunc_RTE.tags.img {
    settings.templateRootPaths {
        10 = EXT:my_sitepackage/Resources/Private/Templates/
    }
}
```

That placement has no effect. TYPO3's `ContentObjectRenderer::stdWrap_preUserFunc()` only forwards `$conf['preUserFunc.']` to the callable:

```php
// typo3/cms-frontend Classes/ContentObject/ContentObjectRenderer.php
public function stdWrap_preUserFunc($content = '', $conf = [])
{
    return $this->callUserFunction($conf['preUserFunc'], $conf['preUserFunc.'] ?? [], $content);
}
```

So anything under `tags.img.settings.*` is never seen by `ImageRenderingAdapter::renderImageAttributes()`, and therefore never reaches `ImageRenderingService::buildTemplatePaths()`. As written today, the documented override silently does nothing — integrators end up with the default extension templates regardless of what `templateRootPaths` they set.

The correct placement is **inside** `preUserFunc.`:

```typoscript
lib.parseFunc_RTE.tags.img.preUserFunc {
    settings.templateRootPaths {
        10 = EXT:my_sitepackage/Resources/Private/Templates/
    }
}
```

The same applies to `externalBlocks.figure.stdWrap.preUserFunc` for figure-wrapped (captioned) images, which is rendered via `renderFigure()`.

## Empirical confirmation

I hit this while overriding templates in my own site package: with `settings.*` at the documented `tags.img` level my custom templates were ignored. After moving the block into `preUserFunc.settings.*`, the custom templates loaded immediately. ImageRenderingService's `buildTemplatePaths()` already handles either `$config['settings.']['templateRootPaths.']` or `$config['templateRootPaths.']` directly, so the only change needed is in the docs.

## Changes

Three places carried the same incorrect example; this PR fixes all three:

- `Documentation/Examples/Template-Overrides.rst` — the canonical override example, plus the accompanying note about `externalBlocks.figure.stdWrap`. The figure-side example is now spelled out explicitly so users don't have to guess where to put it.
- `Resources/AGENTS.md` — short architectural note that mirrored the bad example.
- `Configuration/TypoScript/ImageRendering/setup.typoscript` — inline comment block that shipped with the extension.

Each fix moves `settings.*` under `preUserFunc.` and adds a one-line explanation of *why* (`stdWrap_preUserFunc` only forwards its own sub-array), so future readers don't have to re-trace the call.

## Test plan

- [x] Pre-commit hooks pass (`make lint`) — docs-only change, no PHP/JS edits.
- [x] Unit tests pass (`composer ci:test:php:unit`) — docs-only change.
- [x] Manual testing performed — verified that moving `settings.templateRootPaths` under `preUserFunc.` is the placement that actually loads custom templates on a real TYPO3 v13.10 install.

## Related issues

<!-- No matching open issue found; happy to file one if the maintainers prefer that flow. -->