### PR TITLE
fix(cgl): remove docblocks flagged by rector 2.5.3 dead-code rules

### DIFF
--- a/Classes/Command/ValidateImageReferencesCommand.php
+++ b/Classes/Command/ValidateImageReferencesCommand.php
@@ -145,8 +145,6 @@ class ValidateImageReferencesCommand extends Command
     }
 
     /**
-     * @param mixed $rawInclude
-     *
      * @return list<SrcOrigin>
      */
     private function parseIncludeOption(mixed $rawInclude, SymfonyStyle $io): array

--- a/Classes/Service/Environment/EnvironmentInfoInterface.php
+++ b/Classes/Service/Environment/EnvironmentInfoInterface.php
@@ -55,8 +55,6 @@ interface EnvironmentInfoInterface
      *
      * Returns the authenticated backend user from the current session,
      * or null if not in a backend context.
-     *
-     * @return BackendUserAuthentication|null
      */
     public function getBackendUser(): ?BackendUserAuthentication;
 }


### PR DESCRIPTION
`ci / Rector` is red on `main` and is therefore gating every open PR, including the innocent dependency bumps (#859).

## Cause

Rector [2.5.3](https://github.com/rectorphp/rector/releases/tag/2.5.3) (2026-07-05) added two DeadCode rules:

- `RemoveMixedDocblockOverruledByNativeTypeRector`
- `RemoveUselessUnionReturnDocblockRector`

`composer.lock` is not committed (standard TYPO3 extension convention), so CI resolves Rector fresh on every run. The job went from green on 2026-06-29 (rector 2.5.2) to red on 2026-07-06 (2.5.3+) **with no source change** — the pass/fail boundary matches 2.5.3's publish date. Main HEAD `5c3ffab` has not moved since 2026-06-23.

## Change

Applied via `composer ci:rector`. Two docblock lines removed, each only restating a native type that is still present:

- `ValidateImageReferencesCommand.php` — `@param mixed $rawInclude` (native `mixed` retained)
- `EnvironmentInfoInterface.php` — `@return BackendUserAuthentication|null` (native `?BackendUserAuthentication` retained; the import stays in use via that type)

No behaviour change.

## Verification

Run locally against a clean clone of main with rector 2.5.7:

| Check | Before | After |
|---|---|---|
| `ci:test:php:rector` | exit 2 — 2 files would change | exit 0 — `Rector is done!` |
| `ci:test:php:lint` | — | exit 0 — 97 files |
| `ci:test:php:cgl` | — | exit 0 — 0 of 95 files to fix |
| `ci:test:php:unit` | — | exit 0 — 839 tests, 1896 assertions |

`ci:test:php:phpstan` reports 112 errors both with and without this change (identical on a pristine tree), so it is untouched by this PR.

Merging this unblocks #859.