### PR TITLE
fix: preserve aspect ratio when scaling images to max dimensions (#846)

### DIFF
--- a/Classes/Controller/SelectImageController.php
+++ b/Classes/Controller/SelectImageController.php
@@ -132,12 +132,21 @@ class SelectImageController extends ElementBrowserController
         $maxDimensions = $this->getMaxDimensions($params);
         $processedFile = $this->processImage($file, $params, $maxDimensions);
 
+        $rawWidth          = $file->getProperty('width');
+        $rawHeight         = $file->getProperty('height');
+        $displayDimensions = $this->calculateDisplayDimensions(
+            is_numeric($rawWidth) ? (int) $rawWidth : 0,
+            is_numeric($rawHeight) ? (int) $rawHeight : 0,
+            $maxDimensions['width'],
+            $maxDimensions['height'],
+        );
+
         return new JsonResponse([
             'uid'       => $file->getUid(),
             'alt'       => $file->getProperty('alternative') ?? '',
             'title'     => $file->getProperty('title') ?? '',
-            'width'     => min($file->getProperty('width'), $maxDimensions['width']),
-            'height'    => min($file->getProperty('height'), $maxDimensions['height']),
+            'width'     => $displayDimensions['width'],
+            'height'    => $displayDimensions['height'],
             'url'       => $file->getPublicUrl(),
             'processed' => [
                 'width'  => $processedFile->getProperty('width'),
@@ -231,16 +240,76 @@ class SelectImageController extends ElementBrowserController
     {
         $rawWidth  = $params['width'] ?? $file->getProperty('width');
         $rawHeight = $params['height'] ?? $file->getProperty('height');
-        $width     = min($maxDimensions['width'], is_numeric($rawWidth) ? (int) $rawWidth : 0);
-        $height    = min($maxDimensions['height'], is_numeric($rawHeight) ? (int) $rawHeight : 0);
+
+        // Scale the requested dimensions into the configured limits while
+        // preserving the aspect ratio (see calculateDisplayDimensions), so the
+        // processed file matches the suggested display size (issue #846).
+        $dimensions = $this->calculateDisplayDimensions(
+            is_numeric($rawWidth) ? (int) $rawWidth : 0,
+            is_numeric($rawHeight) ? (int) $rawHeight : 0,
+            $maxDimensions['width'],
+            $maxDimensions['height'],
+        );
 
         return $file->process(
             ProcessedFile::CONTEXT_IMAGECROPSCALEMASK,
             [
-                'width'  => $width,
-                'height' => $height,
+                'width'  => $dimensions['width'],
+                'height' => $dimensions['height'],
             ],
         );
+    }
+
+    /**
+     * Calculate display dimensions that fit within the configured max limits
+     * while preserving the image's aspect ratio.
+     *
+     * When either dimension exceeds its limit, both dimensions are scaled by the
+     * same (smaller) factor. This prevents the distortion reported in issue #846,
+     * where width and height were clamped independently and a portrait image
+     * larger than both limits was squashed into a square.
+     *
+     * @param int $originalWidth  Original image width in pixels
+     * @param int $originalHeight Original image height in pixels
+     * @param int $maxWidth       Maximum allowed width
+     * @param int $maxHeight      Maximum allowed height
+     *
+     * @return array<string, int> Array with 'width' and 'height' keys
+     */
+    protected function calculateDisplayDimensions(
+        int $originalWidth,
+        int $originalHeight,
+        int $maxWidth,
+        int $maxHeight,
+    ): array {
+        // Without both positive dimensions an aspect ratio cannot be computed;
+        // fall back to independent clamping and avoid a division by zero.
+        if ($originalWidth <= 0 || $originalHeight <= 0) {
+            return [
+                'width'  => min(max(0, $originalWidth), $maxWidth),
+                'height' => min(max(0, $originalHeight), $maxHeight),
+            ];
+        }
+
+        // Image already fits: keep its original dimensions (never upscale).
+        if ($originalWidth <= $maxWidth && $originalHeight <= $maxHeight) {
+            return [
+                'width'  => $originalWidth,
+                'height' => $originalHeight,
+            ];
+        }
+
+        // Use the smaller scale so both dimensions end up within the limits.
+        $scale = min($maxWidth / $originalWidth, $maxHeight / $originalHeight);
+
+        // round() keeps the aspect ratio as close as possible and lands the
+        // limiting axis exactly on its max (avoiding float-floor off-by-one);
+        // max(1, ...) guarantees at least 1px for extreme aspect ratios so the
+        // processed dimensions never become 0.
+        return [
+            'width'  => max(1, (int) round($originalWidth * $scale)),
+            'height' => max(1, (int) round($originalHeight * $scale)),
+        ];
     }
 
     /**

--- a/Tests/Unit/Controller/SelectImageControllerTest.php
+++ b/Tests/Unit/Controller/SelectImageControllerTest.php
@@ -160,4 +160,106 @@ class SelectImageControllerTest extends UnitTestCase
 
         self::assertTrue($result, 'Admin user should always have access');
     }
+
+    /**
+     * Helper to invoke calculateDisplayDimensions and return a typed result.
+     *
+     * @return array<string, int>
+     */
+    private function invokeCalculateDisplayDimensions(
+        int $originalWidth,
+        int $originalHeight,
+        int $maxWidth,
+        int $maxHeight,
+    ): array {
+        $result = $this->invokeMethod(
+            $this->getSubject(),
+            'calculateDisplayDimensions',
+            [$originalWidth, $originalHeight, $maxWidth, $maxHeight],
+        );
+        self::assertIsArray($result);
+
+        /** @var array<string, int> $result */
+        return $result;
+    }
+
+    /**
+     * Regression test for issue #846: a portrait image larger than both
+     * maxWidth and maxHeight must keep its aspect ratio instead of being
+     * clamped to maxWidth x maxHeight (which squashed it into a square).
+     *
+     * @test
+     */
+    public function calculateDisplayDimensionsPreservesAspectRatioWhenBothLimitsExceeded(): void
+    {
+        $result = $this->invokeCalculateDisplayDimensions(2000, 3000, 1000, 1000);
+
+        // Shared scale factor 1000/3000 -> 667 x 1000, NOT 1000 x 1000.
+        self::assertSame(667, $result['width']);
+        self::assertSame(1000, $result['height']);
+        self::assertLessThanOrEqual(1000, $result['width']);
+        self::assertLessThanOrEqual(1000, $result['height']);
+    }
+
+    /**
+     * @test
+     */
+    public function calculateDisplayDimensionsKeepsOriginalWhenWithinLimits(): void
+    {
+        $result = $this->invokeCalculateDisplayDimensions(800, 600, 1000, 1000);
+
+        self::assertSame(800, $result['width']);
+        self::assertSame(600, $result['height']);
+    }
+
+    /**
+     * @test
+     */
+    public function calculateDisplayDimensionsScalesLandscapeByWidth(): void
+    {
+        $result = $this->invokeCalculateDisplayDimensions(4000, 1000, 1000, 1000);
+
+        // Scale factor 1000/4000 = 0.25 -> 1000 x 250.
+        self::assertSame(1000, $result['width']);
+        self::assertSame(250, $result['height']);
+    }
+
+    /**
+     * @test
+     */
+    public function calculateDisplayDimensionsScalesPortraitWithDefaultHeightLimit(): void
+    {
+        // Default config (maxWidth 1920, maxHeight 9999): only the width is
+        // exceeded, so the height must scale down proportionally too.
+        $result = $this->invokeCalculateDisplayDimensions(2000, 3000, 1920, 9999);
+
+        self::assertSame(1920, $result['width']);
+        self::assertSame(2880, $result['height']);
+    }
+
+    /**
+     * @test
+     */
+    public function calculateDisplayDimensionsNeverReturnsZeroForExtremeAspectRatio(): void
+    {
+        // 10000 x 1 scaled to fit 1000 x 1000: the height would round to 0,
+        // which is invalid for image processing. It must be clamped to 1px.
+        $result = $this->invokeCalculateDisplayDimensions(10000, 1, 1000, 1000);
+
+        self::assertSame(1000, $result['width']);
+        self::assertSame(1, $result['height']);
+    }
+
+    /**
+     * @test
+     */
+    public function calculateDisplayDimensionsFallsBackToClampingForMissingDimensions(): void
+    {
+        // Unknown intrinsic size (0): cannot compute a ratio, fall back to
+        // independent clamping without dividing by zero.
+        $result = $this->invokeCalculateDisplayDimensions(0, 0, 1000, 1000);
+
+        self::assertSame(0, $result['width']);
+        self::assertSame(0, $result['height']);
+    }
 }


### PR DESCRIPTION
## Problem

Fixes #846.

When both `maxWidth` and `maxHeight` are configured (e.g. both `1000`) and an image exceeds both, the image is displayed distorted. A portrait image larger than both limits is squashed into a `1000 × 1000` square.

### Root cause

`SelectImageController` clamped each axis **independently** with `min()`:

```php
'width'  => min($file->getProperty('width'),  $maxDimensions['width']),
'height' => min($file->getProperty('height'), $maxDimensions['height']),
```

A `2000 × 3000` image becomes `min(2000,1000)=1000` wide and `min(3000,1000)=1000` tall — the two dimensions are reduced by different factors, so the aspect ratio is destroyed. The same independent clamping was present in `processImage()`.

## Fix

Introduce `calculateDisplayDimensions()`, which scales both dimensions by the same (smaller) factor so the image fits within the limits while preserving its aspect ratio:

```php
$scale = min($maxWidth / $originalWidth, $maxHeight / $originalHeight);
return [
    'width'  => max(1, (int) round($originalWidth  * $scale)),
    'height' => max(1, (int) round($originalHeight * $scale)),
];
```

- Image already within limits → original dimensions kept (never upscaled, matching previous behaviour).
- Missing/zero intrinsic dimensions → falls back to independent clamping, avoiding division by zero.
- `round()` keeps the aspect ratio as accurate as possible and lands the limiting axis exactly on its max (avoiding a float-floor off-by-one); `max(1, …)` guarantees at least 1px so extreme aspect ratios never produce a 0px dimension.

Applied to both the suggested display size in `infoAction()` and the processed-file dimensions in `processImage()`.

`2000 × 3000` with `maxWidth = maxHeight = 1000` now yields `667 × 1000` instead of `1000 × 1000`.

This is the same behaviour already present on `main` (v13+); this PR backports the fix to the `TYPO3_12` maintenance branch.

## Tests

Added 6 unit tests: the #846 regression case, within-limits, landscape scaling, portrait scaling against the default `maxHeight`, the extreme-aspect-ratio 1px clamp, and the zero-dimension fallback.

Local CI green: lint, PHPStan, Rector, php-cs-fixer, unit (15), functional (11).
