### PR TITLE
docs(agents): sync AGENTS.md files with current repo state

### DIFF
--- a/.ddev/AGENTS.md
+++ b/.ddev/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-02-13 -->
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-18 -->
 
 # AGENTS.md -- .ddev
 
@@ -15,7 +15,7 @@ DDEV local development environment for multi-version TYPO3 testing. Supports v13
 - **no_project_mount**: true (custom mount setup)
 - **Hostnames**: `rte-ckeditor-image.ddev.site`, `v13.rte-ckeditor-image.ddev.site`, `v14.rte-ckeditor-image.ddev.site`, `docs.rte-ckeditor-image.ddev.site`
 
-## Custom Commands
+## Commands
 
 ### Host Commands (`.ddev/commands/host/`)
 
@@ -33,7 +33,7 @@ DDEV local development environment for multi-version TYPO3 testing. Supports v13
 | `ddev install-v14` | Install TYPO3 v14.3 LTS instance |
 | `ddev install-all` | Install both v13 and v14 |
 
-## Quick Start
+## Getting Started
 
 ```bash
 make up          # Start DDEV + run full setup (docs + v13 + v14)
@@ -51,8 +51,11 @@ ddev setup       # Install both TYPO3 versions + render docs
 | `make stop` | `ddev stop` | Stop DDEV |
 | `make setup` | `ddev setup` | Full setup |
 | `make docs` | `ddev docs` | Render documentation |
-| `make install-v13` | `ddev install-v13` | Install TYPO3 v13 only |
-| `make install-v14` | `ddev install-v14` | Install TYPO3 v14 only |
+| `make docs-lint` | `./Build/Scripts/validate-docs.sh` | Lint documentation |
+| `make docs-fix` | `./Build/Scripts/validate-docs.sh --fix` | Auto-fix documentation |
+| `make ddev-restart` | `ddev restart` | Restart DDEV containers |
+
+Single-version installs run directly via `ddev install-v13` / `ddev install-v14` (no Make wrappers).
 
 ## URLs (when running)
 
@@ -75,3 +78,20 @@ ddev setup       # Install both TYPO3 versions + render docs
 - [ ] Custom commands have descriptions
 - [ ] No hardcoded paths or credentials
 - [ ] Both v13 and v14 installations work
+
+## Security
+
+- No credentials or tokens in `config.yaml`, docker-compose overrides, or custom commands (local dev only, but files are committed)
+- Do not edit files marked `#ddev-generated` -- DDEV overwrites them
+
+## Examples
+
+- Fresh full environment: `make up` (= `ddev start` + `ddev setup`)
+- Re-render docs after RST changes: `ddev docs`
+- Run E2E against Docker: `ddev test-e2e`
+
+## Troubleshooting
+
+- Containers wedged: `make ddev-restart`; if still broken, `ddev poweroff && ddev start`
+- Docker not running: start Docker Desktop first (WSL2)
+- Broken TYPO3 instance: re-run `ddev install-v13` / `ddev install-v14`

--- a/.ddev/CLAUDE.md
+++ b/.ddev/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- FOR AI AGENTS - Human readability is a side effect, not a goal -->
 <!-- Managed by agent: keep sections and order; edit content, not structure -->
-<!-- Last updated: 2026-03-15 | Last verified: 2026-03-15 -->
+<!-- Last updated: 2026-08-18 | Last verified: 2026-08-18 -->
 
 # AGENTS.md
 
@@ -16,7 +16,7 @@ Handles image insertion, processing, rendering with captions, links, popups, qua
 - **Repository**: [github.com/netresearch/t3x-rte_ckeditor_image](https://github.com/netresearch/t3x-rte_ckeditor_image)
 - **Tech Stack**: PHP ^8.2, TYPO3 ^13.4.21 || ^14.3, CKEditor 5
 - **License**: AGPL-3.0-or-later
-- **Current Version**: 13.9.0
+- **Current Version**: see `version` in `ext_emconf.php` (authoritative source)
 
 ## Architecture Overview
 
@@ -57,7 +57,7 @@ CKEditor 5 plugin: `Resources/Public/JavaScript/Plugins/typo3image.js`
 ### Ask First
 
 - Adding new Composer or npm dependencies
-- Modifying CI/CD workflows (`.github/workflows/`)
+- Modifying CI/CD workflows (`.github/workflows/` -- thin wrappers over centralized workflows, see CI/CD below)
 - Changing public API signatures on services or DTOs
 - Running full E2E test suites (resource-intensive)
 - Modifying security-sensitive code (security validators, URL allowlists, caption sanitization)
@@ -79,13 +79,12 @@ CKEditor 5 plugin: `Resources/Public/JavaScript/Plugins/typo3image.js`
 ## Getting Started
 
 ```bash
-composer install          # Install dependencies
-make help                 # Show all available targets
-make lint                 # Run all linters
-make test                 # Run tests
+composer install    # Install dependencies
+composer ci:test    # Full local check suite (lint, phpstan, rector, cgl, unit, js, functional)
+make up             # DDEV: start environment + install TYPO3 v13/v14 + render docs
 ```
 
-For a full local environment with TYPO3 backend, see `.ddev/AGENTS.md`.
+Make targets are DDEV/docs conveniences only (`setup`, `start`, `stop`, `up`, `ddev-restart`, `docs`, `docs-lint`, `docs-fix`); quality gates run through Composer scripts. For a full local environment with TYPO3 backend, see `.ddev/AGENTS.md`.
 
 ## Development Workflow
 
@@ -94,90 +93,49 @@ For a full local environment with TYPO3 backend, see `.ddev/AGENTS.md`.
 3. Pre-commit hooks run automatically: phplint -> php-cs-fixer -> phpstan
 4. Commit with conventional format (commitlint validates)
 5. Push and create PR
-6. CI runs: lint, phpstan, rector, unit tests, functional tests, E2E (v13 + v14 blocking)
+6. CI runs: lint, phpstan, rector, unit tests, functional tests, E2E (all 6 E2E contexts blocking)
 7. Address review feedback (Copilot + Gemini Code Assist auto-review)
 8. Merge via merge queue with `gh pr merge --merge --auto`
 
 ## Commands
 
-**Automatic (husky pre-commit hook):**
-```bash
-composer ci:test:php:lint       # PHP syntax check
-composer ci:test:php:cgl        # PHP-CS-Fixer dry-run (@Symfony rules)
-composer ci:test:php:phpstan    # PHPStan level 10 analysis
-```
+Pre-commit (husky) runs automatically: `composer ci:test:php:lint`, `composer ci:test:php:cgl` (PHP-CS-Fixer dry-run), `composer ci:test:php:phpstan` (level 10).
 
-**Manual (full CI pipeline):**
 ```bash
 composer ci:test                # All checks: lint, phpstan, rector, cgl, unit, js-unit, functional
 composer ci:test:php:unit       # Unit tests only
 composer ci:test:php:functional # Functional tests (needs typo3DatabaseDriver=pdo_sqlite)
 composer ci:test:js:unit        # JavaScript unit tests (Tests/JavaScript/)
 composer ci:test:php:rector     # Rector dry-run check
+Build/Scripts/runTests.sh -s e2e -t 13 -p 8.5   # E2E, Docker-based (-t 14 for TYPO3 v14)
 ```
 
-**E2E tests (Docker-based):**
-```bash
-Build/Scripts/runTests.sh -s e2e -t 13 -p 8.5   # TYPO3 v13 E2E
-Build/Scripts/runTests.sh -s e2e -t 14 -p 8.5   # TYPO3 v14 E2E (blocking)
-```
+## CI/CD
 
-**Make targets (convenience):**
-```bash
-make lint       # All linters (phplint + phpstan + rector + cgl + docs)
-make format     # Auto-fix code style (php-cs-fixer)
-make typecheck  # PHPStan only
-make ci         # Full CI pipeline
-make test       # Run tests
-```
+Workflows in `.github/workflows/` are thin wrappers over centralized reusable workflows: `netresearch/typo3-ci-workflows` (ci, e2e, release, republish, security) and `netresearch/.github` (CodeQL, gitleaks, zizmor, community automation). The per-repo test matrix lives in `.github/workflows/ci.yml`; CGL and coverage cell selection are decided by the central workflow. Keep E2E job names in sync with the branch ruleset's required status checks (see the comment in `ci.yml` -- renaming silently detaches the requirement).
+
+**CI matrix**: PHP 8.2/8.3/8.4/8.5 x TYPO3 ^13.4.21/^14.3 (8 build combinations); E2E: TYPO3 v13/v14 x setup variants `fsc`/`core-only`/`bootstrap` = 6 blocking contexts.
 
 ## Code Quality Standards
 
 - **PHP-CS-Fixer**: @Symfony ruleset with risky rules, `binary_operator_spaces` alignment enforced
 - **PHPStan**: Level 10 with `phpstan-strict-rules`, `phpstan-deprecation-rules`, `phpat` architecture rules
 - **Rector**: TYPO3-specific automated modernization (`ssch/typo3-rector`)
-- **Architecture tests**: `Tests/Architecture/ArchitectureTest.php` (phpat)
-- **Fuzz testing**: `composer ci:fuzz` for ImageAttributeParser and SoftReferenceParser
-- **Mutation testing**: `composer ci:mutation` via Infection
+- **Fuzz/Mutation**: `composer ci:fuzz` (parsers), `composer ci:mutation` (Infection)
 
 ## Security & Safety
 
-This extension implements defense-in-depth security:
+Defense-in-depth: caption XSS sanitization, file-visibility validation, URL protocol allowlist (`http:`, `https:`, `mailto:`, `tel:`, `t3:`), style-attribute exclusion, SVG sanitization, SSRF protection (`SecurityValidator`). Implementation details and the Core-vs-extension responsibility split: `Classes/AGENTS.md` (Security Notes) and [ADR-003](Documentation/Architecture/ADR-003-Security-Responsibility-Boundaries.rst).
 
-- **Caption XSS Prevention**: All user-editable captions sanitized with `htmlspecialchars()` in `ImageResolverService::sanitizeCaption()`
-- **File Visibility Validation**: Non-public storage files blocked in `ImageResolverService::validateFileVisibility()`
-- **URL Protocol Allowlist**: Only `http:`, `https:`, `mailto:`, `tel:`, `t3:` allowed; `javascript:`, `vbscript:`, `data:text/html` blocked
-- **Style Attribute Exclusion**: CSS injection prevented by excluding `style` from allowed HTML attributes
-- **SVG Sanitization**: SVG data URIs sanitized via TYPO3's `SvgSanitizer` in `sanitizeSvgDataUri()`
-- **SSRF Protection**: External image fetching in `SecurityValidator` includes DNS rebinding and private IP blocking
-
-Security handled by TYPO3 Core (not this extension):
-- SVG file upload sanitization (FAL), file extension/MIME validation (FAL), image processing security (GraphicalFunctions)
-
-See [ADR-003: Security Responsibility Boundaries](Documentation/Architecture/ADR-003-Security-Responsibility-Boundaries.rst).
-
-## Testing Requirements
-
-| Type | Command | Environment |
-|------|---------|-------------|
-| Unit | `composer ci:test:php:unit` | Local or CI |
-| Functional | `composer ci:test:php:functional` | Local or CI (SQLite configured in FunctionalTests.xml) |
-| JavaScript | `composer ci:test:js:unit` | Local or CI |
-| E2E | `Build/Scripts/runTests.sh -s e2e -t 13 -p 8.5` | CI (Docker) |
-| Fuzz | `composer ci:fuzz` | Local or CI |
-| Mutation | `composer ci:mutation` | Local or CI |
-| Architecture | Part of unit suite via phpat | Local or CI |
-
-**CI matrix**: PHP 8.2/8.3/8.4/8.5 x TYPO3 ^13.4/^14.3 (8 combinations for build, E2E on v13+v14)
-
-## Index of Scoped AGENTS.md
+## Index of scoped AGENTS.md
 
 - `./Classes/AGENTS.md` -- PHP source classes (service architecture, DTOs, controllers)
 - `./Tests/AGENTS.md` -- All test types (unit, functional, E2E, fuzz, mutation, architecture, JS)
 - `./Documentation/AGENTS.md` -- RST documentation for docs.typo3.org
 - `./Resources/AGENTS.md` -- Fluid templates, XLIFF translations, CKEditor plugin, CSS
 - `./.ddev/AGENTS.md` -- DDEV local development environment
-- `./.github/workflows/AGENTS.md` -- GitHub Actions CI/CD workflows
+
+CI/CD has no scoped file: workflows are centralized (see CI/CD section above).
 
 ## When Instructions Conflict
 

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-02-13 -->
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-18 -->
 
 # AGENTS.md -- Classes
 
@@ -6,6 +6,19 @@
 
 PHP source code for the TYPO3 CKEditor image extension. PSR-4 autoloaded under `Netresearch\RteCKEditorImage\`.
 All files use `declare(strict_types=1)`. PHPStan level 10 with strict-rules.
+
+## Setup
+
+`composer install` from the repo root. Pre-commit hooks (husky) install via the root `package.json` `prepare` script and run phplint, php-cs-fixer, and phpstan automatically.
+
+## Commands
+
+| Task | Command |
+|------|---------|
+| Lint + static analysis | `composer ci:test:php:lint` / `composer ci:test:php:phpstan` |
+| Code style (auto-fix) | `composer ci:cgl` |
+| Unit tests | `composer ci:test:php:unit` |
+| All checks | `composer ci:test` |
 
 ## Architecture
 
@@ -64,7 +77,7 @@ RteImagesDbHook -> RteImageProcessor -> ImageTagParser + ImageFileResolver + Ima
 | `Listener/TCA/RteSoftrefEnforcer.php` | Event listener: auto-enforces RTE softref config on TCA fields |
 | `Utils/ProcessedFilesHandler.php` | Wrapper around TYPO3 ImageService for processed file creation |
 
-## Golden Samples (follow these patterns)
+## Patterns to Follow (Golden Samples)
 
 | Pattern | Reference |
 |---------|-----------|
@@ -149,3 +162,9 @@ All services configured in `Configuration/Services.yaml`:
 - [ ] Security-sensitive changes reviewed for XSS, SSRF, protocol injection
 - [ ] `ext_emconf.php` version updated if releasing
 - [ ] No deprecated TYPO3 APIs
+
+## When stuck
+
+- Rendering pipeline questions: `Documentation/Architecture/System-Architecture.rst` and the ADRs in `Documentation/Architecture/`
+- Frontend rendering issues: `Documentation/Troubleshooting/Frontend-Issues.rst`
+- Behavior questions: find the mirroring test in `Tests/Unit/` or `Tests/Functional/` -- tests are the executable spec

--- a/Classes/CLAUDE.md
+++ b/Classes/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Documentation/AGENTS.md
+++ b/Documentation/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-02-22 -->
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-18 -->
 
 # AGENTS.md -- Documentation
 
@@ -6,6 +6,10 @@
 
 TYPO3 extension documentation in RST format for rendering on docs.typo3.org.
 Includes architecture decision records (ADRs), API reference, CKEditor plugin docs, and integration examples.
+
+## Prerequisites
+
+Rendering needs Docker (official `render-guides` image) or the DDEV environment (`ddev docs`). Linting (`make docs-lint`) needs only the repo checkout.
 
 ## Structure
 
@@ -58,7 +62,7 @@ Documentation/
   Images/                        -- Screenshots and diagrams
 ```
 
-## Rendering Docs
+## Build & Render
 
 | Task | Command |
 |------|---------|
@@ -68,7 +72,7 @@ Documentation/
 | Lint docs | `make docs-lint` or `./Build/Scripts/validate-docs.sh` |
 | Fix docs | `make docs-fix` or `./Build/Scripts/validate-docs.sh --fix` |
 
-## RST Conventions
+## Style Conventions (RST)
 
 - **Format**: RST (reStructuredText), NOT Markdown (except ADRs/RFCs in Architecture/)
 - **Headings**: `=` for H1, `-` for H2, `~` for H3, `^` for H4
@@ -88,7 +92,7 @@ Documentation/
 - `.. t3-field-list-table::` for TYPO3-style tables
 - `.. figure::` with `:alt:` and `:zoom: lightbox` for screenshots
 
-## Screenshots
+## Examples: Screenshots
 
 - Format: PNG only
 - Location: `Documentation/Images/`
@@ -113,3 +117,14 @@ Documentation/
 - [ ] Code examples are tested and correct
 - [ ] Follows docs.typo3.org structure
 - [ ] New features have corresponding documentation
+
+## Security
+
+- No internal hostnames, credentials, tokens, or PII in docs, code examples, or screenshots
+- Use `example.com` / placeholder domains in examples
+
+## When stuck
+
+- Render errors: `make docs-lint` (or `./Build/Scripts/validate-docs.sh`) pinpoints invalid RST
+- Directive reference: [docs.typo3.org "How to document"](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/)
+- Structure questions: mirror an existing chapter under `Documentation/`

--- a/Documentation/CLAUDE.md
+++ b/Documentation/CLAUDE.md
@@ -1,0 +1,3 @@
+<!-- Regular file, not a symlink: the TYPO3 docs renderer (Flysystem) rejects symbolic links inside Documentation/. -->
+
+@AGENTS.md

--- a/Resources/AGENTS.md
+++ b/Resources/AGENTS.md
@@ -1,10 +1,23 @@
-<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-02-13 -->
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-18 -->
 
 # AGENTS.md -- Resources
 
 ## Overview
 
 Fluid templates for image rendering, XLIFF translation files (32 languages), CKEditor 5 plugin JavaScript, and CSS for editor styling.
+
+## Setup
+
+No build step: the CKEditor plugin (`Public/JavaScript/Plugins/typo3image.js`), CSS, and templates ship as-is. `composer install` is only needed to run the test suites.
+
+## Commands
+
+| Task | Command |
+|------|---------|
+| Validate XLIFF | `bash Build/Scripts/validate-xliff.sh` |
+| JS unit tests (plugin) | `composer ci:test:js:unit` |
+| Functional tests (templates) | `composer ci:test:php:functional` |
+| E2E (plugin + rendering) | `Build/Scripts/runTests.sh -s e2e -t 13 -p 8.5` |
 
 ## Directory Structure
 
@@ -64,7 +77,7 @@ Resources/
 
 Figure wrappers are only created when there is a caption. Alignment classes without caption go directly on the `<img>` element.
 
-## Template Override Mechanism
+## Examples: Template Overrides
 
 Integrators can override templates via TypoScript. The `settings.` block
 must live inside `preUserFunc.` because TYPO3 only passes
@@ -134,3 +147,15 @@ Default paths at priority 0 are always preserved. Custom paths use numeric keys 
 - [ ] CKEditor plugin changes tested with E2E and JavaScript unit tests
 - [ ] No sensitive data in resource files
 - [ ] Images are optimized (compressed, correct dimensions)
+
+## Security
+
+- Never add `style` attributes or new raw-output sinks to templates (CSS injection / XSS)
+- `f:format.raw` appears only in `Partials/Image/Figure.html` and `Link.html`, for values sanitized upstream in `ImageResolverService` -- never use it for new user-controlled values
+- Everything else relies on default Fluid output escaping -- do not disable it
+
+## When stuck
+
+- Template override not picked up: check the `preUserFunc` placement rules above (`settings.` must live inside `preUserFunc.`)
+- Rendering differences: run `Tests/Functional/Service/PartialPathResolutionTest.php` and the parseFunc functional tests
+- Plugin behavior: `Documentation/CKEditor/` and the JS unit tests in `Tests/JavaScript/`

--- a/Resources/CLAUDE.md
+++ b/Resources/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -1,10 +1,21 @@
-<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-02-13 -->
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-18 -->
 
 # AGENTS.md -- Tests
 
 ## Overview
 
 Multi-layer test suite: unit, functional, E2E (Playwright), JavaScript (Vitest), architecture (phpat), fuzz (php-fuzzer), and mutation (Infection).
+
+## Setup
+
+- PHP suites: `composer install`; functional tests additionally need `typo3DatabaseDriver=pdo_sqlite` in the environment
+- JS suite: `composer ci:test:js:unit` runs `npm ci` in `Tests/JavaScript/` on demand -- no manual setup
+- E2E: needs Docker (`Build/Scripts/runTests.sh` pulls the images)
+
+## Conventions
+
+- PHPStan level 10 and PSR-12 + TYPO3 CGL apply to test code, same as source (specific ignores in `Build/phpstan.neon`)
+- Test class mirrors source path; one behavior per test; data providers for parameterization
 
 ## Test Structure
 
@@ -93,7 +104,6 @@ Tests/
 - Override checkbox toggle: use vanilla JS `page.evaluate()` -- jQuery not on `window` in TYPO3 v13+
 - CKEditor: bare `<p><img></p>` renders as block widget (dblclick won't open dialog). Must include surrounding text
 - `clearCookies()` before frontend navigation after backend login (session interference)
-- v14 E2E runs with `continue-on-error` (non-blocking while stabilizing)
 - E2E setup variants via `-X` flag exercise the extension under different sitepackage / FSC / Bootstrap-Package combinations:
   - `-X fsc` (default): fluid_styled_content site set, no Bootstrap. Long-standing baseline.
   - `-X core-only`: minimal install, neither FSC nor Bootstrap. Models the fresh-install evaluator scenario; surfaces the bug class in [#790](https://github.com/netresearch/t3x-rte_ckeditor_image/issues/790).
@@ -103,11 +113,11 @@ Tests/
 
 ## CI Environment
 
-- CI matrix: PHP 8.2/8.3/8.4/8.5 x TYPO3 ^13.4/^14.3
-- CGL runs only on PHP 8.2 (code style is PHP version independent)
-- Coverage runs only on PHP 8.5 + TYPO3 ^14.3
+- CI runs via the centralized `netresearch/typo3-ci-workflows` reusable workflows; the per-repo matrix lives in `.github/workflows/ci.yml`
+- CI matrix: PHP 8.2/8.3/8.4/8.5 x TYPO3 ^13.4.21/^14.3
+- CGL runs once, on the first PHP version of the matrix (currently 8.2); coverage upload is handled by the central workflow
 - JavaScript tests run once (not PHP/TYPO3 version dependent)
-- E2E matrix: TYPO3 ^13.4 + ^14.3 x setup-variants `[fsc, core-only, bootstrap]` = 6 jobs. Setup variants are advisory (not in required_status_checks ruleset) until each stabilizes.
+- E2E matrix: TYPO3 ^13.4.21 + ^14.3 x setup-variants `[fsc, core-only, bootstrap]` = 6 jobs, all blocking required status checks in the `default` branch ruleset -- keep job names in sync with the ruleset (see the comment in `ci.yml`)
 
 ## PR Checklist
 
@@ -118,3 +128,18 @@ Tests/
 - [ ] Fixtures are minimal and focused
 - [ ] No hardcoded credentials or paths in tests
 - [ ] Coverage has not decreased
+
+## Security
+
+- No credentials, tokens, or real user data in tests or fixtures
+- Security regressions get a dedicated test (XSS, SSRF, protocol allowlist) -- existing ones live in `Unit/Service/Security/` and `Unit/Service/`
+
+## Examples
+
+Golden tests to copy from: `Unit/Service/ImageResolverServiceTest.php` (mock-based service test), `Functional/Controller/FigureCaptionRenderingTest.php` (TypoScript-driven rendering assertion), `E2E/tests/helpers/typo3-backend.ts` (shared E2E helpers).
+
+## When stuck
+
+- Flaky E2E: see the isolation and waiting rules under "E2E Test Patterns" -- most flakes are missing waits or shared content elements
+- Functional DB errors: check `typo3DatabaseDriver=pdo_sqlite` is set
+- CI-only failures: reproduce with `Build/Scripts/runTests.sh` (same Docker images as CI)

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Closes #887.

**Explain the details**

Full check/update/sync of all six AGENTS.md files using the agent-rules and agent-harness verification tooling, triggered by an external report of the dead `.github/workflows/AGENTS.md` index pointer (file deleted in cb0bb18, index never updated).

- Root: removed the dead index entry and added a note that CI/CD guidance lives in the centralized workflows (`netresearch/typo3-ci-workflows`, `netresearch/.github`); removed the phantom Make targets (`help lint test format typecheck ci` — the Makefile only has DDEV/docs targets); replaced the hardcoded "Current Version: 13.9.0" with a pointer to `ext_emconf.php`; added a CI/CD section with the verified matrix (8 build combinations, 6 blocking E2E contexts); trimmed from 191 to 149 lines (harness cap: 150).
- `Tests/`: corrected stale claims that v14 E2E is `continue-on-error` and setup variants advisory — per `ci.yml` all six E2E contexts are blocking required status checks; reworded CGL/coverage cell selection as owned by the central workflow.
- `.ddev/`: removed nonexistent `make install-v13/v14`, documented the actual `docs-lint`/`docs-fix`/`ddev-restart` targets.
- All scoped files: added the sections required by the agent-rules skill (Setup, Commands, Security, Examples, When stuck), updated Last-updated headers, added the five missing scoped `CLAUDE.md` symlinks.
- Every command, path, file reference, and CI claim in the diff was verified against the working tree, `composer.json`, the Makefile, and `ci.yml` before writing.

**Test plan**

- agent-rules `validate-structure.sh`: 11 errors → 0
- agent-rules `verify-content.sh`: 6 warnings (phantom Make targets) → 0
- agent-rules `score-agents.sh`: average 68/100 → 96/100 (root 52 → 90)
- agent-harness `verify-harness.sh`: AGENTS.md line count and reference checks pass; remaining findings (`docs/ARCHITECTURE.md`, harness-verify CI job) are out of scope here and noted in #887's follow-up discussion.