### PR TITLE
fix(rendering): preserve CKEditor 5 image resize width in frontend

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -1241,6 +1241,33 @@ $bodytext790 = '<p>Lorem ipsum dolor sit amet.</p><p>Another paragraph here for 
 $stmt->execute([1, 'text', 'Plain RTE Bodytext (#790)', $bodytext790, 0, 0, $now, $now, 0, 11008]);
 echo "Plain bodytext CE created for #790\n";
 
+// CE for #863: CKEditor 5 image resize. The resize handles store the chosen
+// size as a `width` declaration on the <figure> (class image_resized) and leave
+// the <img> at its intrinsic pixel size. The frontend used to replace that
+// declaration with the computed max-width, so every resized image rendered full
+// width. Covers percentage, pixel, no-caption and linked variants, plus a figure
+// whose style carries declarations that must never reach the output.
+$bodytextResize = '<figure class="image image_resized" style="width:25%;">'
+    . '<img src="fileadmin/user_upload/example.jpg" alt="Resize Percent Caption" width="400" height="300" data-htmlarea-file-uid="1" />'
+    . '<figcaption>Resized to 25 percent</figcaption></figure>'
+    . '<figure class="image image_resized" style="width:25%;">'
+    . '<img src="fileadmin/user_upload/example.jpg" alt="Resize Percent No Caption" width="400" height="300" data-htmlarea-file-uid="1" />'
+    . '</figure>'
+    . '<figure class="image image_resized" style="width:120px;">'
+    . '<img src="fileadmin/user_upload/example.jpg" alt="Resize Pixels Caption" width="400" height="300" data-htmlarea-file-uid="1" />'
+    . '<figcaption>Resized to 120 pixels</figcaption></figure>'
+    . '<figure class="image image_resized" style="width:25%;">'
+    . '<a href="https://typo3.org" target="_blank"><img src="fileadmin/user_upload/example.jpg" alt="Resize Linked" width="400" height="300" data-htmlarea-file-uid="1" /></a>'
+    . '<figcaption>Resized and linked</figcaption></figure>'
+    . '<figure class="image image_resized" style="width:expression(alert(1));background:url(//evil.example/x);">'
+    . '<img src="fileadmin/user_upload/example.jpg" alt="Resize Unsafe Style" width="400" height="300" data-htmlarea-file-uid="1" />'
+    . '<figcaption>Unsafe declarations</figcaption></figure>'
+    . '<figure class="image">'
+    . '<img src="fileadmin/user_upload/example.jpg" alt="Resize Never Applied" width="400" height="300" data-htmlarea-file-uid="1" />'
+    . '<figcaption>Never resized</figcaption></figure>';
+$stmt->execute([1, 'text', 'Image Resize (#863)', $bodytextResize, 0, 0, $now, $now, 0, 11264]);
+echo "Image resize CE created for #863\n";
+
 CONTENT_EOF
 
         # Start MariaDB container for E2E tests

--- a/Classes/Controller/ImageRenderingAdapter.php
+++ b/Classes/Controller/ImageRenderingAdapter.php
@@ -736,6 +736,7 @@ class ImageRenderingAdapter
         $caption         = $parsed['caption'];
         $linkAttributes  = $parsed['link'];
         $figureClass     = $parsed['figureClass'] ?? '';
+        $figureWidth     = $parsed['figureWidth'] ?? '';
 
         // Skip images without file UID (external images)
         $fileUid = (int) ($imageAttributes['data-htmlarea-file-uid'] ?? 0);
@@ -761,9 +762,10 @@ class ImageRenderingAdapter
         // This ensures the correct template (LinkWithCaption) is selected
         $linkAttributesOrNull = $linkAttributes !== [] ? $linkAttributes : null;
         $figureClassOrNull    = $figureClass !== '' ? $figureClass : null;
+        $figureWidthOrNull    = $figureWidth !== '' ? $figureWidth : null;
 
         // Resolve image to validated DTO
-        $dto = $this->resolverService->resolve($imageAttributes, $conf, $request, $linkAttributesOrNull, $figureClassOrNull);
+        $dto = $this->resolverService->resolve($imageAttributes, $conf, $request, $linkAttributesOrNull, $figureClassOrNull, $figureWidthOrNull);
 
         if (!$dto instanceof ImageRenderingDto) {
             // Resolution failed - return original content

--- a/Classes/Domain/Model/ImageRenderingDto.php
+++ b/Classes/Domain/Model/ImageRenderingDto.php
@@ -33,6 +33,7 @@ final readonly class ImageRenderingDto
      * @param LinkDto|null        $link           Link/popup configuration (nullable for linked images)
      * @param bool                $isMagicImage   Whether this is a magic image (TYPO3 processing enabled)
      * @param string|null         $figureClass    Figure element class for alignment (image-left, image-center, image-right)
+     * @param string|null         $figureWidth    Author resize width from the CKEditor 5 figure (e.g. `26.43%`), already normalised
      */
     public function __construct(
         public string $src,
@@ -45,5 +46,6 @@ final readonly class ImageRenderingDto
         public ?LinkDto $link,
         public bool $isMagicImage,
         public ?string $figureClass = null,
+        public ?string $figureWidth = null,
     ) {}
 }

--- a/Classes/Service/ImageAttributeParser.php
+++ b/Classes/Service/ImageAttributeParser.php
@@ -165,14 +165,14 @@ class ImageAttributeParser
      *
      * @param string $html HTML string containing figure-wrapped image
      *
-     * @return array{attributes: array<string,string>, caption: string, link: array<string,string>, figureClass: string}
+     * @return array{attributes: array<string,string>, caption: string, link: array<string,string>, figureClass: string, figureWidth: string}
      *
      * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/555
      */
     public function parseFigureWithCaption(string $html): array
     {
         if (trim($html) === '') {
-            return ['attributes' => [], 'caption' => '', 'link' => [], 'figureClass' => ''];
+            return ['attributes' => [], 'caption' => '', 'link' => [], 'figureClass' => '', 'figureWidth' => ''];
         }
 
         $dom = new DOMDocument();
@@ -191,7 +191,7 @@ class ImageAttributeParser
         $figures = $xpath->query('//figure');
 
         if ($figures === false || $figures->length === 0) {
-            return ['attributes' => [], 'caption' => '', 'link' => [], 'figureClass' => ''];
+            return ['attributes' => [], 'caption' => '', 'link' => [], 'figureClass' => '', 'figureWidth' => ''];
         }
 
         /** @var DOMElement $figure */
@@ -199,6 +199,9 @@ class ImageAttributeParser
 
         // Extract figure class (for alignment: image-left, image-center, image-right)
         $figureClass = $figure->getAttribute('class') ?? '';
+
+        // Extract the resize width CKEditor 5 stores on the figure (image_resized)
+        $figureWidth = $this->parseCssWidthDeclaration($figure->getAttribute('style') ?? '');
 
         // Extract image attributes
         $images     = $xpath->query('.//img', $figure);
@@ -231,7 +234,60 @@ class ImageAttributeParser
             $linkAttributes = $this->extractAttributes($link);
         }
 
-        return ['attributes' => $attributes, 'caption' => $caption, 'link' => $linkAttributes, 'figureClass' => $figureClass];
+        return ['attributes' => $attributes, 'caption' => $caption, 'link' => $linkAttributes, 'figureClass' => $figureClass, 'figureWidth' => $figureWidth];
+    }
+
+    /**
+     * Parse the `width` declaration out of a CSS declaration list.
+     *
+     * CKEditor 5's image resize feature writes the chosen size as a single
+     * `width` declaration on the <figure> element (class `image_resized`) and
+     * leaves the <img> at its intrinsic pixel size.
+     *
+     * Only a bare <number><unit> value is recognised. Functions (`calc()`,
+     * `var()`, `url()`, legacy `expression()`), keywords (`auto`, `inherit`),
+     * `!important` and unsupported units do not match the grammar and yield an
+     * empty string, as does a declaration list without a `width`.
+     *
+     * The return value is rebuilt from the parsed number and unit, so no part of
+     * the input string is ever carried into the output. Later declarations win,
+     * matching CSS cascade order within a declaration list.
+     *
+     * @param string $style Value of a `style` attribute
+     *
+     * @return string Normalised width (e.g. `26.43%`), or empty string if absent or unparsable
+     *
+     * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/863
+     */
+    private function parseCssWidthDeclaration(string $style): string
+    {
+        if (trim($style) === '') {
+            return '';
+        }
+
+        $value = null;
+
+        foreach (explode(';', $style) as $declaration) {
+            $parts = explode(':', $declaration, 2);
+
+            if (count($parts) !== 2) {
+                continue;
+            }
+
+            if (strtolower(trim($parts[0])) === 'width') {
+                $value = trim($parts[1]);
+            }
+        }
+
+        if ($value === null) {
+            return '';
+        }
+
+        if (preg_match('/^(\d+(?:\.\d+)?|\.\d+)\s*(%|px|rem|em)$/i', $value, $matches) !== 1) {
+            return '';
+        }
+
+        return $matches[1] . strtolower($matches[2]);
     }
 
     /**

--- a/Classes/Service/ImageResolverService.php
+++ b/Classes/Service/ImageResolverService.php
@@ -102,6 +102,7 @@ class ImageResolverService
      * @param ServerRequestInterface    $request        Current request
      * @param array<string,string>|null $linkAttributes Optional link attributes for linked images
      * @param string|null               $figureClass    Optional figure class for alignment (image-left, etc.)
+     * @param string|null               $figureWidth    Optional normalised resize width from the figure (e.g. `26.43%`)
      *
      * @return ImageRenderingDto|null Validated DTO or null if validation fails
      */
@@ -111,6 +112,7 @@ class ImageResolverService
         ServerRequestInterface $request,
         ?array $linkAttributes = null,
         ?string $figureClass = null,
+        ?string $figureWidth = null,
     ): ?ImageRenderingDto {
         // Extract file UID from data-htmlarea-file-uid attribute
         $fileUid = (int) ($attributes['data-htmlarea-file-uid'] ?? 0);
@@ -193,6 +195,14 @@ class ImageResolverService
                 $htmlAttributes['class'] = trim(($existingClass !== '' ? $existingClass . ' ' : '') . $figureClass);
             }
 
+            // Same for the resize width: without a <figure> to carry it, the width
+            // has to go on the <img> itself. `height:auto` keeps the aspect ratio,
+            // which the height attribute would otherwise pin to the intrinsic size.
+            // The declaration is composed here, never copied from the input.
+            if ($caption === '' && $figureWidth !== null && $figureWidth !== '') {
+                $htmlAttributes['style'] = 'width:' . $figureWidth . ';height:auto';
+            }
+
             // Build link DTO if link attributes provided OR if popup attributes are present
             $link = null;
 
@@ -214,6 +224,7 @@ class ImageResolverService
                 link: $link,
                 isMagicImage: true,
                 figureClass: $figureClass !== '' ? $figureClass : null,
+                figureWidth: $figureWidth !== '' ? $figureWidth : null,
             );
         } catch (FileDoesNotExistException $exception) {
             $this->logger->log(

--- a/Resources/Private/Partials/Image/Figure.html
+++ b/Resources/Private/Partials/Image/Figure.html
@@ -1,7 +1,8 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
 <f:variable name="figureClasses" value="{f:if(condition: image.figureClass, then: image.figureClass, else: 'image')}" />
 <f:variable name="additionalClass" value="{f:if(condition: image.htmlAttributes.class, then: ' {image.htmlAttributes.class}')}" />
-<figure class="{figureClasses}{additionalClass}"{f:if(condition: image.width, then: ' style="max-width: {image.width}px"')}>
+<f:variable name="figureStyle" value="{f:if(condition: image.figureWidth, then: 'width:{image.figureWidth};')}{f:if(condition: image.width, then: 'max-width: {image.width}px')}" />
+<figure class="{figureClasses}{additionalClass}"{f:if(condition: figureStyle, then: ' style="{figureStyle}"')}>
     {content -> f:format.raw()}
     <f:if condition="{image.caption}"><figcaption>{image.caption}</figcaption></f:if>
 </figure>

--- a/Resources/Private/Partials/Image/TagInFigure.html
+++ b/Resources/Private/Partials/Image/TagInFigure.html
@@ -1,10 +1,16 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<f:comment>
+    A resized figure carries the author width, so the image has to fill it —
+    otherwise the intrinsic pixel width would overflow the narrowed figure.
+    height:auto keeps the aspect ratio against the height attribute.
+</f:comment>
+<f:variable name="imgStyle" value="{f:if(condition: image.figureWidth, then: 'width:100%;height:auto', else: image.htmlAttributes.style)}" />
 <img src="{image.src}"
      alt="{image.alt}"
      width="{image.width}"
      height="{image.height}"
      decoding="async"
      {f:if(condition: image.title, then: 'title="{image.title}"')}
-     {f:if(condition: image.htmlAttributes.style, then: 'style="{image.htmlAttributes.style}"')}
+     {f:if(condition: imgStyle, then: 'style="{imgStyle}"')}
      {f:if(condition: image.htmlAttributes.loading, then: 'loading="{image.htmlAttributes.loading}"')} />
 </html>

--- a/Tests/E2E/tests/figure-resize-width.spec.ts
+++ b/Tests/E2E/tests/figure-resize-width.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect } from '@playwright/test';
+import { gotoFrontendPage } from './helpers/typo3-backend';
+
+/**
+ * Regression tests for CKEditor 5 image resize in the frontend (#863).
+ *
+ * CKEditor 5's resize handles store the chosen size as a `width` declaration on
+ * the <figure> element (class `image_resized`) and leave the <img> at its
+ * intrinsic pixel size. The frontend replaced that declaration with the computed
+ * `max-width`, so a 25%-wide image rendered at full width.
+ *
+ * These tests assert rendered geometry rather than markup: unit and functional
+ * tests can only prove which attributes are emitted, but the bug was that the
+ * image came out the wrong SIZE. Only a real layout engine settles that.
+ *
+ * Fixture: CE "Image Resize (#863)" seeded in Build/Scripts/runTests.sh.
+ *
+ * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/863
+ */
+test.describe('Figure Resize Width (#863)', () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoFrontendPage(page);
+  });
+
+  /**
+   * Width of an element relative to the width of its offset parent.
+   */
+  async function relativeWidth(page: import('@playwright/test').Page, alt: string): Promise<number> {
+    return page.evaluate((imageAlt) => {
+      const img = document.querySelector<HTMLImageElement>(`img[alt="${imageAlt}"]`);
+      if (img === null) {
+        throw new Error(`No image with alt="${imageAlt}"`);
+      }
+
+      // The outermost element the extension emits for this image: the figure
+      // when one is rendered, otherwise the image itself.
+      const box: HTMLElement = img.closest('figure') ?? img;
+      const parent = box.parentElement;
+      if (parent === null) {
+        throw new Error(`No parent for alt="${imageAlt}"`);
+      }
+
+      return box.getBoundingClientRect().width / parent.getBoundingClientRect().width;
+    }, alt);
+  }
+
+  test('percentage resize with caption renders at the stored fraction', async ({ page }) => {
+    const ratio = await relativeWidth(page, 'Resize Percent Caption');
+
+    // Stored as width:25%. Before the fix this rendered at the full container
+    // width (ratio ~1.0), which is exactly the reported symptom.
+    expect(ratio).toBeGreaterThan(0.2);
+    expect(ratio).toBeLessThan(0.3);
+  });
+
+  test('percentage resize without caption renders at the stored fraction', async ({ page }) => {
+    // No caption means no <figure> wrapper is emitted (see #595), so the width
+    // has to travel on the <img> instead.
+    const ratio = await relativeWidth(page, 'Resize Percent No Caption');
+
+    expect(ratio).toBeGreaterThan(0.2);
+    expect(ratio).toBeLessThan(0.3);
+  });
+
+  test('image fills its resized figure instead of overflowing it', async ({ page }) => {
+    // The <img> keeps its intrinsic width attribute (400). Without a width:100%
+    // on the image, a figure narrowed to 25% would simply be overflowed.
+    const overflow = await page.evaluate(() => {
+      const img = document.querySelector<HTMLImageElement>('img[alt="Resize Percent Caption"]');
+      const figure = img?.closest('figure');
+      if (img === undefined || img === null || figure === undefined || figure === null) {
+        throw new Error('Resized figure not found');
+      }
+
+      return img.getBoundingClientRect().width - figure.getBoundingClientRect().width;
+    });
+
+    expect(overflow).toBeLessThanOrEqual(1);
+  });
+
+  test('resized image keeps its aspect ratio', async ({ page }) => {
+    // width/height attributes are 400x300. A relative width without height:auto
+    // would keep the height pinned at 300 and squash the image.
+    const ratio = await page.evaluate(() => {
+      const img = document.querySelector<HTMLImageElement>('img[alt="Resize Percent Caption"]');
+      if (img === null) {
+        throw new Error('Resized image not found');
+      }
+
+      const rect = img.getBoundingClientRect();
+
+      return rect.width / rect.height;
+    });
+
+    expect(ratio).toBeGreaterThan(1.2);
+    expect(ratio).toBeLessThan(1.5);
+  });
+
+  test('pixel resize renders at the stored pixel width', async ({ page }) => {
+    const width = await page.evaluate(() => {
+      const img = document.querySelector<HTMLImageElement>('img[alt="Resize Pixels Caption"]');
+      const figure = img?.closest('figure');
+      if (figure === undefined || figure === null) {
+        throw new Error('Pixel-resized figure not found');
+      }
+
+      return figure.getBoundingClientRect().width;
+    });
+
+    expect(width).toBeGreaterThan(110);
+    expect(width).toBeLessThan(130);
+  });
+
+  test('resized linked image keeps both its width and its link', async ({ page }) => {
+    const ratio = await relativeWidth(page, 'Resize Linked');
+
+    expect(ratio).toBeGreaterThan(0.2);
+    expect(ratio).toBeLessThan(0.3);
+
+    const link = page.locator('img[alt="Resize Linked"]').locator('xpath=ancestor::a');
+    expect(await link.count(), 'Resized linked image should stay wrapped in <a>').toBeGreaterThan(0);
+    expect(await link.first().getAttribute('href')).toContain('typo3.org');
+  });
+
+  test('image that was never resized renders at its intrinsic width', async ({ page }) => {
+    // No author width, so the figure is bounded only by the computed max-width
+    // (the 400px intrinsic width from #667) and must gain no width declaration.
+    const figure = await page.evaluate(() => {
+      const img = document.querySelector<HTMLImageElement>('img[alt="Resize Never Applied"]');
+      const element = img?.closest('figure');
+      if (element === undefined || element === null) {
+        throw new Error('Unresized figure not found');
+      }
+
+      return {
+        width: element.getBoundingClientRect().width,
+        style: element.getAttribute('style') ?? '',
+      };
+    });
+
+    expect(figure.width).toBeGreaterThan(390);
+    expect(figure.width).toBeLessThan(410);
+    expect(figure.style).toContain('max-width');
+    expect(figure.style).not.toMatch(/(^|;)\s*width\s*:/);
+  });
+
+  test('unsafe declarations from the stored style never reach the output', async ({ page }) => {
+    const style = await page.evaluate(() => {
+      const img = document.querySelector<HTMLImageElement>('img[alt="Resize Unsafe Style"]');
+      const figure = img?.closest('figure');
+
+      return figure?.getAttribute('style') ?? '';
+    });
+
+    expect(style).not.toContain('expression');
+    expect(style).not.toContain('evil.example');
+    expect(style).not.toContain('url(');
+  });
+
+  test('page contains no leaked Fluid expressions', async ({ page }) => {
+    // A malformed inline f:if renders verbatim into the HTML rather than
+    // failing, so the rendered document is the only place it shows up.
+    const html = await page.content();
+
+    expect(html).not.toContain('f:if(');
+  });
+});

--- a/Tests/Functional/Controller/FigureResizeWidthRenderingTest.php
+++ b/Tests/Functional/Controller/FigureResizeWidthRenderingTest.php
@@ -1,0 +1,268 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\RteCKEditorImage\Tests\Functional\Controller;
+
+use Netresearch\RteCKEditorImage\Controller\ImageRenderingAdapter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Functional tests for CKEditor 5 image resize rendering.
+ *
+ * CKEditor 5's resize handles store the chosen size as a `width` declaration on
+ * the <figure> element (class `image_resized`) and leave the <img> at its
+ * intrinsic pixel size. Before the fix for issue #863 the frontend replaced that
+ * declaration with the computed `max-width`, so every resized image rendered at
+ * full width.
+ *
+ * @author  Netresearch DTT GmbH
+ * @license https://www.gnu.org/licenses/agpl-3.0.de.html
+ *
+ * @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/863
+ */
+final class FigureResizeWidthRenderingTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/rte_ckeditor_image',
+    ];
+
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-rte-ckeditor',
+    ];
+
+    private ServerRequestInterface $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/sys_file_storage.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/sys_file.csv');
+
+        $site = new Site('test', 1, [
+            'base'      => 'http://localhost/',
+            'languages' => [
+                [
+                    'languageId' => 0,
+                    'title'      => 'English',
+                    'locale'     => 'en_US.UTF-8',
+                    'base'       => '/',
+                ],
+            ],
+        ]);
+
+        $this->request = (new ServerRequest())
+            ->withAttribute('site', $site)
+            ->withAttribute('language', $site->getDefaultLanguage());
+    }
+
+    /**
+     * Render a stored RTE figure through the TypoScript entry point.
+     */
+    private function renderFigure(string $inputHtml): string
+    {
+        $adapter = $this->get(ImageRenderingAdapter::class);
+
+        /** @var ContentObjectRenderer $contentObjectRenderer */
+        $contentObjectRenderer = $this->get(ContentObjectRenderer::class);
+
+        $contentObjectRenderer->setCurrentVal($inputHtml);
+        $adapter->setContentObjectRenderer($contentObjectRenderer);
+
+        /** @var string $result */
+        $result = $adapter->renderFigure(null, [], $this->request);
+
+        return $result;
+    }
+
+    /**
+     * The reported case: a resized image with a caption.
+     */
+    #[Test]
+    public function percentageResizeWithCaptionKeepsWidthOnFigure(): void
+    {
+        $result = $this->renderFigure(
+            '<figure class="image image_resized" style="width:26.43%;">'
+            . '<img src="/fileadmin/test-image.jpg" width="1334" height="1000" data-htmlarea-file-uid="1" alt="Test">'
+            . '<figcaption>Caption</figcaption>'
+            . '</figure>',
+        );
+
+        // Asserted in full: the figure carries the author width while the <img>
+        // is stretched to fill it. Without the `width:100%` on the image the
+        // narrowed figure would simply be overflowed by the 1334px image, and a
+        // substring assertion on the figure alone would not notice.
+        self::assertSame(
+            '<figure class="image image_resized" style="width:26.43%;max-width: 1334px">'
+            . '<img src="fileadmin/test-image.jpg" alt="Test" width="1334" height="1000" decoding="async" style="width:100%;height:auto" />'
+            . '<figcaption>Caption</figcaption>'
+            . '</figure>',
+            $result,
+        );
+    }
+
+    /**
+     * The computed max-width from #667 keeps captions from overflowing the image
+     * and must survive alongside the restored author width.
+     */
+    #[Test]
+    public function percentageResizeWithCaptionKeepsComputedMaxWidth(): void
+    {
+        $result = $this->renderFigure(
+            '<figure class="image image_resized" style="width:26.43%;">'
+            . '<img src="/fileadmin/test-image.jpg" width="1334" height="1000" data-htmlarea-file-uid="1" alt="Test">'
+            . '<figcaption>Caption</figcaption>'
+            . '</figure>',
+        );
+
+        self::assertStringContainsString('max-width', $result, 'Result: ' . $result);
+    }
+
+    #[Test]
+    public function percentageResizeWithCaptionKeepsResizedClass(): void
+    {
+        $result = $this->renderFigure(
+            '<figure class="image image_resized" style="width:26.43%;">'
+            . '<img src="/fileadmin/test-image.jpg" width="1334" height="1000" data-htmlarea-file-uid="1" alt="Test">'
+            . '<figcaption>Caption</figcaption>'
+            . '</figure>',
+        );
+
+        self::assertStringContainsString('image_resized', $result, 'Result: ' . $result);
+    }
+
+    /**
+     * Without a caption no <figure> wrapper is emitted (see #595), so the width
+     * has to travel on the <img> instead.
+     */
+    #[Test]
+    public function percentageResizeWithoutCaptionKeepsWidthOnImage(): void
+    {
+        $result = $this->renderFigure(
+            '<figure class="image image_resized" style="width:26.43%;">'
+            . '<img src="/fileadmin/test-image.jpg" width="1334" height="1000" data-htmlarea-file-uid="1" alt="Test">'
+            . '</figure>',
+        );
+
+        // `height:auto` is required: the height attribute would otherwise pin the
+        // image to its intrinsic 1000px and distort it once the width is relative.
+        self::assertSame(
+            '<img src="fileadmin/test-image.jpg" alt="Test" width="1334" height="1000" decoding="async"'
+            . ' class="image image_resized" style="width:26.43%;height:auto" />',
+            $result,
+        );
+    }
+
+    #[Test]
+    public function pixelResizeWithCaptionKeepsWidthOnFigure(): void
+    {
+        $result = $this->renderFigure(
+            '<figure class="image image_resized" style="width:320px;">'
+            . '<img src="/fileadmin/test-image.jpg" width="1334" height="1000" data-htmlarea-file-uid="1" alt="Test">'
+            . '<figcaption>Caption</figcaption>'
+            . '</figure>',
+        );
+
+        self::assertStringContainsString('width:320px', $result, 'Result: ' . $result);
+    }
+
+    /**
+     * Resizing a linked image must keep both the width and the link.
+     */
+    #[Test]
+    public function percentageResizeOnLinkedImageKeepsWidthAndLink(): void
+    {
+        $result = $this->renderFigure(
+            '<figure class="image image_resized" style="width:33%;">'
+            . '<a href="https://example.com/target">'
+            . '<img src="/fileadmin/test-image.jpg" width="1334" height="1000" data-htmlarea-file-uid="1" alt="Test">'
+            . '</a>'
+            . '<figcaption>Caption</figcaption>'
+            . '</figure>',
+        );
+
+        self::assertStringContainsString('width:33%', $result, 'Result: ' . $result);
+        self::assertStringContainsString('https://example.com/target', $result, 'Result: ' . $result);
+    }
+
+    /**
+     * An image that was never resized must render exactly as before.
+     */
+    #[Test]
+    public function unresizedImageWithCaptionGetsNoWidthDeclaration(): void
+    {
+        $result = $this->renderFigure(
+            '<figure class="image">'
+            . '<img src="/fileadmin/test-image.jpg" width="1334" height="1000" data-htmlarea-file-uid="1" alt="Test">'
+            . '<figcaption>Caption</figcaption>'
+            . '</figure>',
+        );
+
+        self::assertStringNotContainsString('width:26.43%', $result, 'Result: ' . $result);
+        self::assertStringContainsString('max-width', $result, 'Result: ' . $result);
+    }
+
+    /**
+     * Declarations the author could smuggle into the stored style attribute.
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function unsafeFigureStyleProvider(): array
+    {
+        return [
+            'url in sibling declaration' => ['width:26%;background:url(//evil.example/x);', 'evil.example'],
+            'behavior property'          => ['width:26%;behavior:url(//evil.example/x.htc);', 'evil.example'],
+            'legacy IE expression'       => ['width:expression(alert(1));', 'expression'],
+            'url as width value'         => ['width:url(//evil.example/x);', 'evil.example'],
+            'position fixed overlay'     => ['width:26%;position:fixed;top:0;left:0;', 'position'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('unsafeFigureStyleProvider')]
+    public function unsafeDeclarationsNeverReachTheOutput(string $style, string $forbidden): void
+    {
+        $result = $this->renderFigure(
+            '<figure class="image image_resized" style="' . $style . '">'
+            . '<img src="/fileadmin/test-image.jpg" width="1334" height="1000" data-htmlarea-file-uid="1" alt="Test">'
+            . '<figcaption>Caption</figcaption>'
+            . '</figure>',
+        );
+
+        self::assertStringNotContainsString($forbidden, $result, 'Result: ' . $result);
+    }
+
+    /**
+     * Re-rendering the frontend output must not accumulate or drop the width.
+     */
+    #[Test]
+    public function renderingResizedFigureIsIdempotent(): void
+    {
+        $input = '<figure class="image image_resized" style="width:26.43%;">'
+            . '<img src="/fileadmin/test-image.jpg" width="1334" height="1000" data-htmlarea-file-uid="1" alt="Test">'
+            . '<figcaption>Caption</figcaption>'
+            . '</figure>';
+
+        $first  = $this->renderFigure($input);
+        $second = $this->renderFigure($first);
+
+        self::assertSame(
+            substr_count($first, 'width:26.43%'),
+            substr_count($second, 'width:26.43%'),
+            'First: ' . $first . ' Second: ' . $second,
+        );
+    }
+}

--- a/Tests/Fuzz/ImageAttributeParserTarget.php
+++ b/Tests/Fuzz/ImageAttributeParserTarget.php
@@ -10,8 +10,9 @@ declare(strict_types=1);
 /**
  * Fuzzing target for ImageAttributeParser.
  *
- * Tests parseImageAttributes() and parseLinkWithImages() with random/mutated inputs
- * to find crashes, memory exhaustion, or unexpected exceptions.
+ * Tests parseImageAttributes(), parseLinkWithImages() and parseFigureWithCaption()
+ * with random/mutated inputs to find crashes, memory exhaustion, or unexpected
+ * exceptions.
  *
  * Usage:
  *   composer ci:fuzz:image-parser
@@ -32,6 +33,10 @@ $config->setTarget(function (string $input) use ($parser): void {
 
     // Test parseLinkWithImages() - handles <a><img></a> structures
     $parser->parseLinkWithImages($input);
+
+    // Test parseFigureWithCaption() - handles <figure><img><figcaption> structures
+    // including the CSS width declaration parsed off the figure's style attribute
+    $parser->parseFigureWithCaption($input);
 });
 
 // Limit maximum input length to prevent excessive memory usage

--- a/Tests/Fuzz/corpus/image-parser/figure_resized.txt
+++ b/Tests/Fuzz/corpus/image-parser/figure_resized.txt
@@ -1,0 +1,1 @@
+<figure class="image image_resized" style="width:26.43%;"><img src="/fileadmin/example.jpg" width="1334" height="1000" data-htmlarea-file-uid="1" /><figcaption>Caption</figcaption></figure>

--- a/Tests/Fuzz/corpus/image-parser/figure_style_variants.txt
+++ b/Tests/Fuzz/corpus/image-parser/figure_style_variants.txt
@@ -1,0 +1,1 @@
+<figure class="image" style="float:left;width:.5rem;;width:expression(alert(1));background:url(//x/y);width:120PX !important"><a href="/t"><img src="a.jpg" data-htmlarea-file-uid="2" /></a><figcaption>c</figcaption></figure>

--- a/Tests/Unit/Service/ImageAttributeParserTest.php
+++ b/Tests/Unit/Service/ImageAttributeParserTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\RteCKEditorImage\Tests\Unit\Service;
 
 use Netresearch\RteCKEditorImage\Service\ImageAttributeParser;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -748,5 +749,174 @@ class ImageAttributeParserTest extends TestCase
         $result = $this->parser->parseLinkWithImages($html);
 
         self::assertSame('Über uns', $result['link']['title']);
+    }
+
+    // ========================================================================
+    // parseFigureWithCaption() Tests - Figure resize width (CKEditor 5 image_resized)
+    //
+    // CKEditor 5's resize handles write the chosen size as a `width` declaration
+    // on the <figure> element and leave the <img> at its intrinsic pixel size.
+    // The width is re-emitted from the parsed number + unit, never copied from
+    // the stored string, so no author-controlled CSS can reach the output.
+    //
+    // @see https://github.com/netresearch/t3x-rte_ckeditor_image/issues/863
+    // ========================================================================
+
+    #[Test]
+    public function parseFigureWithCaptionExtractsPercentageResizeWidth(): void
+    {
+        $html = '<figure class="image image_resized" style="width:26.43%;">'
+            . '<img src="/fileadmin/example.jpg" width="1334" height="1000" data-htmlarea-file-uid="41667"/>'
+            . '<figcaption>Caption</figcaption>'
+            . '</figure>';
+
+        $result = $this->parser->parseFigureWithCaption($html);
+
+        self::assertSame('26.43%', $result['figureWidth']);
+    }
+
+    #[Test]
+    public function parseFigureWithCaptionKeepsResizeWidthAlongsideFigureClassAndCaption(): void
+    {
+        $html = '<figure class="image image_resized" style="width:50%;">'
+            . '<img src="/fileadmin/example.jpg" data-htmlarea-file-uid="1"/>'
+            . '<figcaption>Caption</figcaption>'
+            . '</figure>';
+
+        $result = $this->parser->parseFigureWithCaption($html);
+
+        self::assertSame('50%', $result['figureWidth']);
+        self::assertSame('image image_resized', $result['figureClass']);
+        self::assertSame('Caption', $result['caption']);
+    }
+
+    #[Test]
+    public function parseFigureWithCaptionExtractsResizeWidthFromLinkedImage(): void
+    {
+        $html = '<figure class="image image_resized" style="width:33%;">'
+            . '<a href="/target"><img src="/fileadmin/example.jpg" data-htmlarea-file-uid="1"/></a>'
+            . '<figcaption>Caption</figcaption>'
+            . '</figure>';
+
+        $result = $this->parser->parseFigureWithCaption($html);
+
+        self::assertSame('33%', $result['figureWidth']);
+        self::assertSame('/target', $result['link']['href']);
+    }
+
+    #[Test]
+    public function parseFigureWithCaptionReturnsEmptyResizeWidthWhenFigureHasNoStyle(): void
+    {
+        $html = '<figure class="image"><img src="test.jpg"/><figcaption>Caption</figcaption></figure>';
+
+        $result = $this->parser->parseFigureWithCaption($html);
+
+        self::assertSame('', $result['figureWidth']);
+    }
+
+    #[Test]
+    public function parseFigureWithCaptionReturnsEmptyResizeWidthWhenNoFigurePresent(): void
+    {
+        $result = $this->parser->parseFigureWithCaption('<img src="test.jpg"/>');
+
+        self::assertSame('', $result['figureWidth']);
+    }
+
+    #[Test]
+    public function parseFigureWithCaptionTakesResizeWidthFromOuterFigureOnly(): void
+    {
+        $html = '<figure class="image image_resized" style="width:40%;">'
+            . '<img src="outer.jpg" data-htmlarea-file-uid="1"/>'
+            . '<figcaption>Outer <figure class="image" style="width:90%;"><img src="inner.jpg"/></figure></figcaption>'
+            . '</figure>';
+
+        $result = $this->parser->parseFigureWithCaption($html);
+
+        self::assertSame('40%', $result['figureWidth']);
+    }
+
+    /**
+     * Values a resize can legitimately produce, plus the formatting noise CKEditor,
+     * RTE transformations and hand-edited HTML introduce around them.
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function acceptedFigureWidthProvider(): array
+    {
+        return [
+            'percentage with decimals'   => ['width:26.43%;', '26.43%'],
+            'percentage integer'         => ['width:50%', '50%'],
+            'pixel value'                => ['width:320px;', '320px'],
+            'rem value'                  => ['width:20rem;', '20rem'],
+            'em value'                   => ['width:15em;', '15em'],
+            'zero width'                 => ['width:0%;', '0%'],
+            'leading decimal point'      => ['width:.5%;', '.5%'],
+            'spaces around colon'        => ['width : 26.43% ;', '26.43%'],
+            'uppercase property'         => ['WIDTH:26.43%;', '26.43%'],
+            'uppercase unit'             => ['width:320PX;', '320px'],
+            'space before unit'          => ['width:26.43 %;', '26.43%'],
+            'trailing empty declaration' => ['width:50%;;', '50%'],
+            'width after another decl'   => ['float:left;width:50%;', '50%'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('acceptedFigureWidthProvider')]
+    public function parseFigureWithCaptionNormalisesAcceptedResizeWidths(string $style, string $expected): void
+    {
+        $html = '<figure class="image image_resized" style="' . $style . '"><img src="test.jpg"/></figure>';
+
+        $result = $this->parser->parseFigureWithCaption($html);
+
+        self::assertSame($expected, $result['figureWidth']);
+    }
+
+    /**
+     * Anything that is not a plain length or percentage is dropped, so the figure
+     * falls back to the width the extension computes itself.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function rejectedFigureWidthProvider(): array
+    {
+        return [
+            'no width declaration'    => ['border:1px solid red;'],
+            'auto keyword'            => ['width:auto;'],
+            'inherit keyword'         => ['width:inherit;'],
+            'calc expression'         => ['width:calc(100% - 10px);'],
+            'legacy IE expression'    => ['width:expression(alert(1));'],
+            'url function'            => ['width:url(//evil.example/x);'],
+            'important flag'          => ['width:50%!important;'],
+            'negative percentage'     => ['width:-50%;'],
+            'unitless number'         => ['width:50;'],
+            'unsupported unit'        => ['width:50vw;'],
+            'empty value'             => ['width:;'],
+            'var reference'           => ['width:var(--x);'],
+            'comment smuggling'       => ['width:50%/*x*/;'],
+            'attribute break attempt' => ['width:50%&quot; onload=&quot;alert(1)'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('rejectedFigureWidthProvider')]
+    public function parseFigureWithCaptionRejectsNonLengthResizeWidths(string $style): void
+    {
+        $html = '<figure class="image" style="' . $style . '"><img src="test.jpg"/></figure>';
+
+        $result = $this->parser->parseFigureWithCaption($html);
+
+        self::assertSame('', $result['figureWidth']);
+    }
+
+    #[Test]
+    public function parseFigureWithCaptionDropsSiblingDeclarationsNextToResizeWidth(): void
+    {
+        $html = '<figure class="image image_resized" style="width:26%;background:url(//evil.example/x);">'
+            . '<img src="test.jpg"/>'
+            . '</figure>';
+
+        $result = $this->parser->parseFigureWithCaption($html);
+
+        self::assertSame('26%', $result['figureWidth']);
     }
 }


### PR DESCRIPTION
Closes #863

## Details

CKEditor 5's resize handles store the chosen size as a `width` declaration on the `<figure>` element (class `image_resized`) and leave the `<img>` at its intrinsic pixel size. The frontend dropped that declaration and replaced it with the computed `max-width`, so every resized image rendered at full size.

```html
<!-- stored -->
<figure class="image image_resized" style="width:26.43%;">
    <img src="/fileadmin/example.jpg" width="1334" height="1000" data-htmlarea-file-uid="41667">
    <figcaption>Caption</figcaption>
</figure>

<!-- rendered before -->
<figure class="image image_resized" style="max-width: 1334px">
```

`ImageAttributeParser::parseFigureWithCaption()` read only the figure's `class`, so the width was already gone before `ImageRenderingDto` was built, and `Figure.html` synthesised a `style` from scratch.

## Change

The figure's `style` is parsed for a single `width` declaration, which travels through the DTO to the templates:

- `ImageAttributeParser` gains `parseCssWidthDeclaration()`, returning a normalised width or an empty string
- `ImageRenderingDto` gains `figureWidth`
- `Figure.html` emits `style="width:26.43%;max-width: 1334px"` — the author width plus the computed `max-width` from #667
- `TagInFigure.html` sets `width:100%;height:auto` on the image inside a resized figure
- `ImageResolverService` puts `width:26.43%;height:auto` on the `<img>` when there is no caption, since no `<figure>` is emitted in that case (#595)

Both declarations are needed. A `width` on the figure alone changes nothing, because the `<img>` keeps its intrinsic `width="1334"` and would overflow the narrowed figure — CKEditor only gets away with a figure-level width because its content styles pair it with `figure.image img { width: 100% }`, which this extension does not ship. `height:auto` is required for the same reason: the `height` attribute would otherwise pin the image to its intrinsic height and distort it.

## Security

`AGENTS.md` lists *"Add `style` attribute handling to HTML output"* under **Never Do**, and `ImageResolverService::buildHtmlAttributes()` excludes `style` from the allowed attributes. That boundary is unchanged: no part of the stored string reaches the output.

The parser accepts only a bare `<number><unit>` value (`%`, `px`, `rem`, `em`) and rebuilds the declaration from the parsed number and unit. Functions (`calc()`, `var()`, `url()`, legacy `expression()`), keywords (`auto`, `inherit`), `!important`, unsupported units, negative values and unitless numbers all fail the grammar and yield an empty string, which falls back to the previous output. Sibling declarations are dropped — `width:26%;background:url(//evil.example/x)` yields `26%`.

## Test plan

**Unit** — `Tests/Unit/Service/ImageAttributeParserTest.php`, 27 cases:

- accepted: percentage with and without decimals, `px`, `rem`, `em`, zero, leading decimal point, spaces around the colon and before the unit, uppercase property and unit, trailing empty declaration, width after another declaration
- rejected: the 14 non-length forms listed above, plus an attribute-break attempt
- figure level: linked image, nested figure, class and caption preserved alongside the width

**Functional** — `Tests/Functional/Controller/FigureResizeWidthRenderingTest.php`, 13 cases: full pipeline through `renderFigure()`, asserting the complete emitted markup for the caption and no-caption paths, plus pixel resize, linked resize, unresized regression guard, idempotent re-render, and five unsafe-style variants asserted absent from the output.

**E2E** — `Tests/E2E/tests/figure-resize-width.spec.ts`, 9 cases asserting rendered **geometry** rather than markup, since the bug was that the image came out the wrong size: rendered fraction for percentage resizes with and without caption, no overflow of the image past its figure, preserved aspect ratio, pixel width, linked resize, unresized case at intrinsic width, absence of unsafe declarations, and no leaked Fluid expressions. Fixtures seeded in `Build/Scripts/runTests.sh`.

**Fuzz** — `parseFigureWithCaption()` was not part of the image parser fuzz target, and no corpus entry contained a `<figure>`, so the branch this PR touches was unreachable by mutation. Added the call plus two seeds; coverage features per 10000-run pass go from 76 to 162, no crashes.

Local results:

| Check | Result |
|---|---|
| `ci:test:php:phpstan` (level 10) | 0 errors, 93 files |
| `ci:test:php:cgl` | 0 of 96 files need fixing |
| `ci:test:php:rector` | clean |
| `ci:test:php:lint` | 99 files |
| `ci:test:php:unit` | 873 tests, 1933 assertions |
| `ci:test:php:functional` | 173 tests, 574 assertions |
| `ci:fuzz:image-parser` | 10000 runs, no crashes |
| E2E TYPO3 v13 / PHP 8.5 | 204 passed, 10 skipped |

E2E v14 was not run locally; CI covers it, and all six E2E contexts (two TYPO3 versions x three setup variants) pass.

An exact-markup assertion in the functional test caught a defect during development that a substring assertion had passed over: a nested inline `f:if` in `TagInFigure.html` did not parse, and Fluid rendered the raw expression verbatim into the `<img>` tag. Fluid fails open on malformed inline expressions, so the E2E spec now asserts the rendered document contains no `f:if(` at all.

## Notes

- The shipped CSS still has no `figure.image img { width: 100% }` rule — that is why the inline `width:100%` is necessary. Integrators with their own image CSS may want to check it does not conflict.
- `Documentation/` is untouched; happy to write the rendering behaviour up there if wanted.
- A plain local `composer install` resolves PHPUnit 13, where `phpstan/phpstan-phpunit` does not model the changed mock-builder typing and reports 112 `InvocationStubber` errors across existing test files. This does not affect CI: the shared workflow already pins `phpunit/phpunit:<13` for static analysis only, so PHPStan runs on 12.5.33 while the test jobs run on 13.1.14. Reproducing the CI gate locally needs the same pin. Noted here only so the next person does not chase it.
