### PR TITLE
fix(build): point the cgl suite at the config that exists

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -547,7 +547,7 @@ case ${TEST_SUITE} in
         if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
             DRY_RUN_OPTIONS='--dry-run --diff'
         fi
-        COMMAND="php -dxdebug.mode=off .Build/bin/php-cs-fixer fix -v ${DRY_RUN_OPTIONS} --config=Build/php-cs-fixer/php-cs-fixer.php --using-cache=no"
+        COMMAND="php -dxdebug.mode=off .Build/bin/php-cs-fixer fix -v ${DRY_RUN_OPTIONS} --config=Build/.php-cs-fixer.dist.php --using-cache=no"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;


### PR DESCRIPTION
Closes #882

**Explain the details**

`Build/Scripts/runTests.sh -s cgl` built its command with `--config=Build/php-cs-fixer/php-cs-fixer.php`. That directory does not exist here; the tracked config is `Build/.php-cs-fixer.dist.php`.

The result was that php-cs-fixer answered with

```
Cannot read config file "Build/php-cs-fixer/php-cs-fixer.php".
```

followed by its usage text, and exited non-zero. The suite therefore never produced a style verdict — and because it exits non-zero and prints a wall of text, the failure reads like a style violation to anyone running the documented local gate before pushing. I hit exactly that while preparing #881 and had to trace it before I could trust the gate.

**Test plan**

| | before | after |
|---|---|---|
| `runTests.sh -s cgl -n -p 8.4` | exit 16, `Cannot read config file` | **exit 0** |
| config actually loaded | – | `Loaded config default from "Build/.php-cs-fixer.dist.php"` |
| verdict | none | `Found 0 of 96 files that can be fixed` |

One line changed; no rules, no formatting, no source touched.
