### PR TITLE
release: v13.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [13.10.1] - 2026-06-18
+
+### Documentation
+
+- **Corrected template-override TypoScript examples** ([#845](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/845)) — the documented override mechanism was broken: `settings.templateRootPaths`/`partialRootPaths`/`layoutRootPaths` placed as siblings of `preUserFunc` never reach `ImageRenderingService::buildTemplatePaths()`, because `stdWrap_preUserFunc` only forwards `$conf['preUserFunc.']` to the callable. The `Configuration/TypoScript/ImageRendering/setup.typoscript` comments and `Documentation/Examples/Template-Overrides.rst` now show the correct nested structure, plus the matching `lib.parseFunc_RTE.externalBlocks.figure.stdWrap.preUserFunc` block required for captioned (figure-wrapped) images.
+- **README restructured** ([#842](https://github.com/netresearch/t3x-rte_ckeditor_image/pull/842)) — narrative, SEO, and GitHub-UX conventions, plus a documented TYPO3 version-compatibility branch matrix.
+
 ## [13.10.0] - 2026-05-28
 
 ### Changed

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,7 +20,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email'   => 'sebastian.koschel@netresearch.de, sebastian.mendel@netresearch.de, rico.sonntag@netresearch.de',
     'author_company' => 'Netresearch DTT GmbH',
     'state'          => 'stable',
-    'version'        => '13.10.0',
+    'version'        => '13.10.1',
     'constraints'    => [
         'depends' => [
             // ext_emconf does not support disjoint ranges. The supported


### PR DESCRIPTION
## Summary

Documentation maintenance release. **No functional code changes** since v13.10.0 — the CI/template-adoption and dev-dependency work in this window (`.github/`, `Build/`, `Tests/`) is `export-ignore`d and does not ship to TER/Packagist.

## Shipped changes (since v13.10.0)

- **Corrected template-override TypoScript examples** (#845) — the documented override mechanism was broken: `settings.*RootPaths` placed as siblings of `preUserFunc` never reach `ImageRenderingService::buildTemplatePaths()` (`stdWrap_preUserFunc` only forwards `$conf['preUserFunc.']`). `setup.typoscript` + `Documentation/Examples/Template-Overrides.rst` now show the correct nested structure, including the `externalBlocks.figure.stdWrap.preUserFunc` variant for captioned images.
- **README restructured** (#842) — narrative/SEO/GitHub-UX, plus the TYPO3 version-compatibility branch matrix.

## Release mechanics

- `ext_emconf.php`: `13.10.0` → `13.10.1` (composer.json has no version field — derived from tag)
- CHANGELOG `[13.10.1]` section added
- Tag `v13.10.1` to be pushed from `main` HEAD after merge → CI publishes

## Type of Change
- [x] Documentation update
- [ ] Bug fix / feature / breaking change

https://claude.ai/code/session_015Myeo4imGJGskBMto9BVAm