### PR TITLE
Adopt the shared Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    ":automergeMinor",
-    ":automergePatch"
+    "github>netresearch/renovate-config"
   ],
-  "automerge": true,
-  "automergeType": "pr",
-  "platformAutomerge": true,
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Last of the 24 t3x repositories not extending `github>netresearch/renovate-config`.

## What the current config actually does

It reads as if automerge were bounded to minor and patch. It is not:

```json
"extends": ["config:recommended", ":automergeMinor", ":automergePatch"],
"automerge": true
```

`automerge` at the **top level** applies to every update type, majors included. The two presets below it are redundant and bound nothing. This repository automerges more broadly than any other in the fleet — and with fewer guards:

| | fleet (23 repos) | here, today |
|---|---|---|
| automerged update types | patch, minor, pin, digest | **all, including major** |
| `stabilityDays: 3` | yes | **no** — a release can land minutes after publication |
| `internalChecksFilter: strict` | yes | no |
| axios deny-list (2026-03-31 incident) | yes | no |

## The change

Extend the shared preset and drop the local automerge settings it supersedes — `automerge`, `automergeType`, `platformAutomerge`, and the two automerge presets.

**Kept unchanged**, because they are genuinely specific to this repository:

- the `customManagers` regex tracking the hardcoded `mcr.microsoft.com/playwright` tag across `runTests.sh`, both composer manifests and the ddev command
- the `packageRule` grouping that tag with `@playwright/test`, so the E2E browser image and the npm package always move together

## Verification

`renovate-config-validator` (current release) reports `Config validated successfully`. Keys were compared structurally rather than by reading the diff: removed are exactly `automerge`, `automergeType`, `platformAutomerge`; `customManagers` and `packageRules` are present and unchanged. One line added, six removed.

## Effect

Majors will now open as PRs and wait for a human instead of merging themselves. Patch and minor keep merging automatically, after the three-day stability window.
