### PR TITLE
fix(rendering): reject invalid values for the loading attribute

### DIFF
--- a/Classes/Service/ImageResolverService.php
+++ b/Classes/Service/ImageResolverService.php
@@ -83,6 +83,22 @@ class ImageResolverService
         't3:',      // TYPO3 internal links (t3://page?uid=123)
     ];
 
+    /**
+     * Accepted values for the HTML loading attribute.
+     *
+     * Mirrors the enum of the styles.content.image.lazyLoading setting in
+     * EXT:fluid_styled_content. Anything else is discarded rather than passed
+     * through - most importantly an unresolved TypoScript constant, which is a
+     * non-empty string and would otherwise reach the markup verbatim.
+     *
+     * @var array<int, string>
+     */
+    private const ALLOWED_LAZY_LOADING_VALUES = [
+        'lazy',
+        'eager',
+        'auto',
+    ];
+
     private readonly LoggerInterface $logger;
 
     public function __construct(
@@ -412,7 +428,9 @@ class ImageResolverService
             ['lib.', 'contentElement.', 'settings.', 'media.', 'lazyLoading'],
         );
 
-        return is_string($lazyLoading) && $lazyLoading !== '' ? $lazyLoading : null;
+        return is_string($lazyLoading) && in_array($lazyLoading, self::ALLOWED_LAZY_LOADING_VALUES, true)
+            ? $lazyLoading
+            : null;
     }
 
     /**

--- a/Tests/Unit/Service/ImageResolverServiceTest.php
+++ b/Tests/Unit/Service/ImageResolverServiceTest.php
@@ -22,6 +22,8 @@ use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Resource\Security\SvgSanitizer;
+use TYPO3\CMS\Core\TypoScript\AST\Node\RootNode;
+use TYPO3\CMS\Core\TypoScript\FrontendTypoScript;
 
 /**
  * Test case for ImageResolverService.
@@ -1236,5 +1238,70 @@ final class ImageResolverServiceTest extends TestCase
         );
 
         self::assertNull($result, 'resolve() must return null on unexpected exceptions, not throw');
+    }
+
+    /**
+     * @return array<string, array{0: mixed, 1: string|null}>
+     */
+    public static function lazyLoadingValueProvider(): array
+    {
+        return [
+            'lazy is accepted'                => ['lazy', 'lazy'],
+            'eager is accepted'               => ['eager', 'eager'],
+            'auto is accepted'                => ['auto', 'auto'],
+            'unresolved constant is rejected' => ['{$styles.content.image.lazyLoading}', null],
+            'arbitrary string is rejected'    => ['sometimes', null],
+            'empty string is rejected'        => ['', null],
+            'non-string is rejected'          => [1, null],
+        ];
+    }
+
+    /**
+     * An unresolved TypoScript constant is a non-empty string. Accepting any
+     * non-empty value put it into the markup verbatim as
+     * loading="{$styles.content.image.lazyLoading}" on installations without
+     * EXT:fluid_styled_content, which is the only package defining that constant.
+     */
+    #[Test]
+    #[DataProvider('lazyLoadingValueProvider')]
+    public function getLazyLoadingConfigurationAcceptsOnlyValidLoadingValues(
+        mixed $configured,
+        ?string $expected,
+    ): void {
+        $frontendTypoScript = new FrontendTypoScript(new RootNode(), [], [], []);
+        $frontendTypoScript->setSetupArray([
+            'lib.' => [
+                'contentElement.' => [
+                    'settings.' => [
+                        'media.' => [
+                            'lazyLoading' => $configured,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')
+            ->with('frontend.typoscript')
+            ->willReturn($frontendTypoScript);
+
+        self::assertSame(
+            $expected,
+            $this->callPrivateMethod($this->service, 'getLazyLoadingConfiguration', [$request]),
+        );
+    }
+
+    #[Test]
+    public function getLazyLoadingConfigurationReturnsNullWithoutFrontendTypoScript(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')
+            ->with('frontend.typoscript')
+            ->willReturn(null);
+
+        self::assertNull(
+            $this->callPrivateMethod($this->service, 'getLazyLoadingConfiguration', [$request]),
+        );
     }
 }


### PR DESCRIPTION
Closes #880

**Explain the details**

On installations without `EXT:fluid_styled_content`, RTE images render as:

```html
<img ... loading="{$styles.content.image.lazyLoading}">
```

`Configuration/TypoScript/ImageRendering/setup.typoscript:248` bridges that constant into `lib.contentElement.settings.media.lazyLoading`. The constant is defined only by `EXT:fluid_styled_content` (`Configuration/Sets/FluidStyledContent/settings.definitions.yaml`, default `lazy`, enum `lazy|eager|auto`). This extension's own `constants.typoscript` defines nothing and lists fluid_styled_content under `optionalDependencies`, so on such an installation the constant never resolves and TypoScript emits the placeholder as a plain string.

`ImageResolverService::getLazyLoadingConfiguration()` then accepted it, because it only checked for a non-empty string — and an unresolved constant is one.

The check now accepts only `lazy`, `eager` and `auto`, the enum the core setting itself defines. Anything else returns `null`, which omits the attribute entirely.

This is deliberately a validation fix rather than a new default. Defining the constant in this extension's own set would override a value a user set through fluid_styled_content, which would be a regression for the far more common setup.

**Test plan**

`Tests/Unit/Service/ImageResolverServiceTest.php` gains a data-provider test over `lazy`, `eager`, `auto`, an unresolved constant, an arbitrary string, an empty string and a non-string, plus one for a request without `frontend.typoscript`.

Verified that the tests are load-bearing — with the one-line guard reverted:

```
Failed asserting that '{$styles.content.image.lazyLoading}' is identical to null.
Failed asserting that 'sometimes' is identical to null.
Tests: 8, Assertions: 16, Failures: 2.
```

Gates on the final tree, exit codes checked directly:

| gate | exit |
|---|---|
| `php-cs-fixer --dry-run` (`Build/.php-cs-fixer.dist.php`) | 0 |
| `phpstan` (`Build/phpstan.neon`) | 0 |
| `runTests.sh -s unit -p 8.4` | 0 — OK (881 tests, 1949 assertions) |

Observed on a live TYPO3 14.3.5 install before the fix: exactly one occurrence, on the page rendering an RTE image.

**Two pre-existing findings, left untouched**

Neither is caused by this change and neither is fixed here:

- `runTests.sh -s cgl` points at `Build/php-cs-fixer/php-cs-fixer.php`, which does not exist in this repository — the config is `Build/.php-cs-fixer.dist.php`. The suite therefore always fails with a php-cs-fixer usage message rather than a style verdict.
- `Build/rector.php` reports one finding in `Tests/Unit/Service/ImageResolverServiceTest.php`, on mock property declarations this PR does not touch. Confirmed identical on `main`.
