### PR TITLE
ci: pin harden-runner v2.21.0 and clear the php-cs-fixer 3.95.19 alignment failure

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -126,7 +126,7 @@ jobs:
     permissions: {}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 

--- a/Classes/Command/ValidateImageReferencesCommand.php
+++ b/Classes/Command/ValidateImageReferencesCommand.php
@@ -124,8 +124,8 @@ class ValidateImageReferencesCommand extends Command
     {
         $definitions = [
             ['Scanned records' => (string) $result->getScannedRecords()],
-            ['Scanned images'   => (string) $result->getScannedImages()],
-            ['Issues found'     => (string) count($result->getIssues())],
+            ['Scanned images' => (string) $result->getScannedImages()],
+            ['Issues found' => (string) count($result->getIssues())],
             ['Affected records' => (string) $result->getAffectedRecords()],
         ];
 

--- a/Classes/Listener/FileOperation/UpdateImageReferences.php
+++ b/Classes/Listener/FileOperation/UpdateImageReferences.php
@@ -216,7 +216,7 @@ class UpdateImageReferences
         $connection->update(
             $tableName,
             [$field => $value],
-            ['uid'  => $recuid],
+            ['uid' => $recuid],
         );
     }
 

--- a/Classes/Service/RteImageReferenceValidator.php
+++ b/Classes/Service/RteImageReferenceValidator.php
@@ -518,7 +518,7 @@ class RteImageReferenceValidator
         $connection->update(
             $tableName,
             [$field => $value],
-            ['uid'  => $recuid],
+            ['uid' => $recuid],
         );
     }
 


### PR DESCRIPTION
Two changes, because the first could not land without the second.

## The pin

The shared template moved to harden-runner v2.21.0 in netresearch/.github#380, so this repository's v2.20.1 now fails `drift / Template drift` for trailing it. Same SHA the template carries, read from `step-security/harden-runner`'s own `v2.21.0` tag ref rather than copied from a sibling repository. One line in `.github/workflows/checks.yml`, which is the only template-governed file that pins this action; the pin was read structurally with `yq` before and after, so a second one under a different key could not have passed as done.

## The code style failure it ran into

`ci / Code Style` was already failing here, and not because of the pin. `friendsofphp/php-cs-fixer` v3.95.19 was released on 17 August and changed how `binary_operator_spaces` treats alignment padding inside array literals:

```
-            ['uid'  => $recuid],
+            ['uid' => $recuid],
```

Whitespace only, no behaviour. Every repository's most recent `main` run predates that release, so a green `main` is stale evidence rather than an all-clear — the same shape turned up in `t3x-cowriter` and `t3x-nr-repurpose`. It is filed fleet-wide as netresearch/.github#384, including the part that actually needs a decision: the fixer is resolved at CI time rather than pinned, so a patch release can redden the fleet without a commit anywhere.

It is folded in here rather than split off because `ci / Code Style` is a required check: leaving it red would block this pull request, and a separate style pull request would be blocked by the same thing.

## Verification

**Not verified locally** — these worktrees have no `.Build`, so there is no php-cs-fixer to run. The changes are exactly the diff the failing job printed, applied verbatim, and every touched file passes `php -l`. CI is the check that was failing and it is the one that has to report on this.

Refs netresearch/.github#379
